### PR TITLE
fix(relay): serialize stdout writes to prevent NDJSON line interleaving

### DIFF
--- a/src/mcp_stdio/cli.py
+++ b/src/mcp_stdio/cli.py
@@ -11,7 +11,7 @@ from typing import Callable
 import httpx
 
 from . import __version__
-from .relay import check_connection, log, run, run_sse
+from .relay import check_connection, run, run_sse
 
 def _non_negative_float(value: str) -> float:
     """argparse type for non-negative floats (rejects negative leeway)."""

--- a/src/mcp_stdio/oauth.py
+++ b/src/mcp_stdio/oauth.py
@@ -485,7 +485,7 @@ def generate_pkce() -> tuple[str, str]:
 
     Returns (code_verifier, code_challenge).
     """
-    verifier = secrets.token_urlsafe(64)[:96]  # 96 chars, within 43-128
+    verifier = secrets.token_urlsafe(64)[:96]  # ~86 chars, capped well within 43-128
     digest = hashlib.sha256(verifier.encode("ascii")).digest()
     challenge = base64.urlsafe_b64encode(digest).rstrip(b"=").decode("ascii")
     return verifier, challenge

--- a/src/mcp_stdio/relay.py
+++ b/src/mcp_stdio/relay.py
@@ -145,6 +145,22 @@ def log(msg: str) -> None:
     print(f"[mcp-stdio] {msg}", file=sys.stderr, flush=True)
 
 
+# Serializes writes to stdout. ``run_sse`` drives two writers — the SSE
+# reader thread (message events via ``_emit``) and the main loop (error
+# responses) — and ``print`` is not atomic across the content and its
+# trailing newline, so without this lock a POST error coinciding with a
+# message event could interleave mid-line and corrupt the NDJSON wire
+# format. ``run`` is single-threaded and pays only an uncontended lock.
+_STDOUT_LOCK = threading.Lock()
+
+
+def _write_line(line: str) -> None:
+    """Write one line to stdout atomically (content + newline under a lock)."""
+    with _STDOUT_LOCK:
+        sys.stdout.write(f"{line}\n")
+        sys.stdout.flush()
+
+
 def _extract_id(line: str) -> Any:
     """Extract JSON-RPC id from request line."""
     try:
@@ -336,22 +352,22 @@ def _emit(line: str, tracker: "_CancelTracker | None") -> None:
     an answer for the line it just sent.
     """
     if tracker is None:
-        print(line, flush=True)
+        _write_line(line)
         return
     try:
         msg = json.loads(line)
     except (json.JSONDecodeError, TypeError):
-        print(line, flush=True)
+        _write_line(line)
         return
     if not isinstance(msg, dict):
-        print(line, flush=True)
+        _write_line(line)
         return
     rid = msg.get("id")
     if rid is not None and ("result" in msg or "error" in msg):
         if tracker.contains(rid):
             log(f"dropped late response for cancelled id {rid!r}")
             return
-    print(line, flush=True)
+    _write_line(line)
 
 
 class _StreamResult:
@@ -460,7 +476,7 @@ def _post_and_stream(
                 time.sleep(RETRY_DELAY * attempt)
 
     log(f"request failed after retries: {last_error}")
-    print(_error_response(str(last_error), req_id), flush=True)
+    _write_line(_error_response(str(last_error), req_id))
     return None
 
 
@@ -534,7 +550,7 @@ def _post_parsed(
                 time.sleep(RETRY_DELAY * attempt)
 
     log(f"request failed after retries: {last_error}")
-    print(_error_response(str(last_error), req_id), flush=True)
+    _write_line(_error_response(str(last_error), req_id))
     return None, None
 
 
@@ -935,10 +951,7 @@ def run(
                         continue
                 else:
                     log("token refresh failed, returning error")
-                    print(
-                        _error_response("authentication failed", req_id),
-                        flush=True,
-                    )
+                    _write_line(_error_response("authentication failed", req_id))
                     continue
 
             # Insufficient scope (403) — step-up authorization and retry once
@@ -962,10 +975,7 @@ def run(
                             continue
                     else:
                         log("step-up authorization failed, returning error")
-                        print(
-                            _error_response("authorization failed", req_id),
-                            flush=True,
-                        )
+                        _write_line(_error_response("authorization failed", req_id))
                         continue
 
             # Session expired (404) — reset, re-initialize, then retry
@@ -975,7 +985,7 @@ def run(
                 new_session_id = _reinitialize(client, url, dict(headers))
                 if new_session_id is None:
                     log("re-initialize failed, dropping request")
-                    print(_error_response("session lost", req_id), flush=True)
+                    _write_line(_error_response("session lost", req_id))
                     continue
                 session_id = new_session_id
                 req_headers = dict(headers)
@@ -993,10 +1003,7 @@ def run(
             # and intentionally produces no stdout. See #11.
             if result.status_code >= 400:
                 log(f"upstream returned HTTP {result.status_code}")
-                print(
-                    _error_response(f"HTTP {result.status_code}", req_id),
-                    flush=True,
-                )
+                _write_line(_error_response(f"HTTP {result.status_code}", req_id))
     finally:
         client.close()
 
@@ -1210,19 +1217,13 @@ def run_sse(
             if state.endpoint_url is None:
                 if not state.ready.wait(timeout=timeout_read):
                     req_id = _extract_id(line)
-                    print(
-                        _error_response("SSE endpoint unavailable", req_id),
-                        flush=True,
-                    )
+                    _write_line(_error_response("SSE endpoint unavailable", req_id))
                     continue
 
             req_id = _extract_id(line)
             endpoint = state.endpoint_url
             if endpoint is None:
-                print(
-                    _error_response("SSE endpoint unavailable", req_id),
-                    flush=True,
-                )
+                _write_line(_error_response("SSE endpoint unavailable", req_id))
                 continue
 
             try:
@@ -1272,10 +1273,7 @@ def run_sse(
                         )
                     else:
                         log("token refresh failed, returning error")
-                        print(
-                            _error_response("authentication failed", req_id),
-                            flush=True,
-                        )
+                        _write_line(_error_response("authentication failed", req_id))
                         continue
 
                 if resp.status_code == 403 and scope_upgrader:
@@ -1305,23 +1303,15 @@ def run_sse(
                             log(
                                 "step-up authorization failed, returning error"
                             )
-                            print(
-                                _error_response("authorization failed", req_id),
-                                flush=True,
-                            )
+                            _write_line(_error_response("authorization failed", req_id))
                             continue
 
                 if resp.status_code not in (200, 202):
                     log(f"POST returned HTTP {resp.status_code}")
-                    print(
-                        _error_response(
-                            f"HTTP {resp.status_code}", req_id
-                        ),
-                        flush=True,
-                    )
+                    _write_line(_error_response(f"HTTP {resp.status_code}", req_id))
             except httpx.HTTPError as e:
                 log(f"POST failed: {e}")
-                print(_error_response(str(e), req_id), flush=True)
+                _write_line(_error_response(str(e), req_id))
     finally:
         state.stop.set()
         client.close()

--- a/tests/test_relay.py
+++ b/tests/test_relay.py
@@ -53,10 +53,11 @@ class TestWriteLine:
         """stdout stub recording every write() call argument verbatim.
 
         Guards the record list with its own lock so the test stays correct
-        even under a free-threaded interpreter, and so it does not lean on
-        the system-under-test's _STDOUT_LOCK for the recording's own
-        integrity — if that lock were ever removed, writes would still be
-        recorded intact and the assertion would catch the regression.
+        even under a free-threaded interpreter, independent of the
+        system-under-test's _STDOUT_LOCK. Note: this test guards the
+        single-write-per-line property — a revert to a two-call print()
+        would surface as bare "\\n" fragments — not _STDOUT_LOCK itself,
+        which protects the underlying buffered stream the stub does not model.
         """
 
         def __init__(self):

--- a/tests/test_relay.py
+++ b/tests/test_relay.py
@@ -2,7 +2,6 @@
 
 import email.utils
 import json
-import queue
 import socket
 import threading
 import time
@@ -32,10 +31,72 @@ from mcp_stdio.relay import (
     _post_and_stream,
     _sse_reader_loop,
     _tcp_keepalive_socket_options,
+    _write_line,
     check_connection,
     run,
     run_sse,
 )
+
+
+# --- _write_line ---
+
+
+class TestWriteLine:
+    """Guard the NDJSON wire format against mid-line interleaving.
+
+    run_sse writes to stdout from two threads (the SSE reader and the main
+    loop). _write_line must emit each line's content and trailing newline
+    as a single atomic write so a concurrent writer can never split a line.
+    """
+
+    class _RecordingStdout:
+        """stdout stub recording every write() call argument verbatim."""
+
+        def __init__(self):
+            self.writes = []
+
+        def write(self, s):
+            self.writes.append(s)
+
+        def flush(self):
+            pass
+
+    def test_single_write_includes_newline(self):
+        """Content and newline are written in one call, never as two writes."""
+        out = self._RecordingStdout()
+        with patch("mcp_stdio.relay.sys.stdout", out):
+            _write_line('{"id":1}')
+        assert out.writes == ['{"id":1}\n']
+
+    def test_concurrent_writers_never_interleave(self):
+        """Two threads hammering _write_line yield only whole, intact lines."""
+        out = self._RecordingStdout()
+        per_thread = 500
+        expected = {
+            f'{{"t":"{tag}","n":{i}}}\n'
+            for tag in ("a", "b")
+            for i in range(per_thread)
+        }
+
+        def writer(tag):
+            for i in range(per_thread):
+                _write_line(f'{{"t":"{tag}","n":{i}}}')
+
+        with patch("mcp_stdio.relay.sys.stdout", out):
+            threads = [
+                threading.Thread(target=writer, args=(tag,))
+                for tag in ("a", "b")
+            ]
+            for t in threads:
+                t.start()
+            for t in threads:
+                t.join()
+
+        # Every recorded write is exactly one complete line — no bare "\n"
+        # fragments (which a two-call print() would produce) and no partials.
+        assert all(w.endswith("\n") and w.count("\n") == 1 for w in out.writes)
+        assert set(out.writes) == expected
+        assert len(out.writes) == 2 * per_thread
 
 
 # --- _enforce_lf_stdio ---

--- a/tests/test_relay.py
+++ b/tests/test_relay.py
@@ -50,13 +50,22 @@ class TestWriteLine:
     """
 
     class _RecordingStdout:
-        """stdout stub recording every write() call argument verbatim."""
+        """stdout stub recording every write() call argument verbatim.
+
+        Guards the record list with its own lock so the test stays correct
+        even under a free-threaded interpreter, and so it does not lean on
+        the system-under-test's _STDOUT_LOCK for the recording's own
+        integrity — if that lock were ever removed, writes would still be
+        recorded intact and the assertion would catch the regression.
+        """
 
         def __init__(self):
             self.writes = []
+            self._lock = threading.Lock()
 
         def write(self, s):
-            self.writes.append(s)
+            with self._lock:
+                self.writes.append(s)
 
         def flush(self):
             pass


### PR DESCRIPTION
## Summary

Holistic review of `main` surfaced one latent concurrency defect and a few nits. This PR addresses all of them.

### Main fix — `run_sse` stdout interleaving
`run_sse` writes to stdout from **two threads**: the SSE reader thread (message events via `_emit`) and the main loop (error responses on POST failure). `print()` emits the content and its trailing newline as **two separate writes**, so a POST error coinciding with a message event could interleave mid-line and corrupt the NDJSON wire format.

Fix: route every stdout write through a new lock-guarded `_write_line()` that emits `content + "\n"` in a single atomic write. `run()` is single-threaded and pays only an uncontended lock. All previously-scattered `print(_error_response(...), flush=True)` and `_emit` writes now share this one path, establishing the invariant "all stdout goes through `_write_line`".

### Nits folded in
- Remove unused `log` import in `cli.py` (ruff `F401`)
- Remove unused `queue` import in `tests/test_relay.py`
- Correct the PKCE verifier length comment (`~86 chars`, not `96`)

## Test
- New `TestWriteLine` (2 tests): single-write-includes-newline + 1000-line two-thread concurrency guard
- Full suite: **400 passed, 3 skipped** (skips are platform guards)
- `ruff check src/` clean

## Not changed (documented design choices, out of scope)
- Cross-origin AS / issuer-mismatch are warn-but-permit per RFC 9728 federation — flagged in the review as threat-model questions, not bugs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)