### PR TITLE
fix(check): stop logging response body on non-200 in --check

### DIFF
--- a/src/mcp_stdio/relay.py
+++ b/src/mcp_stdio/relay.py
@@ -460,7 +460,11 @@ def check_connection(
         resp = client.post(url, content=initialize_msg, headers=headers)
 
         if resp.status_code != 200:
-            log(f"✗ HTTP {resp.status_code}: {resp.text[:200]}")
+            # Do not surface the response body — server error responses
+            # commonly carry session IDs, stack traces, or echoed request
+            # data. The status code alone is the right operational signal
+            # for the --check probe. See #16.
+            log(f"✗ HTTP {resp.status_code}")
             return False
 
         log(f"✓ Connected (HTTP {resp.status_code})")

--- a/tests/test_relay.py
+++ b/tests/test_relay.py
@@ -1070,6 +1070,21 @@ class TestCheckConnection:
         httpx_mock.add_response(status_code=500, text="oops")
         assert check_connection(self.URL, dict(self.HEADERS)) is False
 
+    def test_non_200_does_not_leak_body_to_stderr(self, httpx_mock, capsys):
+        """#16: response body must not appear in --check stderr output.
+
+        Error bodies regularly contain session IDs, stack traces, or
+        echoed request data, and --check logs are prone to retention
+        in CI / aggregation pipelines.
+        """
+        secret = "session=SENSITIVE-sess-id-echoed-in-500-page"
+        httpx_mock.add_response(status_code=500, text=secret)
+        check_connection(self.URL, dict(self.HEADERS))
+        captured = capsys.readouterr()
+        assert secret not in captured.err
+        # Status code is still logged — that's the operational signal
+        assert "HTTP 500" in captured.err
+
     def test_unauthorized_returns_false(self, httpx_mock):
         httpx_mock.add_response(status_code=401, text="nope")
         assert check_connection(self.URL, dict(self.HEADERS)) is False


### PR DESCRIPTION
## Summary

- `check_connection()` no longer echoes the first 200 bytes of the upstream response body on non-200 status
- Status code continues to be logged — that's the operational signal `--check` is meant to provide
- Adds a regression test that asserts a sensitive string planted in the 500 body does not appear in stderr

Closes #16.

## Test plan

- [x] `pytest tests/` — 211 passed (was 210; +1 for the no-leak assertion)
- [x] Existing `test_non_200_returns_false` unchanged — same return semantics
- [ ] Manual: `mcp-stdio --check` against a server that returns 500 with any body → confirm only `✗ HTTP 500` appears, no body fragment

🤖 Generated with [Claude Code](https://claude.com/claude-code)