### PR TITLE
ci: wire RELEASE_PLEASE_TOKEN and move release.yml to release.published

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -15,5 +15,16 @@ jobs:
     steps:
       - uses: googleapis/release-please-action@v4
         with:
+          # Use a fine-grained PAT so that tags and releases created by
+          # release-please trigger downstream workflows. Tokens attributed
+          # to GITHUB_TOKEN cannot fire other workflow runs (GitHub's
+          # recursion-prevention rule), which leaves the Release to PyPI
+          # pipeline dormant on every release. The PAT's author is a real
+          # user, so release.published propagates normally.
+          #
+          # The secret's repo scope needs Contents + Pull requests +
+          # Metadata at minimum. Falls back to GITHUB_TOKEN when the
+          # secret is unset, which lets PR CI keep working on forks.
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,14 @@
 name: Release to PyPI
 
+# Fires when release-please publishes the Release after its PR is merged.
+# Previously this listened to `push: tags: ['v*']`, but release-please
+# creates tags via the default GITHUB_TOKEN which cannot trigger other
+# workflows. Moving to `release: published` plus the PAT wired in
+# release-please.yml lets the tag → Release handoff light up this
+# pipeline automatically.
 on:
-  push:
-    tags:
-      - "v*"
+  release:
+    types: [published]
 
 jobs:
   test:


### PR DESCRIPTION
## Summary

Two joined changes to make the release-please flow fully automatic, eliminating the manual tag-delete-and-re-push dance that v0.5.0 needed:

- **release-please.yml** — passes a PAT (`secrets.RELEASE_PLEASE_TOKEN`) with `GITHUB_TOKEN` fallback, so release-please's tag/release creation is attributed to a user and can trigger downstream workflows
- **release.yml** — listens to `release: published` instead of `push: tags: ['v*']`. All three existing references to `github.ref_name` / `GITHUB_REF_NAME` keep working because `github.ref` on release events is `refs/tags/<tag>`

## Required before merge

A repository secret **`RELEASE_PLEASE_TOKEN`** must exist on `shigechika/mcp-stdio` with a fine-grained PAT authorised for:

- Contents: Read and write
- Pull requests: Read and write
- Metadata: Read (implicit)
- Issues: Read and write (nice-to-have, for release-please to link issues)

Without the secret, the `||` coalesce falls back to `GITHUB_TOKEN` — the v0.5.0 behaviour returns (manual tag re-push needed to fire the PyPI pipeline).

## Test plan

- [x] YAML syntax valid (both workflows parse)
- [x] No other references to the tag-push trigger elsewhere in the repo
- [ ] After merge + PAT in place: the next release-please release PR merge should trigger tag + Release + release.yml pipeline in one chain, no manual steps
- [ ] Fallback check: if the PAT secret is removed, release-please still opens its release PR (GITHUB_TOKEN path), but release.yml stays dormant — as designed

🤖 Generated with [Claude Code](https://claude.com/claude-code)