### PR TITLE
fix(cli): env bearer token must not block --oauth; -H overrides case-insensitively

### DIFF
--- a/src/mcp_stdio/cli.py
+++ b/src/mcp_stdio/cli.py
@@ -150,7 +150,7 @@ def main() -> None:
     )
     parser.add_argument(
         "--bearer-token",
-        default=os.environ.get("MCP_BEARER_TOKEN", ""),
+        default=None,
         help="Bearer token for authentication (or set MCP_BEARER_TOKEN env var)",
     )
     parser.add_argument(
@@ -299,7 +299,21 @@ def main() -> None:
     )
     args = parser.parse_args()
 
-    n_auth = sum([args.oauth, args.oauth_device, bool(args.bearer_token)])
+    # An explicit --bearer-token on the command line is distinct from an
+    # ambient MCP_BEARER_TOKEN env var. Only the explicit flag participates in
+    # the mutual-exclusion check, so leaving MCP_BEARER_TOKEN exported in the
+    # shell / host config does not block --oauth (the OAuth flow then supplies
+    # the Authorization header and the env token is ignored).
+    bearer_from_flag = args.bearer_token is not None
+    bearer_token = (
+        args.bearer_token
+        if bearer_from_flag
+        else os.environ.get("MCP_BEARER_TOKEN", "")
+    )
+
+    n_auth = sum(
+        [args.oauth, args.oauth_device, bool(bearer_from_flag and bearer_token)]
+    )
     if n_auth > 1:
         print(
             "error: --oauth, --oauth-device, and --bearer-token are mutually exclusive",
@@ -307,15 +321,26 @@ def main() -> None:
         )
         sys.exit(1)
 
+    # When an OAuth flow is selected, ignore any ambient env bearer token —
+    # the flow below sets the Authorization header itself.
+    if args.oauth or args.oauth_device:
+        bearer_token = ""
+
     # Build headers
     headers: dict[str, str] = {
         "Content-Type": "application/json",
         "Accept": "application/json, text/event-stream",
     }
-    if args.bearer_token:
-        headers["Authorization"] = f"Bearer {args.bearer_token}"
+    if bearer_token:
+        headers["Authorization"] = f"Bearer {bearer_token}"
     for h in args.headers:
         key, value = _parse_header(h)
+        # HTTP header names are case-insensitive (RFC 7230 §3.2). Drop any
+        # existing header that differs only in case so an explicit -H overrides
+        # the built-in default (e.g. -H 'authorization: ...' replaces the
+        # bearer Authorization) instead of sending two same-named headers.
+        for existing in [k for k in headers if k.lower() == key.lower()]:
+            del headers[existing]
         headers[key] = value
 
     # OAuth flow (before relay starts)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -243,6 +243,80 @@ class TestMain:
                 main()
             assert exc_info.value.code == 1
 
+    def test_env_bearer_token_does_not_block_oauth(self, monkeypatch):
+        """An ambient MCP_BEARER_TOKEN must not trip the mutual-exclusion guard
+        against --oauth; the OAuth flow runs and supplies the header."""
+        monkeypatch.setenv("MCP_BEARER_TOKEN", "env-token")
+        with (
+            patch("sys.argv", ["mcp-stdio", "--oauth", "https://example.com/mcp"]),
+            patch("mcp_stdio.oauth.ensure_token") as mock_ensure,
+            patch("mcp_stdio.cli.run") as mock_run,
+        ):
+            mock_ensure.return_value.access_token = "oauth-tok"
+            main()  # must NOT sys.exit(1)
+        headers = mock_run.call_args.kwargs["headers"]
+        # OAuth wins; the ambient env bearer token is ignored.
+        assert headers["Authorization"] == "Bearer oauth-tok"
+
+    def test_explicit_bearer_flag_still_conflicts_with_oauth(self, monkeypatch):
+        """An explicit --bearer-token on the command line still conflicts."""
+        monkeypatch.delenv("MCP_BEARER_TOKEN", raising=False)
+        with patch(
+            "sys.argv",
+            [
+                "mcp-stdio",
+                "https://example.com/mcp",
+                "--oauth",
+                "--bearer-token",
+                "tok",
+            ],
+        ):
+            with pytest.raises(SystemExit) as exc_info:
+                main()
+            assert exc_info.value.code == 1
+
+    def test_dash_h_overrides_bearer_authorization_case_insensitively(self):
+        """A -H differing only in case from a built-in header replaces it,
+        rather than sending two same-named headers (RFC 7230 §3.2)."""
+        with (
+            patch(
+                "sys.argv",
+                [
+                    "mcp-stdio",
+                    "https://example.com/mcp",
+                    "--bearer-token",
+                    "tok123",
+                    "-H",
+                    "authorization: Bearer override",
+                ],
+            ),
+            patch("mcp_stdio.cli.run") as mock_run,
+        ):
+            main()
+            headers = mock_run.call_args.kwargs["headers"]
+            auth_keys = [k for k in headers if k.lower() == "authorization"]
+            assert auth_keys == ["authorization"]
+            assert headers["authorization"] == "Bearer override"
+
+    def test_dash_h_overrides_default_content_type_case_insensitively(self):
+        with (
+            patch(
+                "sys.argv",
+                [
+                    "mcp-stdio",
+                    "https://example.com/mcp",
+                    "-H",
+                    "content-type: application/cbor",
+                ],
+            ),
+            patch("mcp_stdio.cli.run") as mock_run,
+        ):
+            main()
+            headers = mock_run.call_args.kwargs["headers"]
+            ct_keys = [k for k in headers if k.lower() == "content-type"]
+            assert ct_keys == ["content-type"]
+            assert headers["content-type"] == "application/cbor"
+
     def test_check_flag_invokes_check_connection(self):
         """--check should call check_connection and exit with its result."""
         with (


### PR DESCRIPTION
Fixes surfaced by the full main-branch code review (Opus 4.8, adversarially verified).

## Findings fixed

### `MCP_BEARER_TOKEN` env var blocked `--oauth` (low)
`--bearer-token` defaulted to the `MCP_BEARER_TOKEN` env var, so a user who keeps it exported (as the README promotes) and then runs `--oauth` hit `n_auth > 1` and exited with `error: --oauth, --oauth-device, and --bearer-token are mutually exclusive` — naming a flag they never passed, with no hint the ambient env var was the cause. Now an **explicit** `--bearer-token` flag is distinguished from an ambient env var: only the explicit flag participates in mutual exclusion, and selecting an OAuth flow ignores the env bearer token (the flow sets the `Authorization` header itself).

### `-H` header case-sensitivity (nit)
Header keys were matched case-sensitively, so `-H 'authorization: ...'` coexisted with the built-in `Authorization` and httpx sent **two** `Authorization` headers. Now any existing header differing only in case is dropped before inserting a `-H`, so an explicit override replaces the default (HTTP header names are case-insensitive, RFC 7230 §3.2).

## Tests
+4 tests: env bearer token + `--oauth` no longer exits and OAuth wins; explicit `--bearer-token` + `--oauth` still conflicts; `-H` overrides `Authorization` and `Content-Type` case-insensitively without duplicates. Suite: **463 passed, 3 skipped**; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)