### PR TITLE
fix(oauth): reject non-/callback paths on the OAuth callback server

### DIFF
--- a/src/mcp_stdio/oauth.py
+++ b/src/mcp_stdio/oauth.py
@@ -274,7 +274,18 @@ def _make_callback_handler(
 
     class Handler(BaseHTTPRequestHandler):
         def do_GET(self) -> None:  # noqa: N802
-            params = parse_qs(urlparse(self.path).query)
+            # Reject everything that isn't the registered redirect_uri path.
+            # Browser prefetch / favicon / stray tabs on 127.0.0.1 would
+            # otherwise land in this handler and — if they happened to
+            # carry `code` and `state` — be treated as the authoritative
+            # authorization response. See #15.
+            parsed = urlparse(self.path)
+            if parsed.path != "/callback":
+                self.send_response(404)
+                self.end_headers()
+                return
+
+            params = parse_qs(parsed.query)
 
             if "error" in params:
                 result.error = params["error"][0]

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -1176,6 +1176,54 @@ class TestCallbackServer:
         assert cb_result.error == "access_denied"
         assert cb_result.auth_code is None
 
+    def test_non_callback_path_returns_404_and_does_not_capture(self):
+        """#15: favicon / prefetch / stray tabs must not deliver a code.
+
+        Only requests to `/callback` may be treated as the authoritative
+        authorization response; everything else is rejected.
+        """
+        cb_result = CallbackResult()
+        handler_cls = _make_callback_handler(cb_result)
+
+        from http.server import HTTPServer
+
+        server = HTTPServer(("127.0.0.1", 0), handler_cls)
+        port = server.server_address[1]
+        done = threading.Event()
+
+        def serve():
+            while not done.is_set():
+                server.handle_request()
+
+        t = threading.Thread(target=serve, daemon=True)
+        t.start()
+        time.sleep(0.3)
+
+        try:
+            # Paths that are NOT /callback must return 404 even when they
+            # carry query parameters that look like an authorization code.
+            for path in (
+                "/favicon.ico",
+                "/?code=bogus&state=attacker",
+                "/callback/extra?code=bogus&state=attacker",
+                "/CALLBACK?code=bogus&state=attacker",  # case-sensitive per spec
+            ):
+                resp = httpx.get(f"http://127.0.0.1:{port}{path}")
+                assert resp.status_code == 404, path
+
+            # Sanity: the legitimate path still works after rejections
+            resp = httpx.get(
+                f"http://127.0.0.1:{port}/callback?code=good_code&state=good_state"
+            )
+            assert resp.status_code == 200
+        finally:
+            done.set()
+            server.server_close()
+
+        # The bogus codes must not have been captured
+        assert cb_result.auth_code == "good_code"
+        assert cb_result.state == "good_state"
+
     def test_concurrent_flows_isolated(self):
         """Two callback handlers with separate result objects don't interfere."""
         result_a = CallbackResult()


### PR DESCRIPTION
## Summary

- `_make_callback_handler` now rejects any path other than `/callback` with a 404 response
- Prevents browser prefetch, favicon requests, stray tabs, and subpath variants (`/callback/extra`, `/CALLBACK`) from being treated as the authoritative authorization response
- Adds a regression test that hits four non-callback paths with plausible-looking query strings and confirms `CallbackResult` stays untouched

Closes #15.

## Test plan

- [x] `pytest tests/` — 211 passed (was 210 on this branch base; +1 for the new rejection test)
- [x] Existing `test_receives_code` and `test_receives_error` still pass — legitimate `/callback` flow unchanged
- [x] Case sensitivity verified: `/CALLBACK` is rejected (redirect_uri matching is case-sensitive per RFC 3986)

🤖 Generated with [Claude Code](https://claude.com/claude-code)