### PR TITLE
fix(cli): reject CRLF / NUL in -H values and non-token header names

### DIFF
--- a/src/mcp_stdio/cli.py
+++ b/src/mcp_stdio/cli.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import argparse
 import os
+import re
 import sys
 from typing import Callable
 
@@ -12,9 +13,24 @@ import httpx
 from . import __version__
 from .relay import check_connection, log, run, run_sse
 
+# RFC 7230 §3.2.6 field-name = token = 1*tchar. tchar covers
+# "!#$%&'*+-.^_`|~" plus DIGIT and ALPHA. Used to reject header names
+# that could be misinterpreted by downstream HTTP parsers.
+_HEADER_NAME_RE = re.compile(r"^[!#$%&'*+\-.^_`|~0-9A-Za-z]+$")
+
+# Characters that terminate or re-open an HTTP header and must never
+# appear in a user-supplied value. CR / LF enable request smuggling and
+# arbitrary header injection; NUL terminates C-string parsing.
+_HEADER_VALUE_FORBIDDEN = ("\r", "\n", "\0")
+
 
 def _parse_header(header: str) -> tuple[str, str]:
-    """Parse a header string 'Key: Value' into a tuple."""
+    """Parse a header string 'Key: Value' into a tuple.
+
+    Rejects header names that violate RFC 7230 §3.2.6 (`token` grammar)
+    and values containing CR, LF, or NUL (RFC 7230 §3.2) to guard
+    against CRLF / NUL injection via `-H`. See #14.
+    """
     if ":" not in header:
         print(
             f"error: invalid header format (expected 'Key: Value'): {header}",
@@ -22,7 +38,24 @@ def _parse_header(header: str) -> tuple[str, str]:
         )
         sys.exit(1)
     key, _, value = header.partition(":")
-    return key.strip(), value.strip()
+    key = key.strip()
+    value = value.strip()
+    if not _HEADER_NAME_RE.match(key):
+        print(
+            f"error: invalid header name {key!r} "
+            f"(must match RFC 7230 token grammar)",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    for bad in _HEADER_VALUE_FORBIDDEN:
+        if bad in value:
+            print(
+                f"error: header value for {key!r} contains "
+                f"a forbidden control character",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+    return key, value
 
 
 def _build_token_refresher(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -27,6 +27,36 @@ class TestParseHeader:
         with pytest.raises(SystemExit):
             _parse_header("no-colon-here")
 
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "value\r\nInjected: bad",  # classic CRLF injection
+            "value\nInjected: bad",  # bare LF
+            "value\rInjected: bad",  # bare CR
+            "value\x00hidden",  # NUL
+        ],
+    )
+    def test_value_with_control_chars_rejected(self, value, capsys):
+        """#14: CRLF / NUL in header values must never be accepted."""
+        with pytest.raises(SystemExit):
+            _parse_header(f"X-Api-Key: {value}")
+        assert "forbidden control character" in capsys.readouterr().err
+
+    @pytest.mark.parametrize(
+        "name",
+        [
+            "bad key",  # whitespace
+            "(comment)",  # parens not in tchar
+            "bad\x7fkey",  # DEL
+            "",  # empty after strip
+        ],
+    )
+    def test_name_violating_token_grammar_rejected(self, name, capsys):
+        """#14: RFC 7230 §3.2.6 token grammar enforcement on header names."""
+        with pytest.raises(SystemExit):
+            _parse_header(f"{name}: value")
+        assert "invalid header name" in capsys.readouterr().err
+
 
 class TestMain:
     def test_version_flag(self, capsys):


### PR DESCRIPTION
## Summary

- `_parse_header` enforces RFC 7230 §3.2.6 `token` grammar on header names and rejects CR / LF / NUL in values
- Clear stderr messages for both failure classes; `sys.exit(1)` as the existing parse-error path does
- Parametrized tests cover the four control-char variants and four invalid-name shapes

Closes #14.

## Test plan

- [x] `pytest tests/` — 219 passed (was 211 on this branch base; +8 for the new parametrized cases)
- [x] Existing `_parse_header` tests unchanged — valid names and colons-in-values still round-trip
- [x] Error messages surface on stderr and are captured in tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)