### PR TITLE
feat(relay): normalize tools/call arguments:null to {} for strict servers

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -49,6 +49,7 @@ Bearer token、カスタムヘッダー、OAuth 2.1 認証情報をリモート�
 - **バックオフ付きリトライ** — 接続エラー時に最大3回リトライ
 - **ストリーミング耐性** — SSE レスポンスをリアルタイムで転送、ストリーム切断時に自動再接続
 - **行区切り文字の安全化** — 上流レスポンス中の生の `U+2028` / `U+2029`（JSON では合法だが JavaScript の行終端文字）をエスケープし、これらを改行として扱うクライアントによるフレーム崩れを防止。ロスレス（cf. modelcontextprotocol/typescript-sdk#2155）
+- **引数の正規化** — `tools/call` の `arguments` が `null` の場合は `{}` に書き換え、null 形式を拒否する厳格なサーバーでも呼び出せるようにする。デフォルト有効、`--no-normalize-arguments` で無効化（cf. modelcontextprotocol/typescript-sdk#2012）
 - **セッション回復** — 404 でセッション ID をリセットして再試行
 - **プロトコルバージョンヘッダー** — `initialize` 応答から交渉済みの `protocolVersion` を捕捉し、以降の Streamable HTTP リクエストすべてに `MCP-Protocol-Version` を付与（MCP 仕様 rev 2025-06-18）。このヘッダーを強制するサーバーは未送信時に初期化後リクエストを `400 Bad Request` で拒否する
 - **401 時の自動トークンリフレッシュ** — セッション中に OAuth トークンが失効しても自動更新

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Bearer tokens, custom headers, and OAuth 2.1 credentials are forwarded to the re
 - **Retry with backoff** — retries up to 3 times on connection errors
 - **Streaming resilience** — streams SSE responses in real time; auto-reconnects on mid-stream disconnect
 - **Line-separator safety** — escapes raw `U+2028` / `U+2029` (legal in JSON, but JavaScript line terminators) in upstream responses so clients that treat them as line breaks cannot mis-frame the output; lossless (cf. modelcontextprotocol/typescript-sdk#2155)
+- **Argument normalization** — rewrites a `tools/call` request whose `arguments` is `null` to `{}` so strict servers that reject the null form accept the call; on by default, opt out with `--no-normalize-arguments` (cf. modelcontextprotocol/typescript-sdk#2012)
 - **Session recovery** — resets MCP session ID on 404 and retries
 - **Protocol version header** — captures the negotiated `protocolVersion` from the `initialize` response and injects `MCP-Protocol-Version` on every subsequent Streamable HTTP request (MCP spec rev 2025-06-18); servers that enforce the header would otherwise reject post-initialize requests with `400 Bad Request`
 - **Token refresh on 401** — automatically refreshes expired OAuth tokens mid-session

--- a/src/mcp_stdio/cli.py
+++ b/src/mcp_stdio/cli.py
@@ -269,6 +269,17 @@ def main() -> None:
         ),
     )
     parser.add_argument(
+        "--no-normalize-arguments",
+        action="store_true",
+        help=(
+            "Disable tools/call argument normalization. By default mcp-stdio "
+            "rewrites a tools/call request whose arguments field is null to "
+            "an empty object {}, so strict servers that reject the null form "
+            "(modelcontextprotocol/typescript-sdk#2012) accept the call. Opt "
+            "out to forward the client request verbatim."
+        ),
+    )
+    parser.add_argument(
         "--check",
         action="store_true",
         help="Check connection to the MCP server and exit",
@@ -363,9 +374,10 @@ def main() -> None:
 
     # run() ignores sse_read_timeout (Streamable HTTP doesn't hold a
     # long-lived GET), so only pass it through on the SSE path.
-    # tcp_keepalive and cancel_filter apply to both transports.
+    # tcp_keepalive, cancel_filter and normalize_arguments apply to both.
     tcp_keepalive = not args.no_tcp_keepalive
     cancel_filter = not args.no_cancel_filter
+    normalize_arguments = not args.no_normalize_arguments
     if args.transport == "sse":
         run_sse(
             url=args.url,
@@ -375,6 +387,7 @@ def main() -> None:
             sse_read_timeout=args.sse_read_timeout,
             tcp_keepalive=tcp_keepalive,
             cancel_filter=cancel_filter,
+            normalize_arguments=normalize_arguments,
             token_refresher=token_refresher,
             scope_upgrader=scope_upgrader,
         )
@@ -386,6 +399,7 @@ def main() -> None:
             timeout_read=args.timeout_read,
             tcp_keepalive=tcp_keepalive,
             cancel_filter=cancel_filter,
+            normalize_arguments=normalize_arguments,
             token_refresher=token_refresher,
             scope_upgrader=scope_upgrader,
         )

--- a/src/mcp_stdio/relay.py
+++ b/src/mcp_stdio/relay.py
@@ -636,6 +636,41 @@ def _post_parsed(
     return None, None
 
 
+# tools/call requests that serialize an empty argument map as ``null``.
+# Some clients (Go/Java/C# serializers) emit ``"arguments": null``; strict
+# MCP servers validate ``arguments`` as an optional object and reject the
+# null form with -32603 (cf. modelcontextprotocol/typescript-sdk#2012). The
+# regex is a cheap gate before the json round-trip; the parsed-structure
+# check below is authoritative.
+_NULL_ARGUMENTS_RE = re.compile(r'"arguments"\s*:\s*null')
+
+
+def _normalize_null_arguments(line: str) -> str:
+    """Rewrite a ``tools/call`` request's null ``arguments`` to ``{}``.
+
+    ``{}`` is accepted by both optional- and required-object servers, so it
+    is the safe normalization of the "no arguments" intent. Narrowly
+    scoped: only a ``tools/call`` whose ``params.arguments`` key is present
+    and ``null`` is rewritten — a string value that merely contains the
+    literal ``"arguments":null`` is left untouched (the parsed-structure
+    check, not the regex, decides). JSON-RPC batch arrays and other methods
+    (e.g. ``prompts/get``, a deliberate non-goal) pass through unchanged.
+    """
+    if not _NULL_ARGUMENTS_RE.search(line):
+        return line
+    try:
+        msg = json.loads(line)
+    except (json.JSONDecodeError, TypeError):
+        return line
+    if not isinstance(msg, dict) or msg.get("method") != "tools/call":
+        return line
+    params = msg.get("params")
+    if isinstance(params, dict) and "arguments" in params and params["arguments"] is None:
+        params["arguments"] = {}
+        return json.dumps(msg)
+    return line
+
+
 def _detect_paginated_list(line: str) -> tuple[str, str] | None:
     """Return ``(method, result_key)`` if the request should auto-paginate.
 
@@ -937,6 +972,7 @@ def run(
     timeout_write: float = 30,
     tcp_keepalive: bool = True,
     cancel_filter: bool = True,
+    normalize_arguments: bool = True,
     token_refresher: Any = None,
     scope_upgrader: Any = None,
 ) -> None:
@@ -963,6 +999,11 @@ def run(
             shields the downstream client from canceller-side bugs such
             as anthropics/claude-code#51073. Disable (``False``) only
             when debugging raw upstream traffic.
+        normalize_arguments: When True (default), rewrite a ``tools/call``
+            request whose ``params.arguments`` is ``null`` to ``{}`` before
+            forwarding, so strict servers that reject the null form
+            (modelcontextprotocol/typescript-sdk#2012) accept the call.
+            Disable (``False``) to forward the client request verbatim.
         token_refresher: Optional callable that returns updated headers
             on successful token refresh, or None on failure. Called when
             the server returns HTTP 401.
@@ -1014,6 +1055,9 @@ def run(
             line = line.strip()
             if not line:
                 continue
+
+            if normalize_arguments:
+                line = _normalize_null_arguments(line)
 
             if tracker is not None:
                 cid = _extract_cancel_id(line)
@@ -1221,6 +1265,7 @@ def run_sse(
     sse_read_timeout: float | None = 300,
     tcp_keepalive: bool = True,
     cancel_filter: bool = True,
+    normalize_arguments: bool = True,
     token_refresher: Any = None,
     scope_upgrader: Any = None,
 ) -> None:
@@ -1264,6 +1309,9 @@ def run_sse(
             upstream response carrying one of those ids on the SSE
             stream before it reaches stdout. See ``run`` for the full
             rationale.
+        normalize_arguments: When True (default), rewrite a ``tools/call``
+            request whose ``params.arguments`` is ``null`` to ``{}`` before
+            forwarding. See ``run`` for the full rationale.
         token_refresher: Optional callable that returns updated headers
             on successful token refresh, or None on failure. Called when
             the server returns HTTP 401 on POST.
@@ -1328,6 +1376,9 @@ def run_sse(
             line = line.strip()
             if not line:
                 continue
+
+            if normalize_arguments:
+                line = _normalize_null_arguments(line)
 
             if tracker is not None:
                 cid = _extract_cancel_id(line)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -375,6 +375,45 @@ class TestMain:
             main()
         assert mock_run_sse.call_args.kwargs["cancel_filter"] is False
 
+    def test_normalize_arguments_default_on(self):
+        """tools/call argument normalization is ON by default → run() sees True."""
+        with (
+            patch("sys.argv", ["mcp-stdio", "https://example.com/mcp"]),
+            patch("mcp_stdio.cli.run") as mock_run,
+        ):
+            main()
+        assert mock_run.call_args.kwargs["normalize_arguments"] is True
+
+    def test_normalize_arguments_opt_out(self):
+        """--no-normalize-arguments flips the flag to False."""
+        with (
+            patch(
+                "sys.argv",
+                ["mcp-stdio", "https://example.com/mcp", "--no-normalize-arguments"],
+            ),
+            patch("mcp_stdio.cli.run") as mock_run,
+        ):
+            main()
+        assert mock_run.call_args.kwargs["normalize_arguments"] is False
+
+    def test_normalize_arguments_passed_to_run_sse(self):
+        """--no-normalize-arguments reaches run_sse on the sse transport."""
+        with (
+            patch(
+                "sys.argv",
+                [
+                    "mcp-stdio",
+                    "https://example.com/mcp",
+                    "--transport",
+                    "sse",
+                    "--no-normalize-arguments",
+                ],
+            ),
+            patch("mcp_stdio.cli.run_sse") as mock_run_sse,
+        ):
+            main()
+        assert mock_run_sse.call_args.kwargs["normalize_arguments"] is False
+
     def test_no_resource_indicator_default_is_true(self):
         """By default resource_indicator=True is passed to ensure_token."""
         with (

--- a/tests/test_relay.py
+++ b/tests/test_relay.py
@@ -27,6 +27,7 @@ from mcp_stdio.relay import (
     _extract_id,
     _handle_rate_limit,
     _make_httpx_transport,
+    _normalize_null_arguments,
     _parse_retry_after,
     _parse_www_authenticate_scope,
     _post_and_stream,
@@ -913,6 +914,86 @@ class TestStepUpScopeChallenge:
         assert err["id"] == 1
         # No retry issued after upgrader failure
         assert len(httpx_mock.get_requests()) == 1
+
+
+# --- tools/call arguments:null normalization (typescript-sdk#2012, issue #74) ---
+
+
+class TestNormalizeNullArguments:
+    """Rewrite a tools/call null `arguments` to {} for strict servers."""
+
+    def test_rewrites_null_arguments_to_empty_object(self):
+        line = '{"jsonrpc":"2.0","method":"tools/call","id":1,"params":{"name":"t","arguments":null}}'
+        out = json.loads(_normalize_null_arguments(line))
+        assert out["params"]["arguments"] == {}
+
+    def test_absent_arguments_stays_absent(self):
+        """Missing arguments must NOT be synthesized to {}."""
+        line = '{"jsonrpc":"2.0","method":"tools/call","id":1,"params":{"name":"t"}}'
+        out = json.loads(_normalize_null_arguments(line))
+        assert "arguments" not in out["params"]
+
+    def test_empty_object_arguments_untouched(self):
+        line = '{"jsonrpc":"2.0","method":"tools/call","id":1,"params":{"name":"t","arguments":{}}}'
+        assert _normalize_null_arguments(line) == line
+
+    def test_populated_arguments_untouched(self):
+        line = '{"jsonrpc":"2.0","method":"tools/call","id":1,"params":{"name":"t","arguments":{"x":1}}}'
+        assert _normalize_null_arguments(line) == line
+
+    def test_non_tools_call_with_null_arguments_untouched(self):
+        line = '{"jsonrpc":"2.0","method":"prompts/get","id":1,"params":{"name":"p","arguments":null}}'
+        assert _normalize_null_arguments(line) == line
+
+    def test_false_positive_in_string_value_untouched(self):
+        """A string value containing the literal "arguments":null must not be rewritten."""
+        line = '{"jsonrpc":"2.0","method":"tools/call","id":1,"params":{"name":"t","arguments":{"note":"\\"arguments\\":null"}}}'
+        out = json.loads(_normalize_null_arguments(line))
+        # arguments object preserved exactly (not clobbered to {})
+        assert out["params"]["arguments"] == {"note": '"arguments":null'}
+
+    def test_batch_array_passed_through(self):
+        """JSON-RPC batch arrays are out of scope and pass through unchanged."""
+        line = '[{"jsonrpc":"2.0","method":"tools/call","id":1,"params":{"name":"t","arguments":null}}]'
+        assert _normalize_null_arguments(line) == line
+
+    def test_malformed_json_passed_through(self):
+        line = '{"method":"tools/call","arguments":null'  # truncated
+        assert _normalize_null_arguments(line) == line
+
+
+class TestRunNormalizeArguments:
+    """Integration: the flag controls outbound rewrite on the wire."""
+
+    def _run(self, httpx_mock, stdin_lines, **kwargs):
+        stdin_data = "\n".join(stdin_lines) + "\n"
+        with patch("sys.stdin", StringIO(stdin_data)), patch("sys.stdout", StringIO()):
+            run("https://example.com/mcp", {"Content-Type": "application/json"}, **kwargs)
+
+    def test_default_rewrites_on_wire(self, httpx_mock):
+        httpx_mock.add_response(
+            text='{"jsonrpc":"2.0","result":{},"id":1}',
+            headers={"content-type": "application/json"},
+        )
+        self._run(
+            httpx_mock,
+            ['{"jsonrpc":"2.0","method":"tools/call","id":1,"params":{"name":"t","arguments":null}}'],
+        )
+        sent = json.loads(httpx_mock.get_requests()[0].read())
+        assert sent["params"]["arguments"] == {}
+
+    def test_opt_out_forwards_verbatim(self, httpx_mock):
+        httpx_mock.add_response(
+            text='{"jsonrpc":"2.0","result":{},"id":1}',
+            headers={"content-type": "application/json"},
+        )
+        self._run(
+            httpx_mock,
+            ['{"jsonrpc":"2.0","method":"tools/call","id":1,"params":{"name":"t","arguments":null}}'],
+            normalize_arguments=False,
+        )
+        sent = json.loads(httpx_mock.get_requests()[0].read())
+        assert sent["params"]["arguments"] is None
 
 
 # --- auto-pagination (anthropics/claude-code#39586) ---


### PR DESCRIPTION
Closes #74.

## Summary

The MCP spec makes `tools/call` `params.arguments` an **optional object**. Some clients (Go/Java/C# serializers) emit `"arguments": null`; strict SDK servers validate it as `optional()` — permitting *missing* but rejecting *null* — and return `-32603 InternalError` (cf. modelcontextprotocol/typescript-sdk#2012). The call fails even though the intent ("no arguments") is unambiguous.

This rewrites a `tools/call` request's null `arguments` to `{}` in the outbound path before forwarding. `{}` is accepted by both optional- and required-object servers.

## Default-on with opt-out — and why (vs #73)

Unlike the U+2028 escaping in #73 (a **provably lossless encoding** normalization, shipped flagless), this is a **semantic mutation of a parsed client request** — a non-compliant server could theoretically observe `null` vs `{}`. That puts it in the cancel-filter category, so it ships **default-on with `--no-normalize-arguments`** to forward the request verbatim when debugging.

## Correctness

- Cheap regex (`"arguments"\s*:\s*null`) gates the json round-trip; the **parsed-structure check is authoritative** — a string value that merely contains the literal `"arguments":null` is left untouched (tested).
- `arguments` **absent** stays absent (not synthesized to `{}`); `{}` and populated arguments pass through untouched.

## Scope

`tools/call` only. `prompts/get` (also has an `arguments` field) is a **deliberate non-goal**. JSON-RPC **batch arrays** pass through unchanged (the structural check bails on non-dict) — a known scope limit, safe-by-passthrough.

## Tests

`TestNormalizeNullArguments` (8) + `TestRunNormalizeArguments` (2, on-the-wire default + opt-out) + 3 CLI flag tests across both transports. Full suite: **424 passed, 3 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)