### PR TITLE
feat(relay): inject MCP-Protocol-Version header on subsequent requests

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -34,7 +34,7 @@ Bearer token、カスタムヘッダー、OAuth 2.1 認証情報をリモート�
   - [RFC 8707](https://www.rfc-editor.org/rfc/rfc8707) Resource Indicators
     - §2 `resource` パラメータを認可リクエスト・トークン交換・**リフレッシュ**に送信
   - [RFC 7636](https://www.rfc-editor.org/rfc/rfc7636) PKCE
-    - §4.1–4.2 S256 `code_challenge_method`、96 文字の `code_verifier`
+    - §4.1–4.2 S256 `code_challenge_method`、約 86 文字の `code_verifier`
   - [RFC 8628](https://www.rfc-editor.org/rfc/rfc8628) Device Authorization Grant
     - §3.1 `resource` インジケータ付きデバイス認可リクエスト（RFC 8707）
     - §3.4–3.5 `authorization_pending` / `slow_down`（interval +=5 s）/ `expired_token` / `access_denied` ハンドリング
@@ -49,6 +49,7 @@ Bearer token、カスタムヘッダー、OAuth 2.1 認証情報をリモート�
 - **バックオフ付きリトライ** — 接続エラー時に最大3回リトライ
 - **ストリーミング耐性** — SSE レスポンスをリアルタイムで転送、ストリーム切断時に自動再接続
 - **セッション回復** — 404 でセッション ID をリセットして再試行
+- **プロトコルバージョンヘッダー** — `initialize` 応答から交渉済みの `protocolVersion` を捕捉し、以降の Streamable HTTP リクエストすべてに `MCP-Protocol-Version` を付与（MCP 仕様 rev 2025-06-18）。このヘッダーを強制するサーバーは未送信時に初期化後リクエストを `400 Bad Request` で拒否する
 - **401 時の自動トークンリフレッシュ** — セッション中に OAuth トークンが失効しても自動更新
 - **Bearer token 認証** — `--bearer-token` フラグまたは `MCP_BEARER_TOKEN` 環境変数
 - **カスタムヘッダー** — `-H` / `--header` で任意のヘッダーを送信
@@ -206,7 +207,7 @@ Claude Code・mcp-remote・Windows の既知の問題については [WORKAROUND
 
 トランスポート別の挙動：
 
-- **Streamable HTTP**（デフォルト）— 各メッセージを単一 POST で送信。`Mcp-Session-Id` ヘッダーでセッション状態を追跡し、404 時は自動で再初期化。
+- **Streamable HTTP**（デフォルト）— 各メッセージを単一 POST で送信。`Mcp-Session-Id` ヘッダーでセッション状態を追跡し、404 時は自動で再初期化。交渉済みの `MCP-Protocol-Version` ヘッダーを初期化後の全リクエストに付与（仕様 rev 2025-06-18）。
 - **SSE**（MCP 2024-11-05 レガシー）— 持続的な `GET` ストリームで応答と初回の `endpoint` イベント（POST 先 URL）を受信。ストリーム切断時は自動再接続。
 
 OAuth トークンは `~/.config/mcp-stdio/tokens.json` に保存されます（パーミッション 0600）。

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Bearer tokens, custom headers, and OAuth 2.1 credentials are forwarded to the re
   - [RFC 8707](https://www.rfc-editor.org/rfc/rfc8707) Resource Indicators
     - §2 `resource` parameter in authorization, token exchange, **and refresh** requests
   - [RFC 7636](https://www.rfc-editor.org/rfc/rfc7636) PKCE
-    - §4.1–4.2 S256 `code_challenge_method` with a 96-char `code_verifier`
+    - §4.1–4.2 S256 `code_challenge_method` with a ~86-char `code_verifier`
   - [RFC 8628](https://www.rfc-editor.org/rfc/rfc8628) Device Authorization Grant
     - §3.1 device authorization request with `resource` indicator (RFC 8707)
     - §3.4–3.5 token polling with `authorization_pending` / `slow_down` (interval +=5 s) / `expired_token` / `access_denied` handling
@@ -51,6 +51,7 @@ Bearer tokens, custom headers, and OAuth 2.1 credentials are forwarded to the re
 - **Retry with backoff** — retries up to 3 times on connection errors
 - **Streaming resilience** — streams SSE responses in real time; auto-reconnects on mid-stream disconnect
 - **Session recovery** — resets MCP session ID on 404 and retries
+- **Protocol version header** — captures the negotiated `protocolVersion` from the `initialize` response and injects `MCP-Protocol-Version` on every subsequent Streamable HTTP request (MCP spec rev 2025-06-18); servers that enforce the header would otherwise reject post-initialize requests with `400 Bad Request`
 - **Token refresh on 401** — automatically refreshes expired OAuth tokens mid-session
 - **Bearer token auth** — via `--bearer-token` flag or `MCP_BEARER_TOKEN` env var
 - **Custom headers** — pass any header with `-H` / `--header`
@@ -207,7 +208,7 @@ See [WORKAROUNDS.md](WORKAROUNDS.md) for known issues in Claude Code, mcp-remote
 
 Transport details:
 
-- **Streamable HTTP** (default) — each stdin message is a single POST; session state is tracked via the `Mcp-Session-Id` header and re-initialized automatically on 404.
+- **Streamable HTTP** (default) — each stdin message is a single POST; session state is tracked via the `Mcp-Session-Id` header and re-initialized automatically on 404. The negotiated `MCP-Protocol-Version` header is sent on every post-initialize request (spec rev 2025-06-18).
 - **SSE** (MCP 2024-11-05 legacy) — a persistent `GET` stream delivers responses and the initial `endpoint` event containing the POST URL; the stream auto-reconnects on disconnect.
 
 OAuth tokens are stored in `~/.config/mcp-stdio/tokens.json` (permissions 0600).

--- a/src/mcp_stdio/relay.py
+++ b/src/mcp_stdio/relay.py
@@ -169,6 +169,46 @@ def _extract_id(line: str) -> Any:
         return None
 
 
+# MCP-Protocol-Version header (spec rev 2025-06-18, "Protocol Version Header").
+# After initialization the client MUST send the negotiated protocol version on
+# every subsequent HTTP request; servers that enforce it return 400 when it is
+# absent. The header is a Streamable-HTTP-era construct — it is absent from the
+# 2025-03-26 spec and from the 2024-11-05 legacy SSE transport — so it is
+# injected on the Streamable HTTP path (``run``) only. A cheap regex pre-check
+# gates the slow json.loads, mirroring ``_CANCELLED_METHOD_RE``.
+_INITIALIZE_METHOD_RE = re.compile(r'"method"\s*:\s*"initialize"')
+
+
+def _looks_like_initialize(line: str) -> bool:
+    """Return True if ``line`` looks like a JSON-RPC ``initialize`` request.
+
+    A cheap pre-filter so the relay only attempts to capture the negotiated
+    protocol version from initialize responses. The trailing quote in the
+    pattern means ``notifications/initialized`` does not match.
+    """
+    return bool(_INITIALIZE_METHOD_RE.search(line))
+
+
+def _extract_protocol_version(payload: str) -> str | None:
+    """Return ``result.protocolVersion`` from an InitializeResult, else None.
+
+    Accepts the JSON-RPC response payload (the text after ``data: `` for an
+    SSE-framed response, or the whole JSON body otherwise). Returns None for
+    anything that is not an object carrying a string ``result.protocolVersion``.
+    """
+    try:
+        msg = json.loads(payload)
+    except (json.JSONDecodeError, TypeError):
+        return None
+    if not isinstance(msg, dict):
+        return None
+    result = msg.get("result")
+    if not isinstance(result, dict):
+        return None
+    pv = result.get("protocolVersion")
+    return pv if isinstance(pv, str) else None
+
+
 # Cancel-aware response filter (MCP cancellation spec SHOULDs).
 #
 # The MCP cancellation utility mandates two reciprocal SHOULDs:
@@ -373,17 +413,21 @@ def _emit(line: str, tracker: "_CancelTracker | None") -> None:
 class _StreamResult:
     """Result of a streaming request."""
 
-    __slots__ = ("session_id", "status_code", "www_authenticate")
+    __slots__ = ("session_id", "status_code", "www_authenticate", "protocol_version")
 
     def __init__(
         self,
         session_id: str | None,
         status_code: int,
         www_authenticate: str | None = None,
+        protocol_version: str | None = None,
     ):
         self.session_id = session_id
         self.status_code = status_code
         self.www_authenticate = www_authenticate
+        # Negotiated MCP protocol version captured from an InitializeResult
+        # (only populated when the caller requests capture). See run().
+        self.protocol_version = protocol_version
 
 
 _INSUFFICIENT_SCOPE_RE = re.compile(r'error\s*=\s*"?insufficient_scope"?')
@@ -422,12 +466,20 @@ def _post_and_stream(
     headers: dict[str, str],
     req_id: Any,
     tracker: _CancelTracker | None = None,
+    *,
+    capture_init: bool = False,
 ) -> _StreamResult | None:
     """Send a POST and stream the response to stdout with retry.
 
     Handles both SSE and JSON responses.  Returns a ``_StreamResult``
     on success (including non-200 status for caller to handle), or
     ``None`` when all retries are exhausted (error already printed).
+
+    When ``capture_init`` is set the streamed payload is additionally
+    parsed for ``result.protocolVersion`` (the negotiated MCP protocol
+    version from an InitializeResult), surfaced via
+    ``_StreamResult.protocol_version``. Parsing is read-only and never
+    affects what is written to stdout.
     """
     last_error: Exception | None = None
     for attempt in range(1, MAX_RETRIES + 1):
@@ -452,18 +504,24 @@ def _post_and_stream(
                     resp.read()
                     return _StreamResult(session, resp.status_code, www_auth)
 
+                pv: str | None = None
                 content_type = resp.headers.get("content-type", "")
                 if "text/event-stream" in content_type:
                     for line in resp.iter_lines():
                         if line.startswith("data: "):
-                            _emit(line[6:], tracker)
+                            payload = line[6:]
+                            if capture_init and pv is None:
+                                pv = _extract_protocol_version(payload)
+                            _emit(payload, tracker)
                 else:
                     resp.read()
                     text = resp.text.strip()
                     if text:
+                        if capture_init:
+                            pv = _extract_protocol_version(text)
                         _emit(text, tracker)
 
-                return _StreamResult(session, 200)
+                return _StreamResult(session, 200, protocol_version=pv)
         except (
             httpx.ConnectError,
             httpx.ReadTimeout,
@@ -691,6 +749,7 @@ def _reinitialize(
     client: httpx.Client,
     url: str,
     headers: dict[str, str],
+    protocol_version: str | None = None,
 ) -> str | None:
     """Send an initialize handshake to establish a new MCP session.
 
@@ -700,6 +759,11 @@ def _reinitialize(
     1. POST an ``initialize`` request to get a new session ID
     2. POST a ``notifications/initialized`` notification to signal
        readiness (required by the MCP spec before any other requests)
+
+    ``notifications/initialized`` is the first "subsequent request" of the
+    recovered session, so it carries the ``MCP-Protocol-Version`` header
+    when ``protocol_version`` is known. The initialize POST itself omits it
+    — it is the (re)negotiation and predates a known version.
 
     Returns the new session ID on success, or None on failure. The
     initialize response payload is discarded — the caller only needs
@@ -736,6 +800,8 @@ def _reinitialize(
     )
     initialized_headers = dict(headers)
     initialized_headers["Mcp-Session-Id"] = new_session_id
+    if protocol_version:
+        initialized_headers["MCP-Protocol-Version"] = protocol_version
     try:
         resp = client.post(url, content=initialized_msg, headers=initialized_headers)
     except httpx.HTTPError as e:
@@ -895,6 +961,10 @@ def run(
     log(f"connecting to {url}")
 
     session_id: str | None = None
+    # Negotiated MCP protocol version, captured from the InitializeResult and
+    # injected as MCP-Protocol-Version on every subsequent request (spec rev
+    # 2025-06-18). Streamable HTTP only — see _looks_like_initialize.
+    protocol_version: str | None = None
     tracker: _CancelTracker | None = _CancelTracker() if cancel_filter else None
     client = httpx.Client(
         transport=_make_httpx_transport(tcp_keepalive=tcp_keepalive),
@@ -905,6 +975,15 @@ def run(
             pool=10,
         )
     )
+
+    def _prepare_headers() -> dict[str, str]:
+        """Build per-request headers with the current session + protocol version."""
+        h = dict(headers)
+        if session_id:
+            h["Mcp-Session-Id"] = session_id
+        if protocol_version:
+            h["MCP-Protocol-Version"] = protocol_version
+        return h
 
     try:
         for line in sys.stdin:
@@ -919,17 +998,31 @@ def run(
 
             req_id = _extract_id(line)
 
-            req_headers = dict(headers)
-            if session_id:
-                req_headers["Mcp-Session-Id"] = session_id
+            req_headers = _prepare_headers()
 
             def _dispatch(content: str, h: dict[str, str]) -> _StreamResult | None:
+                nonlocal protocol_version
                 detected = _detect_paginated_list(content)
                 if detected:
                     return _paginate_and_stream(
                         client, url, content, h, req_id, detected[1], tracker
                     )
-                return _post_and_stream(client, url, content, h, req_id, tracker)
+                # Capture-once semantics: we only learn the version from the
+                # first initialize. A later client-driven re-initialize that
+                # renegotiates a different version is not picked up — rare, and
+                # avoids re-parsing every response on the hot path.
+                capture_init = protocol_version is None and _looks_like_initialize(content)
+                result = _post_and_stream(
+                    client, url, content, h, req_id, tracker, capture_init=capture_init
+                )
+                if (
+                    result is not None
+                    and result.protocol_version
+                    and protocol_version is None
+                ):
+                    protocol_version = result.protocol_version
+                    log(f"negotiated MCP protocol version: {protocol_version}")
+                return result
 
             result = _dispatch(line, req_headers)
             if result is None:
@@ -943,9 +1036,7 @@ def run(
                 new_headers = token_refresher()
                 if new_headers:
                     headers.update(new_headers)
-                    req_headers = dict(headers)
-                    if session_id:
-                        req_headers["Mcp-Session-Id"] = session_id
+                    req_headers = _prepare_headers()
                     result = _dispatch(line, req_headers)
                     if result is None:
                         continue
@@ -967,9 +1058,7 @@ def run(
                     new_headers = scope_upgrader(required_scope)
                     if new_headers:
                         headers.update(new_headers)
-                        req_headers = dict(headers)
-                        if session_id:
-                            req_headers["Mcp-Session-Id"] = session_id
+                        req_headers = _prepare_headers()
                         result = _dispatch(line, req_headers)
                         if result is None:
                             continue
@@ -982,14 +1071,15 @@ def run(
             if result.status_code == 404 and session_id:
                 log("session expired, re-initializing and retrying")
                 session_id = None
-                new_session_id = _reinitialize(client, url, dict(headers))
+                new_session_id = _reinitialize(
+                    client, url, dict(headers), protocol_version
+                )
                 if new_session_id is None:
                     log("re-initialize failed, dropping request")
                     _write_line(_error_response("session lost", req_id))
                     continue
                 session_id = new_session_id
-                req_headers = dict(headers)
-                req_headers["Mcp-Session-Id"] = session_id
+                req_headers = _prepare_headers()
                 result = _dispatch(line, req_headers)
                 if result is None:
                     continue

--- a/src/mcp_stdio/relay.py
+++ b/src/mcp_stdio/relay.py
@@ -1011,6 +1011,12 @@ def run(
                 # first initialize. A later client-driven re-initialize that
                 # renegotiates a different version is not picked up — rare, and
                 # avoids re-parsing every response on the hot path.
+                #
+                # Response-only: the version comes from the server's
+                # InitializeResult, not the client's requested version. If a
+                # (non-compliant) server omits result.protocolVersion, no
+                # header is sent rather than guessing — a server that both
+                # omits it and enforces the header would be self-contradictory.
                 capture_init = protocol_version is None and _looks_like_initialize(content)
                 result = _post_and_stream(
                     client, url, content, h, req_id, tracker, capture_init=capture_init

--- a/tests/test_relay.py
+++ b/tests/test_relay.py
@@ -602,6 +602,131 @@ class TestRun:
         assert result["id"] == 1
 
 
+# --- MCP-Protocol-Version header (spec rev 2025-06-18, issue #69) ---
+
+
+class TestProtocolVersionHeader:
+    """Capture the negotiated protocol version and inject it on subsequent requests.
+
+    Per the Streamable HTTP spec (2025-06-18, "Protocol Version Header"), after
+    initialization the client MUST send MCP-Protocol-Version on every subsequent
+    request. mcp-stdio captures result.protocolVersion from the InitializeResult
+    and injects it; the initialize POST itself carries no header.
+    """
+
+    def _run_with_stdin(self, stdin_lines):
+        stdin_data = "\n".join(stdin_lines) + "\n"
+        stdout = StringIO()
+        with patch("sys.stdin", StringIO(stdin_data)), patch("sys.stdout", stdout):
+            run("https://example.com/mcp", {"Content-Type": "application/json"})
+        return stdout.getvalue()
+
+    def test_captures_version_and_injects_on_subsequent_request(self, httpx_mock):
+        httpx_mock.add_response(
+            text='{"jsonrpc":"2.0","result":{"protocolVersion":"2025-06-18"},"id":1}',
+            headers={"content-type": "application/json"},
+        )
+        httpx_mock.add_response(
+            text='{"jsonrpc":"2.0","result":{},"id":2}',
+            headers={"content-type": "application/json"},
+        )
+        output = self._run_with_stdin(
+            [
+                '{"jsonrpc":"2.0","method":"initialize","id":1}',
+                '{"jsonrpc":"2.0","method":"tools/call","id":2}',
+            ]
+        )
+        # Capture is read-only: the initialize response must still reach stdout.
+        msgs = [json.loads(x) for x in output.strip().splitlines() if x]
+        assert any(
+            m.get("result", {}).get("protocolVersion") == "2025-06-18" for m in msgs
+        )
+        reqs = httpx_mock.get_requests()
+        # initialize itself carries no header (version not yet negotiated)
+        assert "mcp-protocol-version" not in reqs[0].headers
+        # the next request carries the negotiated version
+        assert reqs[1].headers["mcp-protocol-version"] == "2025-06-18"
+
+    def test_initialized_notification_carries_header(self, httpx_mock):
+        """notifications/initialized is the first subsequent request — must carry it."""
+        httpx_mock.add_response(
+            text='{"jsonrpc":"2.0","result":{"protocolVersion":"2025-06-18"},"id":1}',
+            headers={"content-type": "application/json"},
+        )
+        httpx_mock.add_response(status_code=202, text="")
+        self._run_with_stdin(
+            [
+                '{"jsonrpc":"2.0","method":"initialize","id":1}',
+                '{"jsonrpc":"2.0","method":"notifications/initialized"}',
+            ]
+        )
+        reqs = httpx_mock.get_requests()
+        assert reqs[1].headers["mcp-protocol-version"] == "2025-06-18"
+
+    def test_sse_framed_initialize_captures_version(self, httpx_mock):
+        httpx_mock.add_response(
+            text='data: {"jsonrpc":"2.0","result":{"protocolVersion":"2025-03-26"},"id":1}\n\n',
+            headers={"content-type": "text/event-stream"},
+        )
+        httpx_mock.add_response(
+            text='{"jsonrpc":"2.0","result":{},"id":2}',
+            headers={"content-type": "application/json"},
+        )
+        self._run_with_stdin(
+            [
+                '{"jsonrpc":"2.0","method":"initialize","id":1}',
+                '{"jsonrpc":"2.0","method":"tools/call","id":2}',
+            ]
+        )
+        reqs = httpx_mock.get_requests()
+        assert reqs[1].headers["mcp-protocol-version"] == "2025-03-26"
+
+    def test_no_header_when_no_initialize_seen(self, httpx_mock):
+        """A request that is not preceded by an initialize carries no version header."""
+        httpx_mock.add_response(
+            text='{"jsonrpc":"2.0","result":{},"id":1}',
+            headers={"content-type": "application/json"},
+        )
+        self._run_with_stdin(['{"jsonrpc":"2.0","method":"tools/call","id":1}'])
+        reqs = httpx_mock.get_requests()
+        assert "mcp-protocol-version" not in reqs[0].headers
+
+    def test_reinitialize_initialized_carries_header(self, httpx_mock):
+        """After a 404, the recovered session's initialized notification carries it."""
+        # 1: initialize -> negotiate 2025-06-18, session sess-1
+        httpx_mock.add_response(
+            text='{"jsonrpc":"2.0","result":{"protocolVersion":"2025-06-18"},"id":1}',
+            headers={"content-type": "application/json", "mcp-session-id": "sess-1"},
+        )
+        # 2: tools/call -> 404 (session expired)
+        httpx_mock.add_response(
+            status_code=404, text="", headers={"content-type": "application/json"}
+        )
+        # 3: reinit initialize -> new session sess-2
+        httpx_mock.add_response(
+            text='{"jsonrpc":"2.0","result":{"protocolVersion":"2025-06-18"},"id":0}',
+            headers={"content-type": "application/json", "mcp-session-id": "sess-2"},
+        )
+        # 4: reinit notifications/initialized -> 202
+        httpx_mock.add_response(status_code=202, text="")
+        # 5: tools/call retry -> 200
+        httpx_mock.add_response(
+            text='{"jsonrpc":"2.0","result":{},"id":2}',
+            headers={"content-type": "application/json"},
+        )
+        self._run_with_stdin(
+            [
+                '{"jsonrpc":"2.0","method":"initialize","id":1}',
+                '{"jsonrpc":"2.0","method":"tools/call","id":2}',
+            ]
+        )
+        reqs = httpx_mock.get_requests()
+        # reqs: 0=init, 1=call(404), 2=reinit-init, 3=reinit-initialized, 4=call-retry
+        assert "mcp-protocol-version" not in reqs[2].headers  # renegotiation
+        assert reqs[3].headers["mcp-protocol-version"] == "2025-06-18"
+        assert reqs[4].headers["mcp-protocol-version"] == "2025-06-18"
+
+
 # --- step-up authorization (anthropics/claude-code#44652) ---
 
 


### PR DESCRIPTION
Closes #69.

## Summary

The MCP Streamable HTTP spec (rev **2025-06-18**, *Protocol Version Header*) states:

> If using HTTP, the client **MUST** include the `MCP-Protocol-Version: <protocol-version>` HTTP header on all subsequent requests to the MCP server...
> If the server receives a request with an invalid or unsupported `MCP-Protocol-Version`, it **MUST** respond with `400 Bad Request`.

mcp-stdio previously injected only `Authorization` and `Mcp-Session-Id`. Servers that enforce this header reject every post-initialize request with `400 Bad Request`.

## What this does

- Captures `result.protocolVersion` from the `InitializeResult` (read-only tee in `_post_and_stream`, gated by a cheap regex on the request line — mirrors `_CANCELLED_METHOD_RE`).
- Injects `MCP-Protocol-Version: <negotiated>` on every subsequent request via a shared `_prepare_headers()` helper: main dispatch, 401/403 retries, paginated list requests, and the 404 re-initialize handshake's `notifications/initialized`.
- The `initialize` POST itself omits the header (it predates a negotiated version). Capture is once-per-session.

## Scope: Streamable HTTP (`run`) only — and why

The header is a Streamable-HTTP construct **introduced in rev 2025-06-18** — it is absent from the [2025-03-26 spec](https://modelcontextprotocol.io/specification/2025-03-26/basic/transports) and from the 2024-11-05 legacy SSE transport. Additionally, on the SSE path the `InitializeResult` arrives **asynchronously on the GET reader stream**, not on the POST (which returns 202), so response-capture does not apply there. The SSE transport (`run_sse`) is intentionally untouched.

This also normalizes the header/body protocolVersion surface noted in modelcontextprotocol/typescript-sdk#2108 and python-sdk#2618.

## Known limitation

Capture is **response-only**: the version comes solely from the server's `InitializeResult`, with no fallback to the client's requested version. A non-compliant server that omits `result.protocolVersion` gets no header rather than a guess — a server that both omits it and enforces the header would be self-contradictory. Documented in-code at the capture site.

## Tests

`TestProtocolVersionHeader` (5 tests): capture + inject on subsequent request (and the initialize response still reaches stdout), `notifications/initialized` carries it, SSE-framed initialize capture, no header when no initialize is seen, and the 404 re-initialize path. Full suite: **405 passed, 3 skipped**.

## Also

One-line README fix: `~86-char code_verifier` (matches the oauth.py comment corrected in #67).

🤖 Generated with [Claude Code](https://claude.com/claude-code)