### PR TITLE
feat(oauth): use WWW-Authenticate resource_metadata hint for PRM discovery (RFC 9728 §5.1)

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -27,6 +27,7 @@ Bearer token、カスタムヘッダー、OAuth 2.1 認証情報をリモート�
     - §3 `/.well-known/oauth-protected-resource` による認可サーバー検出
     - §3.1 パスベースのリバースプロキシ配下に対応した well-known URL 構築（ホストルートへのフォールバック付き）。リソース URL の query component も構築後の metadata URL に保持する
     - §3.3 `resource` フィールド検証（不一致は警告して続行）
+    - §5.1 `WWW-Authenticate: Bearer resource_metadata=` ヒント — discovery 前にサーバーへ probe を送り、well-known パスの推測に頼らず PRM の所在を直接特定する
   - [RFC 8414](https://www.rfc-editor.org/rfc/rfc8414) Authorization Server Metadata
     - §3 well-known URL 構築。パス付き issuer のパス挿入ルール対応
     - §3 `issuer` 検証（不一致は警告して続行）

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Bearer tokens, custom headers, and OAuth 2.1 credentials are forwarded to the re
     - §3 discovery of authorization servers via `/.well-known/oauth-protected-resource`
     - §3.1 path-aware well-known URL construction for path-based reverse-proxy deployments, with host-root fallback; preserves the resource URL's query component on the constructed metadata URL
     - §3.3 `resource` field validation — warn on mismatch, continue
+    - §5.1 `WWW-Authenticate: Bearer resource_metadata=` hint — probes the server before discovery so servers that publish PRM at a non-standard URL are found without well-known path guessing
   - [RFC 8414](https://www.rfc-editor.org/rfc/rfc8414) Authorization Server Metadata
     - §3 well-known URL construction, including path insertion for issuers with path components
     - §3 `issuer` validation — warn on mismatch, continue

--- a/src/mcp_stdio/oauth.py
+++ b/src/mcp_stdio/oauth.py
@@ -6,6 +6,7 @@ import base64
 import hashlib
 import html
 import ipaddress
+import re
 import secrets
 import threading
 import time
@@ -141,6 +142,70 @@ def _validate_auth_server_url(auth_server_url: str, mcp_server_url: str) -> bool
     return True
 
 
+_RESOURCE_METADATA_QUOTED_RE = re.compile(r'resource_metadata\s*=\s*"([^"]+)"')
+_RESOURCE_METADATA_UNQUOTED_RE = re.compile(r"resource_metadata\s*=\s*([^\s,\"]+)")
+
+
+def _parse_resource_metadata_hint(header: str | None) -> str | None:
+    """Extract the resource_metadata URL from a WWW-Authenticate Bearer challenge.
+
+    RFC 9728 §5.1 defines the ``resource_metadata`` parameter as a hint
+    pointing directly to the Protected Resource Metadata document URL.
+    Returns the URL string when present; ``None`` otherwise.
+    """
+    if not header:
+        return None
+    match = _RESOURCE_METADATA_QUOTED_RE.search(header)
+    if match:
+        return match.group(1)
+    match = _RESOURCE_METADATA_UNQUOTED_RE.search(header)
+    if match:
+        return match.group(1)
+    return None
+
+
+def _validate_prm_hint_url(hint_url: str, server_url: str) -> bool:
+    """Validate a WWW-Authenticate resource_metadata hint URL before fetching.
+
+    Applies the same policy as ``_validate_auth_server_url``:
+    - Reject non-http/https schemes.
+    - Reject plain HTTP for non-loopback hosts (tokens would be leaked).
+    - Warn (but permit) cross-origin PRM URLs.
+
+    Returns ``True`` when the URL is safe to follow, ``False`` to skip it.
+    """
+    try:
+        parsed = urlparse(hint_url)
+    except Exception:
+        log(f"warning: malformed resource_metadata hint URL {hint_url!r}, ignoring")
+        return False
+
+    if parsed.scheme not in ("https", "http"):
+        log(f"warning: unsupported scheme in resource_metadata hint {hint_url!r}, ignoring")
+        return False
+
+    if parsed.scheme == "http" and not _is_loopback(parsed.hostname or ""):
+        log(
+            f"warning: refusing resource_metadata hint {hint_url!r} "
+            f"— plain HTTP over non-loopback would expose the OAuth flow. Ignoring."
+        )
+        return False
+
+    mcp_parsed = urlparse(server_url)
+    if (
+        parsed.hostname
+        and mcp_parsed.hostname
+        and _origin(parsed) != _origin(mcp_parsed)
+    ):
+        log(
+            f"warning: resource_metadata hint {hint_url!r} is cross-origin "
+            f"to the MCP server {server_url!r}. "
+            f"Abort if you did not expect federation."
+        )
+
+    return True
+
+
 def _build_well_known_url(resource_url: str, suffix: str) -> str:
     """Build a well-known URL by inserting the suffix between host and path.
 
@@ -192,10 +257,16 @@ def _fetch_authorization_server_metadata(
     return None
 
 
-def discover_oauth_metadata(server_url: str, client: httpx.Client) -> OAuthMetadata:
+def discover_oauth_metadata(
+    server_url: str,
+    client: httpx.Client,
+    www_authenticate: str | None = None,
+) -> OAuthMetadata:
     """Discover OAuth authorization server metadata.
 
     Follows the MCP spec discovery flow:
+    0. If ``www_authenticate`` is provided and contains a ``resource_metadata``
+       URL (RFC 9728 §5.1), try that URL first as the highest-priority PRM hint.
     1. Try RFC 9728 Protected Resource Metadata
        (/.well-known/oauth-protected-resource) to find the
        authorization server URL.
@@ -206,17 +277,26 @@ def discover_oauth_metadata(server_url: str, client: httpx.Client) -> OAuthMetad
     """
     base = _authorization_base_url(server_url)
 
+    # Phase 0: RFC 9728 §5.1 — resource_metadata hint from WWW-Authenticate.
+    # When the server already told us where its PRM lives, use that URL first
+    # instead of guessing the well-known path.
+    auth_server_url = base
+    prm_candidates: list[str] = []
+    hint = _parse_resource_metadata_hint(www_authenticate)
+    if hint and _validate_prm_hint_url(hint, server_url):
+        log(f"using resource_metadata hint from WWW-Authenticate: {hint}")
+        prm_candidates.append(hint)
+
     # Phase 1: RFC 9728 Protected Resource Metadata.
     # Per RFC 9728 §3.1, the well-known URI is inserted between host and path
     # components of the resource identifier. Try the path-aware URL first for
     # path-based reverse-proxy deployments (cf. geelen/mcp-remote#249), then
     # fall back to host-root for servers that publish PRM at the origin.
-    auth_server_url = base
-    prm_candidates: list[str] = []
     path_aware = _build_well_known_url(server_url, "oauth-protected-resource")
     host_root = f"{base}/.well-known/oauth-protected-resource"
-    prm_candidates.append(path_aware)
-    if host_root != path_aware:
+    if path_aware not in prm_candidates:
+        prm_candidates.append(path_aware)
+    if host_root != path_aware and host_root not in prm_candidates:
         prm_candidates.append(host_root)
 
     for prm_url in prm_candidates:
@@ -760,7 +840,12 @@ def ensure_token(
             delete_token(server_url)
 
     log("starting OAuth 2.1 authorization flow")
-    metadata = discover_oauth_metadata(server_url, client)
+    # Probe the MCP server for a WWW-Authenticate resource_metadata hint
+    # (RFC 9728 §5.1) before running discovery. Servers that publish PRM at
+    # a non-standard URL advertise it here, letting us skip the well-known
+    # guessing. Best-effort — failures silently fall back to normal discovery.
+    www_authenticate = _probe_www_authenticate(server_url, client)
+    metadata = discover_oauth_metadata(server_url, client, www_authenticate=www_authenticate)
     return _run_authorization_flow(
         server_url,
         client,
@@ -770,6 +855,33 @@ def ensure_token(
         scope=scope,
         timeout=timeout,
     )
+
+
+def _probe_www_authenticate(server_url: str, client: httpx.Client) -> str | None:
+    """Send a minimal MCP initialize request and return the WWW-Authenticate header.
+
+    Used before OAuth discovery to extract a ``resource_metadata`` hint
+    (RFC 9728 §5.1). Servers that check authentication before parsing the
+    request body will respond with 401, revealing their PRM URL. Any failure
+    (connection error, non-401 status, missing header) silently returns ``None``.
+    """
+    probe_body = (
+        '{"jsonrpc":"2.0","id":0,"method":"initialize","params":'
+        '{"protocolVersion":"2024-11-05","capabilities":{},'
+        '"clientInfo":{"name":"mcp-stdio-probe","version":"0"}}}'
+    )
+    try:
+        resp = client.post(
+            server_url,
+            content=probe_body,
+            headers={"Content-Type": "application/json"},
+            timeout=10.0,
+        )
+        if resp.status_code == 401:
+            return resp.headers.get("WWW-Authenticate")
+    except Exception:
+        pass
+    return None
 
 
 def step_up_authorize(

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -1483,6 +1483,8 @@ class TestEnsureToken:
             status_code=400,
             json={"error": "invalid_grant"},
         )
+        # Probe for WWW-Authenticate hint (no resource_metadata hint)
+        httpx_mock.add_response(url="https://example.com/mcp", status_code=401)
         # Discovery for full flow (will be attempted after refresh fails)
         httpx_mock.add_response(
             url="https://example.com/.well-known/oauth-protected-resource/mcp",
@@ -1548,7 +1550,9 @@ class TestEnsureToken:
             match_content=b"grant_type=refresh_token&refresh_token=stale_rt"
             b"&client_id=cached_cid&resource=https%3A%2F%2Fexample.com%2Fmcp",
         )
-        # Step 2: discovery for the full flow.
+        # Step 2a: probe for WWW-Authenticate hint (no resource_metadata hint)
+        httpx_mock.add_response(url="https://example.com/mcp", status_code=401)
+        # Step 2b: discovery for the full flow.
         httpx_mock.add_response(
             url="https://example.com/.well-known/oauth-protected-resource/mcp",
             status_code=404,
@@ -1639,6 +1643,8 @@ class TestEnsureToken:
         monkeypatch.setattr("mcp_stdio.token_store._STORE_DIR", tmp_path)
         monkeypatch.setattr("mcp_stdio.token_store._STORE_FILE", store_file)
 
+        # Probe for WWW-Authenticate hint (no resource_metadata hint)
+        httpx_mock.add_response(url="https://example.com/mcp", status_code=401)
         # Discovery
         httpx_mock.add_response(
             url="https://example.com/.well-known/oauth-protected-resource/mcp",
@@ -1721,6 +1727,8 @@ class TestClientSecretExpiry:
             ),
         )
 
+        # Probe for WWW-Authenticate hint (no resource_metadata hint)
+        httpx_mock.add_response(url="https://example.com/mcp", status_code=401)
         # Discovery for full flow (which will run after refresh is skipped)
         httpx_mock.add_response(
             url="https://example.com/.well-known/oauth-protected-resource/mcp",
@@ -1816,6 +1824,8 @@ class TestClientSecretExpiry:
             ),
         )
 
+        # Probe for WWW-Authenticate hint (no resource_metadata hint)
+        httpx_mock.add_response(url="https://example.com/mcp", status_code=401)
         # Discovery
         httpx_mock.add_response(
             url="https://example.com/.well-known/oauth-protected-resource/mcp",
@@ -2274,6 +2284,8 @@ class TestStateCsrfCheck:
         monkeypatch.setattr("mcp_stdio.token_store._STORE_DIR", tmp_path)
         monkeypatch.setattr("mcp_stdio.token_store._STORE_FILE", store_file)
 
+        # Probe for WWW-Authenticate hint (no resource_metadata hint)
+        httpx_mock.add_response(url="https://example.com/mcp", status_code=401)
         # Discovery + registration mocks so we reach the auth-URL stage
         httpx_mock.add_response(
             url=(

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -17,9 +17,12 @@ from mcp_stdio.oauth import (
     _is_client_secret_expired,
     _is_loopback,
     _make_callback_handler,
+    _parse_resource_metadata_hint,
     _parse_token_response,
+    _probe_www_authenticate,
     _token_response_to_data,
     _validate_auth_server_url,
+    _validate_prm_hint_url,
     discover_oauth_metadata,
     ensure_token,
     exchange_code,
@@ -2354,3 +2357,272 @@ class TestStateCsrfCheck:
         assert calls[-1] == ("abc", "abc")
         assert oauth_mod.secrets.compare_digest("abc", "abd") is False
         assert calls[-1] == ("abc", "abd")
+
+
+# --- _parse_resource_metadata_hint ---
+
+
+class TestParseResourceMetadataHint:
+    def test_quoted_value(self):
+        """RFC 9728 §5.1: resource_metadata in double quotes."""
+        header = 'Bearer resource_metadata="https://resource.example.com/.well-known/oauth-protected-resource"'
+        assert (
+            _parse_resource_metadata_hint(header)
+            == "https://resource.example.com/.well-known/oauth-protected-resource"
+        )
+
+    def test_unquoted_value(self):
+        """Unquoted resource_metadata (some servers omit quotes)."""
+        header = "Bearer resource_metadata=https://resource.example.com/prm"
+        assert (
+            _parse_resource_metadata_hint(header)
+            == "https://resource.example.com/prm"
+        )
+
+    def test_with_other_params(self):
+        """resource_metadata combined with other Bearer parameters."""
+        header = 'Bearer realm="example", resource_metadata="https://resource.example.com/prm", error="invalid_token"'
+        assert (
+            _parse_resource_metadata_hint(header)
+            == "https://resource.example.com/prm"
+        )
+
+    def test_no_resource_metadata(self):
+        """WWW-Authenticate without resource_metadata returns None."""
+        header = 'Bearer realm="example", error="invalid_token"'
+        assert _parse_resource_metadata_hint(header) is None
+
+    def test_none_header(self):
+        """None input returns None."""
+        assert _parse_resource_metadata_hint(None) is None
+
+    def test_empty_header(self):
+        """Empty string returns None."""
+        assert _parse_resource_metadata_hint("") is None
+
+    def test_different_scheme_ignored(self):
+        """Non-Bearer scheme without resource_metadata returns None."""
+        header = "Basic realm=example"
+        assert _parse_resource_metadata_hint(header) is None
+
+
+# --- _validate_prm_hint_url ---
+
+
+class TestValidatePrmHintUrl:
+    SERVER = "https://api.example.com/mcp"
+
+    def test_https_same_origin_valid(self):
+        assert _validate_prm_hint_url("https://api.example.com/prm", self.SERVER) is True
+
+    def test_https_cross_origin_valid_with_warning(self, capsys):
+        result = _validate_prm_hint_url("https://other.example.com/prm", self.SERVER)
+        assert result is True
+        err = capsys.readouterr().err
+        assert "cross-origin" in err
+
+    def test_http_loopback_valid(self):
+        result = _validate_prm_hint_url(
+            "http://localhost/prm", "http://localhost:3000/mcp"
+        )
+        assert result is True
+
+    def test_http_non_loopback_rejected(self):
+        assert _validate_prm_hint_url("http://api.example.com/prm", self.SERVER) is False
+
+    def test_unsupported_scheme_rejected(self):
+        assert _validate_prm_hint_url("ftp://api.example.com/prm", self.SERVER) is False
+
+    def test_malformed_url_rejected(self):
+        assert _validate_prm_hint_url("not a url !!!", self.SERVER) is False
+
+
+# --- discover_oauth_metadata with www_authenticate hint ---
+
+
+class TestDiscoverMetadataWwwAuthenticate:
+    def test_hint_used_as_phase0(self, httpx_mock):
+        """RFC 9728 §5.1: resource_metadata hint URL is tried before well-known paths."""
+        hint_url = "https://resource.example.com/.well-known/oauth-protected-resource"
+        httpx_mock.add_response(
+            url=hint_url,
+            json={
+                "resource": "https://api.example.com/mcp",
+                "authorization_servers": ["https://auth.example.com"],
+            },
+        )
+        httpx_mock.add_response(
+            url="https://auth.example.com/.well-known/oauth-authorization-server",
+            json={
+                "authorization_endpoint": "https://auth.example.com/authorize",
+                "token_endpoint": "https://auth.example.com/token",
+            },
+        )
+        client = httpx.Client()
+        header = f'Bearer resource_metadata="{hint_url}"'
+        meta = discover_oauth_metadata(
+            "https://api.example.com/mcp", client, www_authenticate=header
+        )
+        assert meta.authorization_endpoint == "https://auth.example.com/authorize"
+        # Hint URL was fetched — confirm by checking request history
+        urls = [str(r.url) for r in httpx_mock.get_requests()]
+        assert hint_url in urls
+
+    def test_hint_failure_falls_back_to_well_known(self, httpx_mock):
+        """Phase 0 hint 404 → falls through to normal well-known discovery."""
+        hint_url = "https://resource.example.com/.well-known/oauth-protected-resource"
+        httpx_mock.add_response(url=hint_url, status_code=404)
+        # Phase 1 well-known URLs also 404
+        httpx_mock.add_response(
+            url="https://api.example.com/.well-known/oauth-protected-resource/mcp",
+            status_code=404,
+        )
+        httpx_mock.add_response(
+            url="https://api.example.com/.well-known/oauth-protected-resource",
+            status_code=404,
+        )
+        httpx_mock.add_response(
+            url="https://api.example.com/.well-known/oauth-authorization-server",
+            json={
+                "authorization_endpoint": "https://api.example.com/auth",
+                "token_endpoint": "https://api.example.com/token",
+            },
+        )
+        client = httpx.Client()
+        header = f'Bearer resource_metadata="{hint_url}"'
+        meta = discover_oauth_metadata(
+            "https://api.example.com/mcp", client, www_authenticate=header
+        )
+        assert meta.authorization_endpoint == "https://api.example.com/auth"
+
+    def test_no_hint_normal_discovery(self, httpx_mock):
+        """Without www_authenticate, discovery proceeds normally (no extra request)."""
+        httpx_mock.add_response(
+            url="https://api.example.com/.well-known/oauth-protected-resource/mcp",
+            status_code=404,
+        )
+        httpx_mock.add_response(
+            url="https://api.example.com/.well-known/oauth-protected-resource",
+            status_code=404,
+        )
+        httpx_mock.add_response(
+            url="https://api.example.com/.well-known/oauth-authorization-server",
+            json={
+                "authorization_endpoint": "https://api.example.com/auth",
+                "token_endpoint": "https://api.example.com/token",
+            },
+        )
+        client = httpx.Client()
+        meta = discover_oauth_metadata("https://api.example.com/mcp", client)
+        assert meta.authorization_endpoint == "https://api.example.com/auth"
+
+    def test_invalid_hint_url_skipped(self, httpx_mock):
+        """Insecure http:// hint URL is rejected; well-known discovery runs instead."""
+        hint_url = "http://attacker.example.com/steal-tokens"
+        httpx_mock.add_response(
+            url="https://api.example.com/.well-known/oauth-protected-resource/mcp",
+            status_code=404,
+        )
+        httpx_mock.add_response(
+            url="https://api.example.com/.well-known/oauth-protected-resource",
+            status_code=404,
+        )
+        httpx_mock.add_response(
+            url="https://api.example.com/.well-known/oauth-authorization-server",
+            json={
+                "authorization_endpoint": "https://api.example.com/auth",
+                "token_endpoint": "https://api.example.com/token",
+            },
+        )
+        client = httpx.Client()
+        header = f"Bearer resource_metadata={hint_url}"
+        meta = discover_oauth_metadata(
+            "https://api.example.com/mcp", client, www_authenticate=header
+        )
+        assert meta.authorization_endpoint == "https://api.example.com/auth"
+        # Attacker URL must never have been fetched
+        urls = [str(r.url) for r in httpx_mock.get_requests()]
+        assert hint_url not in urls
+
+    def test_hint_not_duplicated_when_same_as_well_known(self, httpx_mock):
+        """When hint URL equals the well-known path, it is fetched only once."""
+        # The hint happens to match the path-aware well-known URL
+        hint_url = "https://api.example.com/.well-known/oauth-protected-resource/mcp"
+        httpx_mock.add_response(
+            url=hint_url,
+            json={
+                "resource": "https://api.example.com/mcp",
+                "authorization_servers": ["https://auth.example.com"],
+            },
+        )
+        httpx_mock.add_response(
+            url="https://auth.example.com/.well-known/oauth-authorization-server",
+            json={
+                "authorization_endpoint": "https://auth.example.com/authorize",
+                "token_endpoint": "https://auth.example.com/token",
+            },
+        )
+        client = httpx.Client()
+        header = f'Bearer resource_metadata="{hint_url}"'
+        meta = discover_oauth_metadata(
+            "https://api.example.com/mcp", client, www_authenticate=header
+        )
+        assert meta.authorization_endpoint == "https://auth.example.com/authorize"
+        # The hint URL must appear exactly once in request history
+        urls = [str(r.url) for r in httpx_mock.get_requests()]
+        assert urls.count(hint_url) == 1
+
+
+# --- _probe_www_authenticate ---
+
+
+class TestProbeWwwAuthenticate:
+    MCP_URL = "https://api.example.com/mcp"
+
+    def test_returns_header_on_401(self, httpx_mock):
+        """401 response with WWW-Authenticate yields the header value."""
+        httpx_mock.add_response(
+            url=self.MCP_URL,
+            status_code=401,
+            headers={
+                "WWW-Authenticate": 'Bearer resource_metadata="https://resource.example.com/prm"'
+            },
+        )
+        client = httpx.Client()
+        result = _probe_www_authenticate(self.MCP_URL, client)
+        assert result == 'Bearer resource_metadata="https://resource.example.com/prm"'
+
+    def test_returns_none_on_401_without_header(self, httpx_mock):
+        """401 without WWW-Authenticate header returns None."""
+        httpx_mock.add_response(url=self.MCP_URL, status_code=401)
+        client = httpx.Client()
+        assert _probe_www_authenticate(self.MCP_URL, client) is None
+
+    def test_returns_none_on_200(self, httpx_mock):
+        """200 response (server doesn't require auth) returns None."""
+        httpx_mock.add_response(url=self.MCP_URL, status_code=200, text="{}")
+        client = httpx.Client()
+        assert _probe_www_authenticate(self.MCP_URL, client) is None
+
+    def test_returns_none_on_405(self, httpx_mock):
+        """405 Method Not Allowed returns None."""
+        httpx_mock.add_response(url=self.MCP_URL, status_code=405)
+        client = httpx.Client()
+        assert _probe_www_authenticate(self.MCP_URL, client) is None
+
+    def test_returns_none_on_connection_error(self, httpx_mock):
+        """Connection error silently returns None."""
+        httpx_mock.add_exception(httpx.ConnectError("refused"))
+        client = httpx.Client()
+        assert _probe_www_authenticate(self.MCP_URL, client) is None
+
+    def test_probe_sends_post_with_json(self, httpx_mock):
+        """Probe uses POST with Content-Type: application/json."""
+        httpx_mock.add_response(url=self.MCP_URL, status_code=401)
+        client = httpx.Client()
+        _probe_www_authenticate(self.MCP_URL, client)
+        req = httpx_mock.get_requests()[0]
+        assert req.method == "POST"
+        assert req.headers.get("content-type") == "application/json"
+        body = json.loads(req.content)
+        assert body["method"] == "initialize"


### PR DESCRIPTION
## Summary

- RFC 9728 §5.1 defines `resource_metadata` as a `WWW-Authenticate Bearer` parameter that tells the client exactly where the Protected Resource Metadata document lives — no well-known URL guessing needed.
- `_parse_resource_metadata_hint()` extracts the URL; `_validate_prm_hint_url()` enforces the same HTTP-safety policy as `_validate_auth_server_url` (reject plain HTTP non-loopback, warn on cross-origin).
- `discover_oauth_metadata(www_authenticate=)` accepts the hint as a new Phase 0 candidate, prepended before the well-known path candidates. Deduplication prevents double-fetching when the hint matches the path-aware well-known URL.
- `_probe_www_authenticate()` sends a minimal MCP `initialize` POST to the server before discovery; servers that check authentication before parsing the request body will respond 401 with the hint. Best-effort — any failure silently falls back to normal discovery.
- `ensure_token()` calls the probe just before `discover_oauth_metadata()`, so the hint is available even on the initial auth flow without relay-side changes.

## Motivation

Servers that publish PRM at a non-standard URL (not following `/.well-known/oauth-protected-resource`) have no way to communicate that location to the client — until now. With this change, those servers can simply return `WWW-Authenticate: Bearer resource_metadata="https://..."` and the client will follow it directly.

## RFC basis

- RFC 9728 §5 "Use of WWW-Authenticate for Protected Resource Metadata"
- RFC 9728 §5.1 — `resource_metadata` parameter definition and example

## Test plan

- [ ] `TestParseResourceMetadataHint` — quoted, unquoted, absent, None
- [ ] `TestValidatePrmHintUrl` — HTTPS same-origin, cross-origin warning, HTTP loopback, HTTP non-loopback reject, bad scheme, malformed URL
- [ ] `TestDiscoverMetadataWwwAuthenticate` — hint used as Phase 0, hint failure falls back, no hint normal flow, insecure hint skipped, hint deduplication
- [ ] `TestProbeWwwAuthenticate` — 401 with header, 401 without header, 200, 405, connection error, POST with JSON body verified
- [ ] Full suite: `pytest tests/ -v` → 343 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)