### PR TITLE
feat(sse): wire scope_upgrader into run_sse for 403 step-up symmetry

### DIFF
--- a/src/mcp_stdio/cli.py
+++ b/src/mcp_stdio/cli.py
@@ -240,20 +240,12 @@ def main() -> None:
         )
         sys.exit(0 if ok else 1)
 
-    if args.transport == "sse":
-        run_sse(
-            url=args.url,
-            headers=headers,
-            timeout_connect=args.timeout_connect,
-            timeout_read=args.timeout_read,
-            token_refresher=token_refresher,
-        )
-    else:
-        run(
-            url=args.url,
-            headers=headers,
-            timeout_connect=args.timeout_connect,
-            timeout_read=args.timeout_read,
-            token_refresher=token_refresher,
-            scope_upgrader=scope_upgrader,
-        )
+    relay_fn = run_sse if args.transport == "sse" else run
+    relay_fn(
+        url=args.url,
+        headers=headers,
+        timeout_connect=args.timeout_connect,
+        timeout_read=args.timeout_read,
+        token_refresher=token_refresher,
+        scope_upgrader=scope_upgrader,
+    )

--- a/src/mcp_stdio/relay.py
+++ b/src/mcp_stdio/relay.py
@@ -766,6 +766,7 @@ def run_sse(
     timeout_read: float = 120,
     timeout_write: float = 30,
     token_refresher: Any = None,
+    scope_upgrader: Any = None,
 ) -> None:
     """Run the stdio-to-SSE relay loop (MCP 2024-11-05 legacy transport).
 
@@ -791,6 +792,11 @@ def run_sse(
         token_refresher: Optional callable that returns updated headers
             on successful token refresh, or None on failure. Called when
             the server returns HTTP 401 on POST.
+        scope_upgrader: Optional callable invoked when the server returns
+            HTTP 403 with a ``Bearer error="insufficient_scope"``
+            challenge on POST. Receives the scope string from the
+            challenge and returns updated headers containing a
+            broader-scope token, or None on failure. See #17.
     """
 
     def _shutdown(signum: int, _: Any) -> None:
@@ -893,6 +899,39 @@ def run_sse(
                             flush=True,
                         )
                         continue
+
+                if resp.status_code == 403 and scope_upgrader:
+                    required_scope = _parse_www_authenticate_scope(
+                        resp.headers.get("www-authenticate")
+                    )
+                    if required_scope is not None:
+                        log(
+                            f"received 403 insufficient_scope "
+                            f"(required: {required_scope}), attempting step-up"
+                        )
+                        new_headers = scope_upgrader(required_scope)
+                        if new_headers:
+                            headers.update(new_headers)
+                            resp = client.post(
+                                endpoint,
+                                content=line,
+                                headers=headers,
+                                timeout=httpx.Timeout(
+                                    connect=timeout_connect,
+                                    read=timeout_read,
+                                    write=timeout_write,
+                                    pool=10,
+                                ),
+                            )
+                        else:
+                            log(
+                                "step-up authorization failed, returning error"
+                            )
+                            print(
+                                _error_response("authorization failed", req_id),
+                                flush=True,
+                            )
+                            continue
 
                 if resp.status_code not in (200, 202):
                     log(f"POST returned HTTP {resp.status_code}")

--- a/tests/test_relay.py
+++ b/tests/test_relay.py
@@ -1467,6 +1467,143 @@ class TestRunSse:
         assert refresher_called["n"] == 1
         assert call_count["n"] == 2
 
+    def test_post_403_triggers_scope_upgrader(self, httpx_mock):
+        """#17: SSE transport must run step-up on 403 insufficient_scope."""
+        post_received = threading.Event()
+        release_stdin = threading.Event()
+
+        def sse_gen():
+            yield b"event: endpoint\ndata: /messages?sessionId=xyz\n\n"
+            post_received.wait(timeout=3)
+            yield b'event: message\ndata: {"jsonrpc":"2.0","result":{},"id":1}\n\n'
+            time.sleep(0.1)
+            release_stdin.set()
+
+        httpx_mock.add_response(
+            url=self.URL,
+            method="GET",
+            stream=IteratorStream(sse_gen()),
+            headers={"content-type": "text/event-stream"},
+        )
+
+        call_count = {"n": 0}
+
+        def post_callback(request):
+            call_count["n"] += 1
+            if call_count["n"] == 1:
+                return httpx.Response(
+                    status_code=403,
+                    headers={
+                        "www-authenticate": (
+                            'Bearer error="insufficient_scope", '
+                            'scope="hr:read hr:write"'
+                        ),
+                    },
+                )
+            post_received.set()
+            return httpx.Response(status_code=202)
+
+        httpx_mock.add_callback(
+            post_callback,
+            url="https://example.com/messages?sessionId=xyz",
+            method="POST",
+            is_reusable=True,
+        )
+
+        seen_scopes: list[str] = []
+
+        def mock_upgrader(required_scope: str):
+            seen_scopes.append(required_scope)
+            return {"Authorization": "Bearer upgraded"}
+
+        stdin = _BlockingStdin(
+            '{"jsonrpc":"2.0","method":"test","id":1}\n', release_stdin
+        )
+        stdout = StringIO()
+        with patch("sys.stdin", stdin), patch("sys.stdout", stdout):
+            run_sse(self.URL, {}, scope_upgrader=mock_upgrader)
+
+        assert seen_scopes == ["hr:read hr:write"]
+        assert call_count["n"] == 2
+
+    def test_post_403_without_insufficient_scope_emits_error(self, httpx_mock):
+        """Plain 403 (no scope challenge) surfaces as error (#11 + #17)."""
+        release_stdin = threading.Event()
+
+        def sse_gen():
+            yield b"event: endpoint\ndata: /messages?sessionId=xyz\n\n"
+            time.sleep(0.3)
+            release_stdin.set()
+
+        httpx_mock.add_response(
+            url=self.URL,
+            method="GET",
+            stream=IteratorStream(sse_gen()),
+            headers={"content-type": "text/event-stream"},
+        )
+        httpx_mock.add_response(
+            url="https://example.com/messages?sessionId=xyz",
+            method="POST",
+            status_code=403,
+        )
+
+        called = []
+
+        def mock_upgrader(_scope):
+            called.append(True)
+            return {"Authorization": "Bearer x"}
+
+        stdin = _BlockingStdin(
+            '{"jsonrpc":"2.0","method":"t","id":3}\n', release_stdin
+        )
+        stdout = StringIO()
+        with patch("sys.stdin", stdin), patch("sys.stdout", stdout):
+            run_sse(self.URL, {}, scope_upgrader=mock_upgrader)
+
+        # Upgrader was not invoked — no scope challenge to act on
+        assert called == []
+        parsed = json.loads(stdout.getvalue().strip())
+        assert parsed["error"]["message"] == "HTTP 403"
+        assert parsed["id"] == 3
+
+    def test_post_403_upgrader_failure_returns_error(self, httpx_mock):
+        """Step-up failure on SSE surfaces as JSON-RPC error (#17)."""
+        release_stdin = threading.Event()
+
+        def sse_gen():
+            yield b"event: endpoint\ndata: /messages?sessionId=xyz\n\n"
+            time.sleep(0.3)
+            release_stdin.set()
+
+        httpx_mock.add_response(
+            url=self.URL,
+            method="GET",
+            stream=IteratorStream(sse_gen()),
+            headers={"content-type": "text/event-stream"},
+        )
+        httpx_mock.add_response(
+            url="https://example.com/messages?sessionId=xyz",
+            method="POST",
+            status_code=403,
+            headers={
+                "www-authenticate": 'Bearer error="insufficient_scope", scope="x"'
+            },
+        )
+
+        def mock_upgrader(_scope):
+            return None  # user aborted / browser failed
+
+        stdin = _BlockingStdin(
+            '{"jsonrpc":"2.0","method":"t","id":4}\n', release_stdin
+        )
+        stdout = StringIO()
+        with patch("sys.stdin", stdin), patch("sys.stdout", stdout):
+            run_sse(self.URL, {}, scope_upgrader=mock_upgrader)
+
+        parsed = json.loads(stdout.getvalue().strip())
+        assert parsed["error"]["message"] == "authorization failed"
+        assert parsed["id"] == 4
+
     def test_post_non_success_returns_error_response(self, httpx_mock):
         """Non-200/202 POST status maps to a JSON-RPC error response."""
         post_received = threading.Event()


### PR DESCRIPTION
## Summary

- `run_sse()` now accepts `scope_upgrader` and runs the 403 insufficient_scope → step-up → retry sequence, mirroring what `run()` has shipped since v0.4.9
- `cli.py` collapses the transport-gated fork into a single `relay_fn(...)` call, passing both `token_refresher` and `scope_upgrader` regardless of transport
- Three new tests under `TestRunSse`:
  - happy path (403 challenge → upgrader called with verbatim scope → retry succeeds)
  - passthrough for plain 403 with no `insufficient_scope` challenge
  - error surfacing when the upgrader returns `None`

Closes #17.

## Test plan

- [x] `pytest tests/` — 215 passed (+3 for the SSE step-up trio)
- [x] Existing `TestRunSse::test_post_401_triggers_token_refresh` still passes — the 401 path is unchanged
- [x] Existing `TestStepUpScopeChallenge` (Streamable HTTP) still passes — the shared `_parse_www_authenticate_scope` helper is reused
- [ ] Manual: SSE server that returns 403 insufficient_scope on a scoped tool → confirm the browser opens for step-up and the retry succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)