### PR TITLE
fix(relay): WHATWG SSE parsing, at-most-once streaming retry, SSE header race

### DIFF
--- a/src/mcp_stdio/relay.py
+++ b/src/mcp_stdio/relay.py
@@ -11,6 +11,7 @@ import socket
 import sys
 import threading
 import time
+from collections.abc import Iterable, Iterator
 from datetime import datetime, timezone
 from typing import Any
 from urllib.parse import urljoin
@@ -483,6 +484,49 @@ def _parse_www_authenticate_scope(header: str | None) -> str | None:
     return None
 
 
+def _iter_sse_events(lines: Iterable[str]) -> Iterator[tuple[str, str]]:
+    """Yield ``(event_type, data)`` pairs from SSE lines per the WHATWG spec.
+
+    Implements the WHATWG Server-Sent Events line-decoding algorithm so every
+    SSE-decoding site parses identically:
+
+    - a ``data:`` field strips at most one leading U+0020 from its value, so a
+      space-less ``data:{...}`` is valid (servers are not required to emit the
+      conventional ``data: {...}`` with a space);
+    - ``event:`` sets the event type, which defaults to ``"message"`` and resets
+      after every dispatched event;
+    - ``:``-prefixed comment lines and unrecognised fields are ignored;
+    - an event is dispatched on each blank-line boundary with its ``data:``
+      fields concatenated by LF;
+    - a final unterminated event with non-empty data is also dispatched at end
+      of input, so a response body that omits the trailing blank line is not
+      silently dropped.
+
+    Callers decide which event types to act on (``message`` for JSON-RPC
+    payloads, ``endpoint`` for the legacy SSE bootstrap).
+    """
+    event_type = "message"
+    data_lines: list[str] = []
+    for line in lines:
+        if line == "":
+            if data_lines:
+                yield event_type, "\n".join(data_lines)
+            event_type = "message"
+            data_lines = []
+            continue
+        if line.startswith(":"):
+            continue
+        field, _, value = line.partition(":")
+        if value.startswith(" "):
+            value = value[1:]
+        if field == "event":
+            event_type = value
+        elif field == "data":
+            data_lines.append(value)
+    if data_lines:
+        yield event_type, "\n".join(data_lines)
+
+
 def _post_and_stream(
     client: httpx.Client,
     url: str,
@@ -507,6 +551,13 @@ def _post_and_stream(
     """
     last_error: Exception | None = None
     for attempt in range(1, MAX_RETRIES + 1):
+        # Tracks whether any payload has been committed to stdout on this
+        # attempt. Once a byte is written to the client the non-idempotent
+        # POST can no longer be safely replayed, so a mid-stream transient
+        # error must surface an error instead of retrying — otherwise the
+        # server re-streams and the client sees duplicate JSON-RPC responses
+        # (and tools/call may execute twice server-side).
+        emitted = False
         try:
             with client.stream("POST", url, content=content, headers=headers) as resp:
                 session = resp.headers.get("mcp-session-id")
@@ -531,12 +582,13 @@ def _post_and_stream(
                 pv: str | None = None
                 content_type = resp.headers.get("content-type", "")
                 if "text/event-stream" in content_type:
-                    for line in resp.iter_lines():
-                        if line.startswith("data: "):
-                            payload = line[6:]
-                            if capture_init and pv is None:
-                                pv = _extract_protocol_version(payload)
-                            _emit(payload, tracker)
+                    for event_type, payload in _iter_sse_events(resp.iter_lines()):
+                        if event_type != "message":
+                            continue
+                        if capture_init and pv is None:
+                            pv = _extract_protocol_version(payload)
+                        _emit(payload, tracker)
+                        emitted = True
                 else:
                     resp.read()
                     text = resp.text.strip()
@@ -544,6 +596,7 @@ def _post_and_stream(
                         if capture_init:
                             pv = _extract_protocol_version(text)
                         _emit(text, tracker)
+                        emitted = True
 
                 return _StreamResult(session, 200, protocol_version=pv)
         except (
@@ -554,6 +607,15 @@ def _post_and_stream(
         ) as e:
             last_error = e
             log(f"attempt {attempt}/{MAX_RETRIES} failed: {e}")
+            if emitted:
+                # Response already partially delivered to the client; replaying
+                # the POST would duplicate it. Surface a stream-interrupted
+                # error (at-most-once) rather than retry.
+                log("upstream stream interrupted after partial delivery; not retrying")
+                _write_line(
+                    _error_response(f"upstream stream interrupted: {e}", req_id)
+                )
+                return None
             if attempt < MAX_RETRIES:
                 time.sleep(RETRY_DELAY * attempt)
 
@@ -602,15 +664,13 @@ def _post_parsed(
 
             content_type = resp.headers.get("content-type", "")
             if "text/event-stream" in content_type:
-                for sse_line in resp.text.splitlines():
-                    if sse_line.startswith("data: "):
-                        try:
-                            return (
-                                json.loads(sse_line[len("data: "):]),
-                                _StreamResult(session, 200),
-                            )
-                        except json.JSONDecodeError:
-                            continue
+                for event_type, payload in _iter_sse_events(resp.text.splitlines()):
+                    if event_type != "message":
+                        continue
+                    try:
+                        return json.loads(payload), _StreamResult(session, 200)
+                    except json.JSONDecodeError:
+                        continue
                 return None, _StreamResult(session, 200)
 
             text = resp.text.strip()
@@ -919,13 +979,14 @@ def check_connection(
         result_data: dict[str, Any] | None = None
 
         if "text/event-stream" in content_type:
-            for event_line in resp.text.splitlines():
-                if event_line.startswith("data: "):
-                    try:
-                        result_data = json.loads(event_line[6:])
-                        break
-                    except json.JSONDecodeError:
-                        continue
+            for event_type, payload in _iter_sse_events(resp.text.splitlines()):
+                if event_type != "message":
+                    continue
+                try:
+                    result_data = json.loads(payload)
+                    break
+                except json.JSONDecodeError:
+                    continue
         else:
             try:
                 result_data = json.loads(resp.text)
@@ -1189,49 +1250,46 @@ def _sse_reader_loop(
     headers: dict[str, str],
     state: _SseState,
     tracker: _CancelTracker | None = None,
+    headers_lock: threading.Lock | None = None,
 ) -> None:
     """Reader thread: maintain SSE GET stream and dispatch events.
 
     Parses the SSE event stream per the WHATWG Server-Sent Events
-    specification. The first ``endpoint`` event provides the POST URL
-    (which may be relative — resolved with urljoin). Subsequent
-    ``message`` events are JSON-RPC responses written to stdout.
+    specification (via the shared ``_iter_sse_events`` decoder). The first
+    ``endpoint`` event provides the POST URL (which may be relative —
+    resolved with urljoin). Subsequent ``message`` events are JSON-RPC
+    responses written to stdout.
+
+    ``headers`` is shared with the main stdin loop, which may mutate it on a
+    401/403 token refresh. ``headers_lock`` (when provided) serialises the
+    per-reconnect snapshot taken here against those mutations so the request
+    build never iterates a dict that is changing under it.
 
     Reconnects automatically on disconnect.
     """
     while not state.stop.is_set():
         try:
-            with client.stream("GET", url, headers=headers) as resp:
+            if headers_lock is not None:
+                with headers_lock:
+                    req_headers = dict(headers)
+            else:
+                req_headers = dict(headers)
+            with client.stream("GET", url, headers=req_headers) as resp:
                 if resp.status_code != 200:
                     log(f"SSE connection failed: HTTP {resp.status_code}")
                     state.ready.set()
                     return
 
-                event_type = "message"
-                data_lines: list[str] = []
-
-                for line in resp.iter_lines():
+                for event_type, data in _iter_sse_events(resp.iter_lines()):
                     if state.stop.is_set():
                         return
-
-                    if line == "":
-                        if data_lines:
-                            data = "\n".join(data_lines)
-                            if event_type == "endpoint":
-                                resolved = urljoin(url, data)
-                                state.endpoint_url = resolved
-                                state.ready.set()
-                                log(f"SSE endpoint: {resolved}")
-                            elif event_type == "message":
-                                _emit(data, tracker)
-                        event_type = "message"
-                        data_lines = []
-                    elif line.startswith(":"):
-                        continue
-                    elif line.startswith("event:"):
-                        event_type = line[len("event:") :].strip()
-                    elif line.startswith("data:"):
-                        data_lines.append(line[len("data:") :].lstrip(" "))
+                    if event_type == "endpoint":
+                        resolved = urljoin(url, data)
+                        state.endpoint_url = resolved
+                        state.ready.set()
+                        log(f"SSE endpoint: {resolved}")
+                    elif event_type == "message":
+                        _emit(data, tracker)
 
                 if state.stop.is_set():
                     return
@@ -1352,9 +1410,13 @@ def run_sse(
 
     tracker: _CancelTracker | None = _CancelTracker() if cancel_filter else None
     state = _SseState()
+    # The reader thread snapshots ``headers`` on every (re)connect while the
+    # main loop below may mutate it on a 401/403 token refresh. Serialise the
+    # two so the GET request build never iterates a dict mid-mutation.
+    headers_lock = threading.Lock()
     reader = threading.Thread(
         target=_sse_reader_loop,
-        args=(client, url, headers, state, tracker),
+        args=(client, url, headers, state, tracker, headers_lock),
         daemon=True,
     )
     reader.start()
@@ -1430,7 +1492,8 @@ def run_sse(
                     log("received 401, attempting token refresh")
                     new_headers = token_refresher()
                     if new_headers:
-                        headers.update(new_headers)
+                        with headers_lock:
+                            headers.update(new_headers)
                         resp = client.post(
                             endpoint,
                             content=line,
@@ -1458,7 +1521,8 @@ def run_sse(
                         )
                         new_headers = scope_upgrader(required_scope)
                         if new_headers:
-                            headers.update(new_headers)
+                            with headers_lock:
+                                headers.update(new_headers)
                             resp = client.post(
                                 endpoint,
                                 content=line,

--- a/tests/test_relay.py
+++ b/tests/test_relay.py
@@ -15,6 +15,7 @@ from pytest_httpx import IteratorStream
 
 from mcp_stdio.relay import (
     MAX_LIST_PAGES,
+    MAX_RETRIES,
     PAGINATED_LIST_METHODS,
     _CancelTracker,
     _SseState,
@@ -26,6 +27,7 @@ from mcp_stdio.relay import (
     _extract_cancel_id,
     _extract_id,
     _handle_rate_limit,
+    _iter_sse_events,
     _make_httpx_transport,
     _normalize_null_arguments,
     _parse_retry_after,
@@ -243,6 +245,143 @@ class TestPostAndStream:
         result = _post_and_stream(client, "https://example.com/mcp", '{"id":1}', {}, 1)
         assert result is not None
         assert result.status_code == 404
+
+    def test_sse_data_without_space_is_parsed(self, httpx_mock):
+        """WHATWG SSE: ``data:`` needs no trailing space — a compliant server
+        sending ``data:{...}`` must be relayed, not silently dropped."""
+        payload = '{"jsonrpc":"2.0","result":{},"id":1}'
+        httpx_mock.add_response(
+            stream=IteratorStream([f"data:{payload}\n\n".encode()]),
+            headers={"content-type": "text/event-stream"},
+        )
+        client = httpx.Client()
+        stdout = StringIO()
+        with patch("sys.stdout", stdout):
+            result = _post_and_stream(
+                client, "https://example.com/mcp", '{"id":1}', {}, 1
+            )
+        assert result is not None and result.status_code == 200
+        assert payload in stdout.getvalue()
+
+    def test_sse_non_message_event_not_emitted(self, httpx_mock):
+        """A ``data:``-bearing non-``message`` event (ping/keepalive) must not
+        be forwarded to stdout as if it were a JSON-RPC message."""
+        payload = '{"jsonrpc":"2.0","result":{},"id":1}'
+        body = (
+            b"event: ping\ndata: heartbeat\n\n"
+            + f"event: message\ndata: {payload}\n\n".encode()
+        )
+        httpx_mock.add_response(
+            stream=IteratorStream([body]),
+            headers={"content-type": "text/event-stream"},
+        )
+        client = httpx.Client()
+        stdout = StringIO()
+        with patch("sys.stdout", stdout):
+            _post_and_stream(client, "https://example.com/mcp", '{"id":1}', {}, 1)
+        lines = [x for x in stdout.getvalue().strip().splitlines() if x]
+        assert lines == [payload]
+
+    def test_sse_multiline_data_joined(self, httpx_mock):
+        """Multiple ``data:`` fields of one event are joined with LF, not
+        emitted as separate (invalid) stdout lines."""
+        httpx_mock.add_response(
+            stream=IteratorStream([b"event: message\ndata: a\ndata: b\ndata: c\n\n"]),
+            headers={"content-type": "text/event-stream"},
+        )
+        client = httpx.Client()
+        stdout = StringIO()
+        with patch("sys.stdout", stdout):
+            _post_and_stream(client, "https://example.com/mcp", '{"id":1}', {}, 1)
+        assert stdout.getvalue().strip() == "a\nb\nc"
+
+    def test_midstream_failure_does_not_retry_or_duplicate(self, httpx_mock):
+        """A transient error AFTER a payload was delivered must not replay the
+        non-idempotent POST (which would duplicate the response). Instead a
+        single stream-interrupted error is emitted and no second POST runs."""
+        delivered = '{"jsonrpc":"2.0","result":{},"id":1}'
+
+        def gen():
+            yield f"event: message\ndata: {delivered}\n\n".encode()
+            raise httpx.ReadError("connection dropped mid-stream")
+
+        httpx_mock.add_response(
+            stream=IteratorStream(gen()),
+            headers={"content-type": "text/event-stream"},
+        )
+        client = httpx.Client()
+        stdout = StringIO()
+        with patch("sys.stdout", stdout), patch("mcp_stdio.relay.time.sleep"):
+            result = _post_and_stream(
+                client, "https://example.com/mcp", '{"id":1}', {}, 1
+            )
+        # No retry: the POST was issued exactly once.
+        assert len(httpx_mock.get_requests()) == 1
+        # Caller sees "error already printed".
+        assert result is None
+        lines = [json.loads(x) for x in stdout.getvalue().strip().splitlines() if x]
+        # The already-delivered payload, then exactly one synthesized error
+        # for the same request id — never a duplicate of the payload.
+        assert lines[0]["result"] == {}
+        assert lines[1]["error"]["message"].startswith("upstream stream interrupted")
+        assert lines[1]["id"] == 1
+        assert len(lines) == 2
+
+    def test_preoutput_failure_still_retries(self, httpx_mock):
+        """A transient error BEFORE any output (e.g. JSON body read) is still
+        safely retriable — the response had not begun streaming."""
+        httpx_mock.add_exception(httpx.ConnectError("refused"))
+        httpx_mock.add_response(
+            json={"jsonrpc": "2.0", "result": {"ok": True}, "id": 1},
+            headers={"content-type": "application/json"},
+        )
+        client = httpx.Client()
+        stdout = StringIO()
+        with patch("sys.stdout", stdout), patch("mcp_stdio.relay.time.sleep"):
+            result = _post_and_stream(
+                client, "https://example.com/mcp", '{"id":1}', {}, 1
+            )
+        assert result is not None and result.status_code == 200
+        assert len(httpx_mock.get_requests()) == 2  # retried after the connect error
+        emitted = json.loads(stdout.getvalue().strip())
+        assert emitted["result"] == {"ok": True}
+
+
+class TestIterSseEvents:
+    """WHATWG Server-Sent Events line decoder shared by all SSE-decode sites."""
+
+    def test_data_without_space(self):
+        assert list(_iter_sse_events(["data:hello", ""])) == [("message", "hello")]
+
+    def test_data_with_single_space_stripped(self):
+        assert list(_iter_sse_events(["data: hello", ""])) == [("message", "hello")]
+
+    def test_only_one_leading_space_stripped(self):
+        # WHATWG strips exactly one U+0020; further spaces are part of the value.
+        assert list(_iter_sse_events(["data:  hello", ""])) == [("message", " hello")]
+
+    def test_default_event_type_is_message(self):
+        assert list(_iter_sse_events(["data:x", ""])) == [("message", "x")]
+
+    def test_event_type_tracked_and_reset(self):
+        lines = ["event:ping", "data:a", "", "data:b", ""]
+        assert list(_iter_sse_events(lines)) == [("ping", "a"), ("message", "b")]
+
+    def test_multiline_data_joined_with_lf(self):
+        assert list(_iter_sse_events(["data:a", "data:b", ""])) == [("message", "a\nb")]
+
+    def test_comment_lines_ignored(self):
+        assert list(_iter_sse_events([": keepalive", "data:a", ""])) == [
+            ("message", "a")
+        ]
+
+    def test_trailing_event_without_blank_line_flushed(self):
+        # httpx may not surface a final empty line; a complete event must still
+        # be dispatched at end of input.
+        assert list(_iter_sse_events(["data:a"])) == [("message", "a")]
+
+    def test_event_without_data_not_dispatched(self):
+        assert list(_iter_sse_events(["event:message", ""])) == []
 
 
 # --- run (integration) ---
@@ -668,6 +807,31 @@ class TestProtocolVersionHeader:
     def test_sse_framed_initialize_captures_version(self, httpx_mock):
         httpx_mock.add_response(
             text='data: {"jsonrpc":"2.0","result":{"protocolVersion":"2025-03-26"},"id":1}\n\n',
+            headers={"content-type": "text/event-stream"},
+        )
+        httpx_mock.add_response(
+            text='{"jsonrpc":"2.0","result":{},"id":2}',
+            headers={"content-type": "application/json"},
+        )
+        self._run_with_stdin(
+            [
+                '{"jsonrpc":"2.0","method":"initialize","id":1}',
+                '{"jsonrpc":"2.0","method":"tools/call","id":2}',
+            ]
+        )
+        reqs = httpx_mock.get_requests()
+        assert reqs[1].headers["mcp-protocol-version"] == "2025-03-26"
+
+    def test_sse_initialize_with_leading_noise_captures_version(self, httpx_mock):
+        """capture_init skips a leading comment and a non-result data line and
+        still captures protocolVersion from the InitializeResult event."""
+        body = (
+            ": keepalive\n"
+            'data: {"jsonrpc":"2.0","method":"notifications/progress"}\n\n'
+            'data: {"jsonrpc":"2.0","result":{"protocolVersion":"2025-03-26"},"id":1}\n\n'
+        )
+        httpx_mock.add_response(
+            text=body,
             headers={"content-type": "text/event-stream"},
         )
         httpx_mock.add_response(
@@ -1293,6 +1457,53 @@ class TestPagination:
         requests = httpx_mock.get_requests()
         assert requests[1].headers["authorization"] == "Bearer new-token"
 
+    def test_first_page_retry_exhaustion_emits_single_error(self, httpx_mock):
+        """When page 1 exhausts all retries (repeated ConnectError), the
+        buffered ``_post_parsed`` path writes exactly one JSON-RPC error for
+        the request id and no partial result."""
+        for _ in range(MAX_RETRIES):
+            httpx_mock.add_exception(httpx.ConnectError("refused"), url=self.URL)
+
+        with patch("mcp_stdio.relay.time.sleep"):
+            output = self._run_with_stdin(
+                httpx_mock,
+                [json.dumps({"jsonrpc": "2.0", "id": 7, "method": "tools/list"})],
+            )
+        lines = [json.loads(x) for x in output.strip().splitlines() if x]
+        assert len(lines) == 1
+        assert lines[0]["id"] == 7
+        assert "error" in lines[0]
+        assert "result" not in lines[0]
+
+    def test_sse_data_without_space_is_paginated(self, httpx_mock):
+        """Pagination's buffered SSE parse accepts space-less ``data:`` framing."""
+        page1 = {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "result": {"tools": [{"name": "a"}], "nextCursor": "p2"},
+        }
+        page2 = {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "result": {"tools": [{"name": "b"}]},
+        }
+        httpx_mock.add_response(
+            url=self.URL,
+            text=f"data:{json.dumps(page1)}\n\n",
+            headers={"content-type": "text/event-stream"},
+        )
+        httpx_mock.add_response(
+            url=self.URL,
+            text=f"data:{json.dumps(page2)}\n\n",
+            headers={"content-type": "text/event-stream"},
+        )
+        output = self._run_with_stdin(
+            httpx_mock,
+            [json.dumps({"jsonrpc": "2.0", "id": 1, "method": "tools/list"})],
+        )
+        merged = json.loads(output.strip())
+        assert [t["name"] for t in merged["result"]["tools"]] == ["a", "b"]
+
     def test_max_list_pages_constant_is_positive(self):
         """Sanity check on the shipped cap."""
         assert MAX_LIST_PAGES >= 1
@@ -1331,6 +1542,20 @@ class TestCheckConnection:
         """SSE response with one data: line."""
         body = (
             'data: {"jsonrpc":"2.0","id":1,"result":'
+            '{"protocolVersion":"2024-11-05","serverInfo":{"name":"sse","version":"0.1"},'
+            '"capabilities":{}}}\n\n'
+        )
+        httpx_mock.add_response(
+            text=body,
+            headers={"content-type": "text/event-stream"},
+        )
+        assert check_connection(self.URL, dict(self.HEADERS)) is True
+
+    def test_sse_data_without_space(self, httpx_mock):
+        """WHATWG SSE: ``data:`` without a trailing space is valid framing and
+        --check must still parse the initialize result."""
+        body = (
+            'data:{"jsonrpc":"2.0","id":1,"result":'
             '{"protocolVersion":"2024-11-05","serverInfo":{"name":"sse","version":"0.1"},'
             '"capabilities":{}}}\n\n'
         )
@@ -1788,6 +2013,48 @@ class TestRunSse:
                 sse_read_timeout=300,
             )
 
+    def test_post_during_reconnect_window_emits_error(self, monkeypatch):
+        """A stdin line arriving while the reader is mid-reconnect (endpoint
+        cleared) must get a clean 'SSE endpoint unavailable' error, not hang.
+
+        Deterministic: a one-shot ``endpoint_url`` reports the bootstrap URL
+        for run_sse's startup check, then ``None`` once the main loop tries to
+        POST — exactly the reconnect-window race the branch guards.
+        """
+        bootstrap_url = "https://example.com/messages"
+
+        class _OneShotEndpointState:
+            def __init__(self):
+                self._reads = 0
+                self.ready = threading.Event()
+                self.stop = threading.Event()
+
+            @property
+            def endpoint_url(self):
+                self._reads += 1
+                return bootstrap_url if self._reads == 1 else None
+
+            @endpoint_url.setter
+            def endpoint_url(self, value):
+                pass  # reader-thread writes are irrelevant to this test
+
+        def fake_reader(client, url, headers, state, tracker=None, headers_lock=None):
+            state.ready.set()
+            state.stop.wait(timeout=3)
+
+        monkeypatch.setattr("mcp_stdio.relay._SseState", _OneShotEndpointState)
+        monkeypatch.setattr("mcp_stdio.relay._sse_reader_loop", fake_reader)
+
+        stdin = StringIO('{"jsonrpc":"2.0","method":"test","id":5}\n')
+        stdout = StringIO()
+        with patch("sys.stdin", stdin), patch("sys.stdout", stdout):
+            run_sse(self.URL, {}, timeout_read=0.05)
+
+        msgs = [json.loads(x) for x in stdout.getvalue().strip().splitlines() if x]
+        assert len(msgs) == 1
+        assert msgs[0]["id"] == 5
+        assert msgs[0]["error"]["message"] == "SSE endpoint unavailable"
+
     def test_endpoint_then_post_then_message(self, httpx_mock):
         payload = '{"jsonrpc":"2.0","result":{},"id":42}'
         post_received = threading.Event()
@@ -1847,9 +2114,11 @@ class TestRunSse:
         )
 
         call_count = {"n": 0}
+        seen_auth: list[str | None] = []
 
         def post_callback(request):
             call_count["n"] += 1
+            seen_auth.append(request.headers.get("authorization"))
             if call_count["n"] == 1:
                 return httpx.Response(status_code=401)
             post_received.set()
@@ -1877,6 +2146,8 @@ class TestRunSse:
 
         assert refresher_called["n"] == 1
         assert call_count["n"] == 2
+        # The retried POST must carry the refreshed token, not the stale one.
+        assert seen_auth[1] == "Bearer new"
 
     def test_post_403_triggers_scope_upgrader(self, httpx_mock):
         """#17: SSE transport must run step-up on 403 insufficient_scope."""
@@ -1898,9 +2169,11 @@ class TestRunSse:
         )
 
         call_count = {"n": 0}
+        seen_auth: list[str | None] = []
 
         def post_callback(request):
             call_count["n"] += 1
+            seen_auth.append(request.headers.get("authorization"))
             if call_count["n"] == 1:
                 return httpx.Response(
                     status_code=403,
@@ -1936,6 +2209,8 @@ class TestRunSse:
 
         assert seen_scopes == ["hr:read hr:write"]
         assert call_count["n"] == 2
+        # The retried POST must carry the upgraded-scope token.
+        assert seen_auth[1] == "Bearer upgraded"
 
     def test_post_403_without_insufficient_scope_emits_error(self, httpx_mock):
         """Plain 403 (no scope challenge) surfaces as error (#11 + #17)."""
@@ -2143,6 +2418,29 @@ class TestTcpKeepaliveSocketOptions:
         if hasattr(socket, "TCP_KEEPALIVE"):
             keys = [(level, opt) for (level, opt, _val) in opts]
             assert (socket.IPPROTO_TCP, socket.TCP_KEEPALIVE) in keys
+
+    def test_darwin_full_set_deterministic(self, monkeypatch):
+        """Cover the darwin idle+interval+count append path on any host OS by
+        faking a socket module that exposes all three constants — so the macOS
+        branch has deterministic coverage on the Linux CI matrix too."""
+        monkeypatch.setattr("mcp_stdio.relay.sys.platform", "darwin")
+        import mcp_stdio.relay as relay_mod
+
+        class _FakeSocket:
+            SOL_SOCKET = socket.SOL_SOCKET
+            SO_KEEPALIVE = socket.SO_KEEPALIVE
+            IPPROTO_TCP = socket.IPPROTO_TCP
+            TCP_KEEPALIVE = 0x10
+            TCP_KEEPINTVL = 0x101
+            TCP_KEEPCNT = 0x102
+
+        monkeypatch.setattr(relay_mod, "socket", _FakeSocket)
+        opts = _tcp_keepalive_socket_options()
+        keys = [(level, opt) for (level, opt, _val) in opts]
+        assert (_FakeSocket.SOL_SOCKET, _FakeSocket.SO_KEEPALIVE) in keys
+        assert (_FakeSocket.IPPROTO_TCP, _FakeSocket.TCP_KEEPALIVE) in keys
+        assert (_FakeSocket.IPPROTO_TCP, _FakeSocket.TCP_KEEPINTVL) in keys
+        assert (_FakeSocket.IPPROTO_TCP, _FakeSocket.TCP_KEEPCNT) in keys
 
     def test_windows_sets_only_so_keepalive(self, monkeypatch):
         """Windows has no per-socket idle/intvl tuning via setsockopt — we


### PR DESCRIPTION
Fixes surfaced by a full main-branch code review (Opus 4.8, adversarially verified).

## What & why

### SSE parsing — WHATWG compliance + internal consistency
The three **Streamable HTTP** SSE-decode sites (`_post_and_stream`, `_post_parsed`, `check_connection`) required a literal `"data: "` with a trailing space. Per WHATWG SSE the leading space is **optional**, so a spec-compliant server emitting `data:{...}` was silently dropped on the Streamable HTTP transport — yet parsed correctly by the legacy GET reader, an internal inconsistency. They also ignored the `event:` type (forwarding `ping`/keepalive data as if it were a JSON-RPC message) and never concatenated multi-line `data:` fields.

→ Factored the WHATWG line decoder into a shared `_iter_sse_events()` generator now consumed by **all four** SSE sites, so they parse identically and only dispatch `message`-typed events.

### Streaming retry double-delivery (non-idempotent POST)
`_post_and_stream` emits each SSE `data:` line as it arrives. A transient `ReadError`/`ReadTimeout` **after** delivery began re-POSTed the request from scratch, re-delivering already-written lines plus a fresh full response → duplicate JSON-RPC ids and possible **double `tools/call` execution**.

→ Track whether output was committed; once it was, surface a single `upstream stream interrupted` error (at-most-once) instead of retrying. Pre-output failures stay retriable.

### SSE header data race
`run_sse` handed the reader thread the **same** `headers` dict the main loop mutates on 401/403 refresh, so a reconnect request-build could iterate the dict mid-update.

→ Serialise the per-reconnect snapshot and the in-place updates with a shared lock.

## Tests
+20 tests: shared SSE decoder units; no-space / non-message / multiline `data:` across post/parsed/check; mid-stream-interrupt at-most-once + pre-output retry; pagination page-1 retry exhaustion; run_sse reconnect-window error; multi-event initialize capture; 401/403 retried-header assertions; deterministic darwin keepalive. Full suite: **444 passed, 3 skipped**; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)