### PR TITLE
fix(oauth): validate AS-metadata endpoints, coerce expires_in, Google device fallback

### DIFF
--- a/src/mcp_stdio/oauth.py
+++ b/src/mcp_stdio/oauth.py
@@ -209,6 +209,42 @@ def _validate_prm_hint_url(hint_url: str, server_url: str) -> bool:
     return True
 
 
+def _validate_endpoint_url(endpoint_url: str | None, *, label: str) -> str | None:
+    """Validate an AS-metadata-declared endpoint URL before any secret is sent.
+
+    The AS base URL is validated against the #13 "no plaintext token leak"
+    policy, but the endpoints *inside* the fetched metadata
+    (authorization/token/registration/device) are attacker-influenced: a
+    hostile or compromised authorization server could declare
+    ``token_endpoint="http://evil/token"`` and exfiltrate the authorization
+    code, client_secret, and refresh_token in cleartext. Apply the same policy
+    here — reject non-http(s) schemes and reject plain HTTP for non-loopback
+    hosts — returning ``None`` (with a warning) so the caller drops the unsafe
+    endpoint rather than POSTing credentials to it. See #13.
+    """
+    if not endpoint_url:
+        return None
+    try:
+        parsed = urlparse(endpoint_url)
+    except Exception:
+        log(f"warning: malformed {label} URL {endpoint_url!r}, ignoring")
+        return None
+    if parsed.scheme not in ("https", "http"):
+        log(
+            f"warning: unsupported {label} scheme {parsed.scheme!r} "
+            f"in {endpoint_url!r}, ignoring"
+        )
+        return None
+    if parsed.scheme == "http" and not _is_loopback(parsed.hostname or ""):
+        log(
+            f"warning: refusing non-loopback HTTP {label} {endpoint_url!r} "
+            f"— OAuth credentials would traverse the wire in cleartext. "
+            f"Ignoring. See #13."
+        )
+        return None
+    return endpoint_url
+
+
 def _build_well_known_url(resource_url: str, suffix: str) -> str:
     """Build a well-known URL by inserting the suffix between host and path.
 
@@ -250,12 +286,27 @@ def _fetch_authorization_server_metadata(
                     f"expected {auth_server_url!r}, got {issuer!r}"
                 )
             methods = data.get("token_endpoint_auth_methods_supported")
+            # Validate every endpoint the metadata declares against the #13
+            # cleartext-leak policy before it can receive a secret. An unsafe
+            # authorization/token endpoint falls back to the default path on
+            # the already-validated AS base URL; an unsafe optional endpoint is
+            # dropped to None.
             return OAuthMetadata(
-                authorization_endpoint=data.get("authorization_endpoint")
+                authorization_endpoint=_validate_endpoint_url(
+                    data.get("authorization_endpoint"), label="authorization_endpoint"
+                )
                 or f"{auth_server_url}/authorize",
-                token_endpoint=data.get("token_endpoint") or f"{auth_server_url}/token",
-                registration_endpoint=data.get("registration_endpoint") or None,
-                device_authorization_endpoint=data.get("device_authorization_endpoint") or None,
+                token_endpoint=_validate_endpoint_url(
+                    data.get("token_endpoint"), label="token_endpoint"
+                )
+                or f"{auth_server_url}/token",
+                registration_endpoint=_validate_endpoint_url(
+                    data.get("registration_endpoint"), label="registration_endpoint"
+                ),
+                device_authorization_endpoint=_validate_endpoint_url(
+                    data.get("device_authorization_endpoint"),
+                    label="device_authorization_endpoint",
+                ),
                 token_endpoint_auth_methods_supported=methods if isinstance(methods, list) else None,
             )
     except Exception:
@@ -700,7 +751,13 @@ def _token_response_to_data(
     """
     expires_at = None
     if "expires_in" in raw:
-        expires_at = time.time() + raw["expires_in"]
+        # ``expires_in`` is numeric in JSON responses but a string in
+        # form-urlencoded ones (GitHub-legacy path via _parse_token_response).
+        # Coerce defensively so a string value cannot crash the whole flow.
+        try:
+            expires_at = time.time() + float(raw["expires_in"])
+        except (TypeError, ValueError):
+            expires_at = None
 
     return TokenData(
         access_token=raw["access_token"],
@@ -841,6 +898,12 @@ def _run_authorization_flow(
         params["scope"] = scope
 
     auth_url = f"{metadata.authorization_endpoint}?{urlencode(params)}"
+    # The full URL (including the single-use CSRF ``state`` nonce and the
+    # public S256 ``code_challenge``) is logged deliberately so the user can
+    # complete the flow manually when the browser does not auto-open. ``state``
+    # is single-use and timeout-bounded and the PKCE secret (``code_verifier``)
+    # is never logged, so this is an accepted UX-over-defence-in-depth tradeoff
+    # rather than a token leak — authorize URLs do appear in stderr logs.
     log(f"authorize URL (open in browser if not auto-opened):\n{auth_url}")
 
     webbrowser.open(auth_url)
@@ -986,8 +1049,21 @@ def _run_device_authorization_flow(
 
     device_code: str = da["device_code"]
     user_code: str = da["user_code"]
-    verification_uri: str = da["verification_uri"]
-    verification_uri_complete: str | None = da.get("verification_uri_complete")
+    # RFC 8628 §3.2 mandates ``verification_uri``; Google's device endpoint
+    # historically returns the non-standard ``verification_url``. Accept either
+    # so the advertised --oauth-device flow works against Google, with a clear
+    # error if both are absent.
+    verification_uri: str | None = da.get("verification_uri") or da.get(
+        "verification_url"
+    )
+    if not verification_uri:
+        raise ValueError(
+            "Device authorization response is missing verification_uri "
+            "(RFC 8628 §3.2)."
+        )
+    verification_uri_complete: str | None = da.get(
+        "verification_uri_complete"
+    ) or da.get("verification_url_complete")
     expires_in = int(da.get("expires_in", 1800))
     poll_interval = int(da.get("interval", 5))
 
@@ -1000,7 +1076,7 @@ def _run_device_authorization_flow(
         print(f"  Enter code: {user_code}", file=sys.stderr)
     print(f"\nWaiting for authorization (expires in {expires_in}s)...", file=sys.stderr)
 
-    # Step 2: Poll token endpoint (RFC 8628 §3.5)
+    # Step 2: Poll token endpoint (RFC 8628 §3.4 request / §3.5 response)
     # Sleep is at the end of each iteration so the first poll is immediate.
     deadline = time.monotonic() + expires_in
     while time.monotonic() < deadline:

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -21,9 +21,11 @@ from mcp_stdio.oauth import (
     _parse_token_response,
     _pick_token_endpoint_auth_method,
     _probe_www_authenticate,
+    _run_authorization_flow,
     _run_device_authorization_flow,
     _token_response_to_data,
     _validate_auth_server_url,
+    _validate_endpoint_url,
     _validate_prm_hint_url,
     discover_oauth_metadata,
     ensure_token,
@@ -483,10 +485,6 @@ class TestDiscoverMetadata:
             },
         )
         client = httpx.Client()
-        import io
-        import sys
-
-        captured = io.StringIO()
         with caplog.at_level(logging.DEBUG):
             meta = discover_oauth_metadata("https://api.example.com/mcp", client)
         # Metadata is still returned despite mismatch
@@ -1198,6 +1196,28 @@ class TestTokenResponseToData:
             previous_refresh_token="old_rt",
         )
         assert data.refresh_token == "new_rt"
+
+    def test_string_expires_in_is_coerced(self):
+        """Form-urlencoded responses (GitHub App user-to-server) deliver
+        ``expires_in`` as a string; it must not crash expires_at arithmetic."""
+        raw = {"access_token": "at", "expires_in": "28800"}
+        meta = OAuthMetadata(
+            authorization_endpoint="https://ex.com/auth",
+            token_endpoint="https://ex.com/token",
+        )
+        data = _token_response_to_data(raw, meta, "cid", None)
+        assert data.expires_at is not None
+        assert data.expires_at > time.time()
+
+    def test_unparseable_expires_in_degrades_to_none(self):
+        """A non-numeric expires_in is tolerated as 'no expiry known', not a crash."""
+        raw = {"access_token": "at", "expires_in": "soon"}
+        meta = OAuthMetadata(
+            authorization_endpoint="https://ex.com/auth",
+            token_endpoint="https://ex.com/token",
+        )
+        data = _token_response_to_data(raw, meta, "cid", None)
+        assert data.expires_at is None
 
 
 # --- _parse_token_response ---
@@ -2627,6 +2647,67 @@ class TestValidateAuthServerUrl:
         assert meta.authorization_endpoint == "https://auth.example.com/authorize"
 
 
+class TestValidateEndpointUrl:
+    """AS-metadata endpoint URLs must pass the #13 cleartext-leak policy
+    before any secret is POSTed to them, mirroring the AS base-URL check."""
+
+    def test_https_accepted(self):
+        assert (
+            _validate_endpoint_url("https://as.example.com/token", label="token")
+            == "https://as.example.com/token"
+        )
+
+    def test_loopback_http_accepted(self):
+        assert (
+            _validate_endpoint_url("http://127.0.0.1:9000/token", label="token")
+            == "http://127.0.0.1:9000/token"
+        )
+
+    def test_plaintext_http_public_host_rejected(self, capsys):
+        assert _validate_endpoint_url("http://evil.example/token", label="token") is None
+        assert "cleartext" in capsys.readouterr().err
+
+    def test_non_http_scheme_rejected(self, capsys):
+        assert _validate_endpoint_url("javascript:alert(1)", label="token") is None
+        assert "unsupported" in capsys.readouterr().err
+
+    def test_empty_and_none_pass_through_silently(self, capsys):
+        assert _validate_endpoint_url(None, label="token") is None
+        assert _validate_endpoint_url("", label="token") is None
+        assert capsys.readouterr().err == ""
+
+    def test_discover_drops_cleartext_token_endpoint_and_uses_default(
+        self, httpx_mock, capsys
+    ):
+        """A (validated, https) AS metadata doc declaring an http:// token
+        endpoint must not be honoured — fall back to the default token path on
+        the validated AS base instead of POSTing credentials in cleartext."""
+        server_url = "https://mcp.example.com/mcp"
+        httpx_mock.add_response(
+            url="https://mcp.example.com/.well-known/oauth-protected-resource/mcp",
+            status_code=404,
+        )
+        httpx_mock.add_response(
+            url="https://mcp.example.com/.well-known/oauth-protected-resource",
+            status_code=404,
+        )
+        httpx_mock.add_response(
+            url="https://mcp.example.com/.well-known/oauth-authorization-server",
+            json={
+                "authorization_endpoint": "https://mcp.example.com/authorize",
+                "token_endpoint": "http://evil.example/token",
+                "registration_endpoint": "http://evil.example/register",
+            },
+        )
+        client = httpx.Client()
+        meta = discover_oauth_metadata(server_url, client)
+        # Cleartext token endpoint dropped → default on the validated base.
+        assert meta.token_endpoint == "https://mcp.example.com/token"
+        # Cleartext optional endpoint dropped to None.
+        assert meta.registration_endpoint is None
+        assert "cleartext" in capsys.readouterr().err
+
+
 # --- OAuth state CSRF check (#26) ---
 
 
@@ -2734,6 +2815,59 @@ class TestStateCsrfCheck:
         assert calls[-1] == ("abc", "abc")
         assert oauth_mod.secrets.compare_digest("abc", "abd") is False
         assert calls[-1] == ("abc", "abd")
+
+
+class TestAuthorizationFlowFailurePaths:
+    """End-to-end failure paths of `_run_authorization_flow`: the callback
+    timeout and the server-returned-error branch (both clean up the server)."""
+
+    META = OAuthMetadata(
+        authorization_endpoint="https://ex.com/authorize",
+        token_endpoint="https://ex.com/token",
+    )
+
+    def test_callback_timeout_raises(self, monkeypatch):
+        """No callback ever arrives → TimeoutError after the deadline."""
+        monkeypatch.setattr("mcp_stdio.oauth.webbrowser.open", lambda _url: True)
+        client = httpx.Client()
+        with pytest.raises(TimeoutError, match="callback not received"):
+            _run_authorization_flow(
+                "https://ex.com/mcp",
+                client,
+                metadata=self.META,
+                cached=None,
+                client_id_override="cid",
+                timeout=0.3,
+            )
+
+    def test_callback_error_raises_runtime_error(self, monkeypatch):
+        """A callback carrying ?error=... → RuntimeError, no code exchange."""
+        from urllib.parse import parse_qs, urlparse
+        from urllib.request import urlopen
+
+        def fake_open(auth_url: str) -> bool:
+            redirect_uri = parse_qs(urlparse(auth_url).query)["redirect_uri"][0]
+
+            def hit() -> None:
+                try:
+                    urlopen(f"{redirect_uri}?error=access_denied", timeout=5).read()
+                except Exception:
+                    pass
+
+            threading.Thread(target=hit, daemon=True).start()
+            return True
+
+        monkeypatch.setattr("mcp_stdio.oauth.webbrowser.open", fake_open)
+        client = httpx.Client()
+        with pytest.raises(RuntimeError, match="OAuth error"):
+            _run_authorization_flow(
+                "https://ex.com/mcp",
+                client,
+                metadata=self.META,
+                cached=None,
+                client_id_override="cid",
+                timeout=5,
+            )
 
 
 # --- _parse_resource_metadata_hint ---
@@ -3118,13 +3252,9 @@ class TestDeviceAuthorizationFlow:
         self._patch_store(tmp_path, monkeypatch)
 
         intervals: list[float] = []
-        last_sleep = [0.0]
-
-        original_sleep = time.sleep
 
         def mock_sleep(secs: float) -> None:
             intervals.append(secs)
-            last_sleep[0] = secs
 
         monkeypatch.setattr(time, "sleep", mock_sleep)
 
@@ -3320,6 +3450,110 @@ class TestDeviceAuthorizationFlow:
         ]
         assert len(da_reqs) == 1
         assert b"resource=" not in da_reqs[0].content
+
+    def test_google_verification_url_fallback(
+        self, httpx_mock, tmp_path, monkeypatch, capsys
+    ):
+        """Google's device endpoint returns the non-standard ``verification_url``;
+        the flow must accept it instead of dying with a KeyError."""
+        self._patch_store(tmp_path, monkeypatch)
+        da = _da_response()
+        del da["verification_uri"]
+        da["verification_url"] = "https://www.google.com/device"
+        httpx_mock.add_response(url=REG_URL, json={"client_id": "cid"})
+        httpx_mock.add_response(url=DEVICE_AUTH_URL, json=da)
+        httpx_mock.add_response(
+            url=TOKEN_URL, json={"access_token": "acc", "token_type": "Bearer"}
+        )
+        client = httpx.Client()
+        data = _run_device_authorization_flow(
+            MCP_URL, client, metadata=_device_meta(), cached=None
+        )
+        assert data.access_token == "acc"
+        assert "https://www.google.com/device" in capsys.readouterr().err
+
+    def test_missing_verification_uri_raises_clear_error(
+        self, httpx_mock, tmp_path, monkeypatch
+    ):
+        """Neither verification_uri nor verification_url → a clear ValueError,
+        not a raw KeyError."""
+        self._patch_store(tmp_path, monkeypatch)
+        da = _da_response()
+        del da["verification_uri"]
+        httpx_mock.add_response(url=REG_URL, json={"client_id": "cid"})
+        httpx_mock.add_response(url=DEVICE_AUTH_URL, json=da)
+        client = httpx.Client()
+        with pytest.raises(ValueError, match="verification_uri"):
+            _run_device_authorization_flow(
+                MCP_URL, client, metadata=_device_meta(), cached=None
+            )
+
+    def test_poll_deadline_exhaustion_raises_timeout(
+        self, httpx_mock, tmp_path, monkeypatch
+    ):
+        """When the device code expires before the user authorizes, the poll
+        loop raises TimeoutError. A fake clock crosses the deadline
+        deterministically."""
+        self._patch_store(tmp_path, monkeypatch)
+        httpx_mock.add_response(url=REG_URL, json={"client_id": "cid"})
+        httpx_mock.add_response(url=DEVICE_AUTH_URL, json=_da_response())
+        httpx_mock.add_response(
+            url=TOKEN_URL,
+            json={"error": "authorization_pending"},
+            status_code=400,
+            is_reusable=True,
+        )
+
+        clock = {"t": 0.0}
+        monkeypatch.setattr(time, "monotonic", lambda: clock["t"])
+
+        def jump_sleep(_secs: float) -> None:
+            clock["t"] += 100000  # leap past the deadline after the first poll
+
+        monkeypatch.setattr(time, "sleep", jump_sleep)
+
+        client = httpx.Client()
+        with pytest.raises(TimeoutError, match="timed out"):
+            _run_device_authorization_flow(
+                MCP_URL, client, metadata=_device_meta(), cached=None
+            )
+
+    def test_poll_network_error_is_retried(
+        self, httpx_mock, tmp_path, monkeypatch
+    ):
+        """A transient network error during polling must not abort the flow —
+        the loop logs, sleeps, and continues to the next poll."""
+        self._patch_store(tmp_path, monkeypatch)
+        httpx_mock.add_response(url=REG_URL, json={"client_id": "cid"})
+        httpx_mock.add_response(url=DEVICE_AUTH_URL, json=_da_response())
+        httpx_mock.add_exception(httpx.ConnectError("flaky"), url=TOKEN_URL)
+        httpx_mock.add_response(
+            url=TOKEN_URL, json={"access_token": "acc", "token_type": "Bearer"}
+        )
+        monkeypatch.setattr(time, "sleep", lambda _s: None)
+        client = httpx.Client()
+        data = _run_device_authorization_flow(
+            MCP_URL, client, metadata=_device_meta(), cached=None
+        )
+        assert data.access_token == "acc"
+
+    def test_poll_unknown_error_surfaces_http_error(
+        self, httpx_mock, tmp_path, monkeypatch
+    ):
+        """A non-spec error code (e.g. invalid_client) falls through to
+        raise_for_status and surfaces as HTTPStatusError."""
+        self._patch_store(tmp_path, monkeypatch)
+        httpx_mock.add_response(url=REG_URL, json={"client_id": "cid"})
+        httpx_mock.add_response(url=DEVICE_AUTH_URL, json=_da_response())
+        httpx_mock.add_response(
+            url=TOKEN_URL, json={"error": "invalid_client"}, status_code=400
+        )
+        monkeypatch.setattr(time, "sleep", lambda _s: None)
+        client = httpx.Client()
+        with pytest.raises(httpx.HTTPStatusError):
+            _run_device_authorization_flow(
+                MCP_URL, client, metadata=_device_meta(), cached=None
+            )
 
 
 class TestEnsureTokenDeviceFlow:


### PR DESCRIPTION
Fixes surfaced by the full main-branch code review (Opus 4.8, adversarially verified).

## Findings fixed

### `expires_in` crash on form-urlencoded responses (medium)
`_token_response_to_data` computed `time.time() + raw["expires_in"]` with no coercion. The form-urlencoded token path (GitHub-legacy) delivers `expires_in` as a **string** — GitHub App user-to-server tokens carry e.g. `expires_in=28800` — so the arithmetic raised `TypeError` and aborted the whole auth-code / device flow. Now coerced with `float()`, degrading an unparseable value to "no expiry known".

### AS-metadata endpoint URLs used without TLS validation (medium)
The AS *base* URL is validated against the #13 cleartext-leak policy, but the endpoints **inside** the fetched metadata (authorization/token/registration/device) were taken verbatim. A hostile/compromised AS could declare `token_endpoint="http://evil/token"` and exfiltrate the code, `client_secret`, and `refresh_token` in cleartext — and the endpoint is persisted, so reused on every later refresh. Added `_validate_endpoint_url()` applied to all four endpoints before any secret is sent: unsafe authorization/token endpoints fall back to the default path on the validated base; unsafe optional endpoints drop to `None`.

### Google device flow `verification_url` (low)
`_run_device_authorization_flow` read only RFC 8628 §3.2 `verification_uri`; Google's device endpoint returns the non-standard `verification_url`, so the flow died with a `KeyError`. Now accepts either key (and the `*_complete` variants), with a clear `ValueError` if both are absent.

### Minor
- **authorize URL logging (low)**: documented that the full authorize URL (single-use CSRF `state` + public PKCE challenge) is logged on purpose for manual-fallback UX — accepted tradeoff, not a token leak (the PKCE secret is never logged).
- **RFC citation (nit)**: device-poll comment cited §3.5 for the request; RFC 8628 defines it in §3.4.

## Tests
+15 tests: string/unparseable `expires_in`; `_validate_endpoint_url` units + discovery dropping a cleartext token/registration endpoint; Google `verification_url` fallback + missing-uri error; device-poll deadline timeout / network-error retry / unknown-error (fake clock); auth-code callback timeout + server-error. Also removed pre-existing ruff-flagged dead locals in this file. Suite: **439 passed, 3 skipped**; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)