### PR TITLE
fix(oauth): support path-scoped issuers in RFC 8414 discovery (Keycloak, Cognito)

### DIFF
--- a/src/mcp_stdio/oauth.py
+++ b/src/mcp_stdio/oauth.py
@@ -348,6 +348,15 @@ def discover_oauth_metadata(
         if meta:
             return meta
 
+    # Path-scoped issuers (Keycloak realm URLs, AWS Cognito user pools, etc.)
+    # publish metadata at /.well-known/oauth-authorization-server/<path> per
+    # RFC 8414 §3 path-insertion. Try the original server_url when it has a
+    # path component that neither the PRM-discovered AS nor the base URL tried.
+    if server_url not in (auth_server_url, base):
+        meta = _fetch_authorization_server_metadata(server_url, client)
+        if meta:
+            return meta
+
     # Phase 3: Default paths
     log("OAuth metadata not found, using default endpoints")
     return OAuthMetadata(

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -147,6 +147,11 @@ class TestDiscoverMetadata:
             url="https://api.example.com/.well-known/oauth-authorization-server",
             status_code=404,
         )
+        # Path-scoped probe (new fallback for Keycloak-style issuers)
+        httpx_mock.add_response(
+            url="https://api.example.com/.well-known/oauth-authorization-server/mcp",
+            status_code=404,
+        )
         client = httpx.Client()
         meta = discover_oauth_metadata("https://api.example.com/mcp", client)
         assert meta.authorization_endpoint == "https://api.example.com/authorize"
@@ -154,7 +159,8 @@ class TestDiscoverMetadata:
         assert meta.registration_endpoint == "https://api.example.com/register"
 
     def test_fallback_on_connection_error(self, httpx_mock):
-        # ConnectError affects path-aware PRM, host-root PRM, and AS metadata
+        # ConnectError for: path-aware PRM, host-root PRM, host-root AS, path-scoped AS
+        httpx_mock.add_exception(httpx.ConnectError("refused"))
         httpx_mock.add_exception(httpx.ConnectError("refused"))
         httpx_mock.add_exception(httpx.ConnectError("refused"))
         httpx_mock.add_exception(httpx.ConnectError("refused"))
@@ -206,6 +212,10 @@ class TestDiscoverMetadata:
             text="not json",
             status_code=200,
         )
+        httpx_mock.add_response(
+            url="https://api.example.com/.well-known/oauth-authorization-server/mcp",
+            status_code=404,
+        )
         client = httpx.Client()
         meta = discover_oauth_metadata("https://api.example.com/mcp", client)
         # Should fallback to defaults
@@ -216,6 +226,10 @@ class TestDiscoverMetadata:
         httpx_mock.add_response(
             url="https://api.example.com/.well-known/oauth-authorization-server",
             status_code=500,
+        )
+        httpx_mock.add_response(
+            url="https://api.example.com/.well-known/oauth-authorization-server/mcp",
+            status_code=404,
         )
         client = httpx.Client()
         meta = discover_oauth_metadata("https://api.example.com/mcp", client)
@@ -273,6 +287,10 @@ class TestDiscoverMetadata:
             )
         httpx_mock.add_response(
             url="https://api.example.com/.well-known/oauth-authorization-server",
+            status_code=404,
+        )
+        httpx_mock.add_response(
+            url="https://api.example.com/.well-known/oauth-authorization-server/mcp",
             status_code=404,
         )
         client = httpx.Client()
@@ -528,6 +546,57 @@ class TestDiscoverMetadata:
         client = httpx.Client()
         meta = discover_oauth_metadata("https://api.example.com/mcp", client)
         assert meta.authorization_endpoint == "https://auth.example.com/authorize"
+
+    def test_path_scoped_issuer_keycloak_style(self, httpx_mock):
+        """#53: Keycloak/Cognito path-scoped issuers advertise metadata at RFC 8414 §3
+        path-insertion URL (/.well-known/oauth-authorization-server/<path>).
+
+        When the MCP server URL IS the issuer (no separate authorization server),
+        host-root RFC 8414 returns 404, but the path-insertion well-known succeeds.
+        Repro: mcp-stdio --oauth-device --client-id x http://keycloak/realms/test
+        """
+        # No PRM (Keycloak doesn't implement RFC 9728)
+        self._mock_no_prm(httpx_mock, base="https://keycloak.example.com", path="/realms/test")
+        # Host-root AS metadata: 404
+        httpx_mock.add_response(
+            url="https://keycloak.example.com/.well-known/oauth-authorization-server",
+            status_code=404,
+        )
+        # Path-insertion AS metadata (RFC 8414 §3): 200 with device endpoint
+        httpx_mock.add_response(
+            url="https://keycloak.example.com/.well-known/oauth-authorization-server/realms/test",
+            json={
+                "issuer": "https://keycloak.example.com/realms/test",
+                "authorization_endpoint": "https://keycloak.example.com/realms/test/protocol/openid-connect/auth",
+                "token_endpoint": "https://keycloak.example.com/realms/test/protocol/openid-connect/token",
+                "device_authorization_endpoint": "https://keycloak.example.com/realms/test/protocol/openid-connect/auth/device",
+            },
+        )
+        client = httpx.Client()
+        meta = discover_oauth_metadata(
+            "https://keycloak.example.com/realms/test", client
+        )
+        assert "auth" in meta.authorization_endpoint
+        assert "token" in meta.token_endpoint
+        assert meta.device_authorization_endpoint == (
+            "https://keycloak.example.com/realms/test/protocol/openid-connect/auth/device"
+        )
+
+    def test_path_scoped_issuer_does_not_shadow_host_root_match(self, httpx_mock):
+        """#53: when host-root AS metadata succeeds, path-scoped probe is not called."""
+        self._mock_no_prm(httpx_mock, path="/realms/test")
+        # Host-root AS metadata: 200
+        httpx_mock.add_response(
+            url="https://api.example.com/.well-known/oauth-authorization-server",
+            json={
+                "authorization_endpoint": "https://api.example.com/auth",
+                "token_endpoint": "https://api.example.com/token",
+            },
+        )
+        # Path-insertion URL must NOT be called (no extra mock registered)
+        client = httpx.Client()
+        meta = discover_oauth_metadata("https://api.example.com/realms/test", client)
+        assert meta.authorization_endpoint == "https://api.example.com/auth"
 
 
 # --- register_client ---
@@ -1499,6 +1568,11 @@ class TestEnsureToken:
             url="https://example.com/.well-known/oauth-authorization-server",
             status_code=404,
         )
+        # Path-scoped probe (Keycloak-style fallback)
+        httpx_mock.add_response(
+            url="https://example.com/.well-known/oauth-authorization-server/mcp",
+            status_code=404,
+        )
 
         # Stale token should be cleared after refresh failure
         # Full OAuth flow will be attempted (and fail due to no browser),
@@ -1741,6 +1815,11 @@ class TestClientSecretExpiry:
         )
         httpx_mock.add_response(
             url="https://example.com/.well-known/oauth-authorization-server",
+            status_code=404,
+        )
+        # Path-scoped probe (Keycloak-style fallback)
+        httpx_mock.add_response(
+            url="https://example.com/.well-known/oauth-authorization-server/mcp",
             status_code=404,
         )
         # Full flow re-registers (since client_secret expired, not reused)

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -576,11 +576,9 @@ class TestDiscoverMetadata:
         meta = discover_oauth_metadata(
             "https://keycloak.example.com/realms/test", client
         )
-        assert "auth" in meta.authorization_endpoint
-        assert "token" in meta.token_endpoint
-        assert meta.device_authorization_endpoint == (
-            "https://keycloak.example.com/realms/test/protocol/openid-connect/auth/device"
-        )
+        assert meta.authorization_endpoint == "https://keycloak.example.com/realms/test/protocol/openid-connect/auth"
+        assert meta.token_endpoint == "https://keycloak.example.com/realms/test/protocol/openid-connect/token"
+        assert meta.device_authorization_endpoint == "https://keycloak.example.com/realms/test/protocol/openid-connect/auth/device"
 
     def test_path_scoped_issuer_does_not_shadow_host_root_match(self, httpx_mock):
         """#53: when host-root AS metadata succeeds, path-scoped probe is not called."""


### PR DESCRIPTION
Fixes #53

## Problem

Keycloak realm URLs (`http://keycloak/realms/test`) and AWS Cognito user pool URLs are
path-scoped issuers where the issuer identity includes the path component.
`discover_oauth_metadata` was stripping the path via `_authorization_base_url` and
only probing `/.well-known/oauth-authorization-server` at the host root (404 on
Keycloak), falling through to dummy default endpoints with no `device_authorization_endpoint`.

```
$ mcp-stdio --oauth-device --client-id mcp-stdio-test http://keycloak/realms/test
error: Server does not support Device Authorization Grant
       (no device_authorization_endpoint in metadata)
```

## Fix

RFC 8414 §3 specifies that the well-known URL is constructed by *inserting* the well-known
prefix between the host and path components of the issuer URL. `_build_well_known_url`
already performs this correctly. The fix adds a third Phase 2 probe using `server_url`
directly (path preserved) when it differs from both the PRM-discovered auth server and
the base URL:

```
http://keycloak/realms/test
  → /.well-known/oauth-authorization-server/realms/test  ← 200 ✓
```

Discovery order (unchanged for non-Keycloak servers):
1. RFC 9728 Protected Resource Metadata
2. RFC 8414 on `auth_server_url` (base, or PRM-discovered)
3. RFC 8414 on `base` (fallback when PRM redirected to a different AS that failed)
4. **NEW** RFC 8414 on `server_url` (path-scoped issuer probe)
5. Default endpoints

## Testing

- Validated against Keycloak 26.6.1 via local Docker (`m2.local`): `--oauth-device`
  now successfully discovers `device_authorization_endpoint` and issues a device code.
- 2 new unit tests: `test_path_scoped_issuer_keycloak_style` and
  `test_path_scoped_issuer_does_not_shadow_host_root_match`
- 6 existing tests updated to account for the new path-scoped probe request

## Test plan

- [x] `pytest tests/ -v` — all 360 tests pass
- [x] Keycloak 26.6.1 device flow: `mcp-stdio --oauth-device --client-id mcp-stdio-test http://localhost:18080/realms/test` issues device code successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)