### PR TITLE
fix(token_store): advisory lock, migration hardening, dir mode, key normalization

### DIFF
--- a/src/mcp_stdio/token_store.py
+++ b/src/mcp_stdio/token_store.py
@@ -1,13 +1,25 @@
-"""Persistent token storage for OAuth 2.1 credentials."""
+"""Persistent token storage for OAuth 2.1 credentials.
+
+Concurrency: ``save_token`` / ``delete_token`` hold a best-effort advisory
+file lock (``_store_lock``) across their read-modify-write so two mcp-stdio
+processes updating distinct server keys merge instead of last-writer-wins.
+The lock is real on POSIX (``fcntl``) and Windows (``msvcrt``); on a platform
+exposing neither it degrades to a no-op and the lost-update race remains
+possible (acquisition failures are non-fatal by design).
+"""
 
 from __future__ import annotations
 
+import contextlib
 import json
 import os
 import stat
+import sys
+from collections.abc import Iterator
 from dataclasses import asdict, dataclass
 from pathlib import Path
 from typing import Any
+from urllib.parse import urlsplit, urlunsplit
 
 
 _STORE_DIR = Path.home() / ".config" / "mcp-stdio"
@@ -16,6 +28,36 @@ _STORE_FILE = _STORE_DIR / "tokens.json"
 # Legacy path (v0.3.0 and earlier)
 _LEGACY_STORE_DIR = Path.home() / ".mcp-stdio"
 _LEGACY_STORE_FILE = _LEGACY_STORE_DIR / "tokens.json"
+
+# Default ports folded out when normalising a server URL into a store key.
+_DEFAULT_PORTS = {"https": 443, "http": 80}
+
+
+def _normalize_key(server_url: str) -> str:
+    """Normalise a server URL into a stable token-store key.
+
+    Folds cosmetically-different spellings of the same endpoint — host case,
+    an explicit default port (``:443`` / ``:80``), and a single trailing
+    slash — to one key so they share a cached token instead of triggering a
+    redundant OAuth flow. Only the *store key* is normalised; oauth.py still
+    uses the operator-supplied URL verbatim for the RFC 8707 resource
+    indicator, so end-to-end behaviour is unchanged. Anything that does not
+    parse as http(s) with a host is returned unchanged.
+    """
+    try:
+        parsed = urlsplit(server_url)
+    except ValueError:
+        return server_url
+    if parsed.scheme not in ("http", "https") or not parsed.hostname:
+        return server_url
+    host = parsed.hostname  # urlsplit lowercases the host and strips userinfo
+    port = parsed.port
+    if port is not None and port != _DEFAULT_PORTS.get(parsed.scheme):
+        netloc = f"{host}:{port}"
+    else:
+        netloc = host
+    path = parsed.path.rstrip("/")
+    return urlunsplit((parsed.scheme, netloc, path, parsed.query, ""))
 
 
 @dataclass
@@ -42,8 +84,17 @@ class TokenData:
 
 
 def _ensure_store_dir() -> None:
-    """Create the store directory with secure permissions."""
+    """Create the store directory with secure permissions.
+
+    ``mkdir``'s ``mode`` only applies on creation, so re-assert 0o700 in case
+    the directory pre-existed with looser permissions (created earlier by
+    another tool, or under a permissive umask).
+    """
     _STORE_DIR.mkdir(mode=0o700, parents=True, exist_ok=True)
+    try:
+        os.chmod(_STORE_DIR, stat.S_IRWXU)  # 0o700
+    except OSError:
+        pass
 
 
 def _migrate_legacy_store() -> None:
@@ -55,8 +106,31 @@ def _migrate_legacy_store() -> None:
         _LEGACY_STORE_FILE.unlink()
     else:
         _ensure_store_dir()
-        _LEGACY_STORE_FILE.rename(_STORE_FILE)
-        os.chmod(_STORE_FILE, stat.S_IRUSR | stat.S_IWUSR)
+        # Tighten the legacy file's mode BEFORE moving it, so the secrets never
+        # sit at the new XDG path with a looser (pre-0o600) mode, even briefly:
+        # rename() preserves the source inode's permission bits.
+        try:
+            os.chmod(_LEGACY_STORE_FILE, stat.S_IRUSR | stat.S_IWUSR)
+        except OSError:
+            pass
+        try:
+            _LEGACY_STORE_FILE.rename(_STORE_FILE)
+            os.chmod(_STORE_FILE, stat.S_IRUSR | stat.S_IWUSR)
+        except OSError:
+            # rename() raises EXDEV when the legacy and XDG paths are on
+            # different filesystems. Fall back to copy-via-_write_store (which
+            # creates the target 0o600 and atomically replaces) so a
+            # cross-device layout cannot brick every token operation.
+            try:
+                data = json.loads(_LEGACY_STORE_FILE.read_text())
+            except (json.JSONDecodeError, OSError):
+                data = {}
+            if isinstance(data, dict):
+                _write_store(data)
+            try:
+                _LEGACY_STORE_FILE.unlink()
+            except OSError:
+                pass
     # Remove legacy directory if empty
     try:
         _LEGACY_STORE_DIR.rmdir()
@@ -101,13 +175,63 @@ def _write_store(data: dict[str, Any]) -> None:
         raise
 
 
+@contextlib.contextmanager
+def _store_lock() -> Iterator[None]:
+    """Best-effort advisory exclusive lock around a read-modify-write.
+
+    Serialises ``save_token`` / ``delete_token`` across concurrent mcp-stdio
+    processes so updates to distinct server keys merge rather than clobbering
+    each other (last-writer-wins). Uses ``fcntl`` on POSIX and ``msvcrt`` on
+    Windows; if no primitive is available or acquisition fails, it proceeds
+    without the lock (the operation must never be blocked by lock trouble).
+    """
+    _ensure_store_dir()
+    # Derive the lock path from the current _STORE_DIR (not a module constant)
+    # so test monkeypatching of _STORE_DIR redirects the lock file too.
+    lock_path = _STORE_DIR / "tokens.json.lock"
+    try:
+        fd = os.open(lock_path, os.O_WRONLY | os.O_CREAT, stat.S_IRUSR | stat.S_IWUSR)
+    except OSError:
+        yield
+        return
+    locked = False
+    try:
+        try:
+            if sys.platform == "win32":
+                import msvcrt
+
+                msvcrt.locking(fd, msvcrt.LK_LOCK, 1)
+            else:
+                import fcntl
+
+                fcntl.flock(fd, fcntl.LOCK_EX)
+            locked = True
+        except (OSError, ImportError, ValueError):
+            pass  # best-effort: fall back to an unsynchronised write
+        yield
+    finally:
+        if locked and sys.platform == "win32":
+            try:
+                import msvcrt
+
+                os.lseek(fd, 0, os.SEEK_SET)
+                msvcrt.locking(fd, msvcrt.LK_UNLCK, 1)
+            except OSError:
+                pass
+        os.close(fd)
+
+
 def load_token(server_url: str) -> TokenData | None:
     """Load token data for a server URL.
 
-    Returns None if no token is stored.
+    Returns None if no token is stored. Looks up the normalised key first,
+    then the verbatim key so entries written by older versions (which used the
+    raw URL as the key) are still found.
     """
     store = _read_store()
-    entry = store.get(server_url)
+    entry = store.get(_normalize_key(server_url))
+    if entry is None:
+        entry = store.get(server_url)
     if entry is None:
         return None
     try:
@@ -118,14 +242,25 @@ def load_token(server_url: str) -> TokenData | None:
 
 def save_token(server_url: str, data: TokenData) -> None:
     """Save token data for a server URL."""
-    store = _read_store()
-    store[server_url] = asdict(data)
-    _write_store(store)
+    with _store_lock():
+        store = _read_store()
+        key = _normalize_key(server_url)
+        # Drop any stale entry stored under the un-normalised key by an older
+        # version so the two spellings don't both linger.
+        if server_url != key:
+            store.pop(server_url, None)
+        store[key] = asdict(data)
+        _write_store(store)
 
 
 def delete_token(server_url: str) -> None:
     """Delete token data for a server URL."""
-    store = _read_store()
-    if server_url in store:
-        del store[server_url]
-        _write_store(store)
+    with _store_lock():
+        store = _read_store()
+        removed = False
+        for key in {_normalize_key(server_url), server_url}:
+            if key in store:
+                del store[key]
+                removed = True
+        if removed:
+            _write_store(store)

--- a/tests/test_token_store.py
+++ b/tests/test_token_store.py
@@ -3,10 +3,17 @@
 import os
 import stat
 import sys
+import threading
 
 import pytest
 
-from mcp_stdio.token_store import TokenData, delete_token, load_token, save_token
+from mcp_stdio.token_store import (
+    TokenData,
+    _normalize_key,
+    delete_token,
+    load_token,
+    save_token,
+)
 
 
 class TestTokenData:
@@ -111,6 +118,75 @@ class TestLoadSaveDelete:
         store_file.write_text("not json")
         assert load_token("https://example.com/mcp") is None
 
+    def test_load_unknown_future_field_returns_none(self, tmp_path, monkeypatch):
+        """Forward-compat: an entry written by a newer version carrying a field
+        this version doesn't know must degrade to None, not raise."""
+        store_file = tmp_path / "tokens.json"
+        monkeypatch.setattr("mcp_stdio.token_store._STORE_DIR", tmp_path)
+        monkeypatch.setattr("mcp_stdio.token_store._STORE_FILE", store_file)
+
+        store_file.write_text(
+            '{"https://example.com/mcp": '
+            '{"access_token": "t", "unknown_future_field": 1}}'
+        )
+        assert load_token("https://example.com/mcp") is None
+
+    def test_save_over_corrupt_store_succeeds(self, tmp_path, monkeypatch):
+        """A corrupt store file is replaced (not appended to) on the next save."""
+        store_file = tmp_path / "tokens.json"
+        monkeypatch.setattr("mcp_stdio.token_store._STORE_DIR", tmp_path)
+        monkeypatch.setattr("mcp_stdio.token_store._STORE_FILE", store_file)
+
+        store_file.write_text("not json")
+        save_token("https://example.com/mcp", TokenData(access_token="fresh"))
+        loaded = load_token("https://example.com/mcp")
+        assert loaded is not None and loaded.access_token == "fresh"
+
+    @pytest.mark.skipif(
+        sys.platform == "win32",
+        reason="POSIX mode bits don't model NTFS ACLs",
+    )
+    def test_store_dir_mode_reenforced_when_preexisting(self, tmp_path, monkeypatch):
+        """A pre-existing store dir with loose perms is tightened to 0o700."""
+        store_dir = tmp_path / "store"
+        store_dir.mkdir(mode=0o755)
+        store_file = store_dir / "tokens.json"
+        monkeypatch.setattr("mcp_stdio.token_store._STORE_DIR", store_dir)
+        monkeypatch.setattr("mcp_stdio.token_store._STORE_FILE", store_file)
+
+        save_token("https://example.com/mcp", TokenData(access_token="tok"))
+        mode = os.stat(store_dir).st_mode
+        assert mode & stat.S_IRWXG == 0
+        assert mode & stat.S_IRWXO == 0
+
+    def test_concurrent_saves_of_distinct_keys_both_persist(
+        self, tmp_path, monkeypatch
+    ):
+        """The advisory lock serialises read-modify-write so two threads saving
+        distinct server keys merge instead of last-writer-wins."""
+        store_file = tmp_path / "tokens.json"
+        monkeypatch.setattr("mcp_stdio.token_store._STORE_DIR", tmp_path)
+        monkeypatch.setattr("mcp_stdio.token_store._STORE_FILE", store_file)
+
+        # Seed so both threads read a non-empty baseline they each extend.
+        save_token("https://seed.com/mcp", TokenData(access_token="seed"))
+
+        barrier = threading.Barrier(2)
+
+        def worker(n: int) -> None:
+            barrier.wait()
+            save_token(f"https://host{n}.com/mcp", TokenData(access_token=f"t{n}"))
+
+        threads = [threading.Thread(target=worker, args=(i,)) for i in range(2)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert load_token("https://seed.com/mcp").access_token == "seed"
+        assert load_token("https://host0.com/mcp").access_token == "t0"
+        assert load_token("https://host1.com/mcp").access_token == "t1"
+
     def test_atomic_write_leaves_no_tempfile(self, tmp_path, monkeypatch):
         """Successful save should not leave .tmp files behind."""
         store_file = tmp_path / "tokens.json"
@@ -151,7 +227,120 @@ class TestLoadSaveDelete:
         assert list(tmp_path.glob("tokens.json.tmp*")) == []
 
 
+class TestNormalizeKey:
+    def test_lowercases_host(self):
+        assert (
+            _normalize_key("https://Example.COM/mcp") == "https://example.com/mcp"
+        )
+
+    def test_folds_default_port(self):
+        assert _normalize_key("https://x.com:443/mcp") == "https://x.com/mcp"
+        assert _normalize_key("http://x.com:80/mcp") == "http://x.com/mcp"
+
+    def test_keeps_non_default_port(self):
+        assert _normalize_key("https://x.com:8443/mcp") == "https://x.com:8443/mcp"
+
+    def test_strips_single_trailing_slash(self):
+        assert _normalize_key("https://x.com/mcp/") == "https://x.com/mcp"
+
+    def test_non_http_returned_unchanged(self):
+        assert _normalize_key("not a url") == "not a url"
+
+
+class TestKeyNormalizationInStore:
+    def _patch(self, tmp_path, monkeypatch):
+        store_file = tmp_path / "tokens.json"
+        monkeypatch.setattr("mcp_stdio.token_store._STORE_DIR", tmp_path)
+        monkeypatch.setattr("mcp_stdio.token_store._STORE_FILE", store_file)
+        return store_file
+
+    def test_cosmetic_variants_share_one_entry(self, tmp_path, monkeypatch):
+        """Trailing slash / host case / default port resolve to the same token."""
+        self._patch(tmp_path, monkeypatch)
+        save_token("https://Example.com/mcp/", TokenData(access_token="tok"))
+        assert load_token("https://example.com:443/mcp").access_token == "tok"
+
+    def test_legacy_raw_key_still_loads(self, tmp_path, monkeypatch):
+        """An entry written by an older version under the verbatim URL is found
+        via the raw-key fallback."""
+        store_file = self._patch(tmp_path, monkeypatch)
+        store_file.write_text(
+            '{"https://x.com/mcp/": {"access_token": "legacy"}}'
+        )
+        loaded = load_token("https://x.com/mcp/")
+        assert loaded is not None and loaded.access_token == "legacy"
+
+    def test_delete_removes_normalized_and_raw(self, tmp_path, monkeypatch):
+        store_file = self._patch(tmp_path, monkeypatch)
+        # Pre-seed a stale raw-key entry plus a normalized one.
+        store_file.write_text(
+            '{"https://x.com/mcp/": {"access_token": "raw"}}'
+        )
+        save_token("https://x.com/mcp", TokenData(access_token="norm"))
+        delete_token("https://x.com/mcp/")
+        assert load_token("https://x.com/mcp") is None
+        assert load_token("https://x.com/mcp/") is None
+
+
 class TestLegacyMigration:
+    def _set_legacy_mode(self, path, mode):
+        os.chmod(path, mode)
+
+    def test_migrated_file_is_0600_even_if_legacy_was_loose(
+        self, tmp_path, monkeypatch
+    ):
+        """rename() preserves source mode bits; migration must still leave the
+        moved file at 0o600 (and never expose it looser, even transiently)."""
+        if sys.platform == "win32":
+            pytest.skip("POSIX mode bits don't model NTFS ACLs")
+        legacy_dir = tmp_path / "legacy"
+        legacy_file = legacy_dir / "tokens.json"
+        new_dir = tmp_path / "new"
+        new_file = new_dir / "tokens.json"
+        legacy_dir.mkdir()
+        legacy_file.write_text('{"https://example.com/mcp": {"access_token": "old"}}')
+        os.chmod(legacy_file, 0o644)  # loose legacy mode
+
+        monkeypatch.setattr("mcp_stdio.token_store._STORE_DIR", new_dir)
+        monkeypatch.setattr("mcp_stdio.token_store._STORE_FILE", new_file)
+        monkeypatch.setattr("mcp_stdio.token_store._LEGACY_STORE_DIR", legacy_dir)
+        monkeypatch.setattr("mcp_stdio.token_store._LEGACY_STORE_FILE", legacy_file)
+
+        assert load_token("https://example.com/mcp").access_token == "old"
+        mode = os.stat(new_file).st_mode
+        assert mode & stat.S_IRWXG == 0
+        assert mode & stat.S_IRWXO == 0
+
+    def test_migration_survives_cross_device_rename(self, tmp_path, monkeypatch):
+        """An EXDEV (cross-filesystem) rename must not brick the store — the
+        copy-through fallback persists the tokens at the new path."""
+        legacy_dir = tmp_path / "legacy"
+        legacy_file = legacy_dir / "tokens.json"
+        new_dir = tmp_path / "new"
+        new_file = new_dir / "tokens.json"
+        legacy_dir.mkdir()
+        legacy_file.write_text('{"https://example.com/mcp": {"access_token": "old"}}')
+
+        monkeypatch.setattr("mcp_stdio.token_store._STORE_DIR", new_dir)
+        monkeypatch.setattr("mcp_stdio.token_store._STORE_FILE", new_file)
+        monkeypatch.setattr("mcp_stdio.token_store._LEGACY_STORE_DIR", legacy_dir)
+        monkeypatch.setattr("mcp_stdio.token_store._LEGACY_STORE_FILE", legacy_file)
+
+        real_rename = os.rename
+
+        def exdev_rename(src, dst, *a, **k):
+            raise OSError(18, "Invalid cross-device link")  # EXDEV
+
+        monkeypatch.setattr("mcp_stdio.token_store.os.rename", exdev_rename)
+        # Path.rename goes through os.rename under the hood on CPython, but
+        # guard explicitly in case the implementation calls it differently.
+        loaded = load_token("https://example.com/mcp")
+        monkeypatch.setattr("mcp_stdio.token_store.os.rename", real_rename)
+
+        assert loaded is not None and loaded.access_token == "old"
+        assert new_file.exists()
+        assert not legacy_file.exists()
+
     def test_migrate_legacy_to_xdg(self, tmp_path, monkeypatch):
         """Legacy ~/.mcp-stdio/tokens.json is moved to new XDG path."""
         legacy_dir = tmp_path / "legacy"


### PR DESCRIPTION
Fixes surfaced by the full main-branch code review (Opus 4.8, adversarially verified).

## Findings fixed

### Lost-update race on concurrent writes (low)
`save_token` / `delete_token` did read → mutate → write with no lock spanning the three steps, so two concurrent mcp-stdio processes could each add a distinct server key and the second `os.replace` would silently drop the first. Added a best-effort advisory file lock (`_store_lock` — `fcntl` on POSIX, `msvcrt` on Windows, no-op fallback elsewhere) around the read-modify-write. Acquisition failures are non-fatal by design.

### Legacy-migration hardening (low)
`rename()` preserves the source inode's mode bits, so a pre-0o600 legacy file briefly sat at the new XDG path with loose permissions. Now `chmod` the legacy file to 0o600 **before** the rename so the window never exists. Also wrapped the rename in `try/except` so an **EXDEV** (cross-filesystem) move falls back to copy-via-`_write_store` instead of propagating uncaught and bricking every token operation.

### Store directory mode (low)
`mkdir(mode=0o700)` only applies on creation; now re-assert 0o700 via `os.chmod` so a pre-existing dir with looser permissions is tightened.

### Key normalization (nit)
Cosmetically-different spellings of the same endpoint (host case, explicit `:443`/`:80`, single trailing slash) keyed to separate entries, causing redundant OAuth flows. The store key is now normalized via `_normalize_key`; `load_token` falls back to the verbatim key for entries written by older versions, and the RFC 8707 resource indicator still uses the raw operator-supplied URL.

## Tests
+14 tests: forward-compat unknown-key → None; save-over-corrupt-store; dir-mode re-enforcement; concurrent distinct-key saves both persist; normalization units + cosmetic-variant sharing + legacy raw-key fallback + delete-both; migrated-file 0o600 despite loose legacy mode; EXDEV migration fallback. Suite: **458 passed, 3 skipped**; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)