### PR TITLE
docs: list missing CLI flags, note resource-indicator persistence, fix CHANGELOG link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,7 +68,7 @@
 
 ### Features
 
-* honour Retry-After on HTTP 429 (typescript-sdk[#1892](https://github.com/shigechika/mcp-stdio/issues/1892)) ([#45](https://github.com/shigechika/mcp-stdio/issues/45)) ([fb5ac14](https://github.com/shigechika/mcp-stdio/commit/fb5ac148ecde6cd0252de956db934241a1941b99))
+* honour Retry-After on HTTP 429 (typescript-sdk[#1892](https://github.com/modelcontextprotocol/typescript-sdk/issues/1892)) ([#45](https://github.com/shigechika/mcp-stdio/issues/45)) ([fb5ac14](https://github.com/shigechika/mcp-stdio/commit/fb5ac148ecde6cd0252de956db934241a1941b99))
 
 ## [0.7.0](https://github.com/shigechika/mcp-stdio/compare/v0.6.0...v0.7.0) (2026-04-20)
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -184,12 +184,22 @@ mcp-stdio [OPTIONS] URL
                          すべての OAuth リクエストから RFC 8707 resource
                          パラメータを除外する。api:// スコープを使う Microsoft
                          Entra ID v2 など、resource パラメータを拒否する AS
-                         （AADSTS9010010）で必要
+                         （AADSTS9010010）で必要。トークンストアに永続化され、
+                         proactive refresh や step-up フローでも一貫して適用される
   -H, --header 'Key: Value'  カスタムヘッダー（複数指定可）
   --transport {streamable-http,sse}
                          トランスポート種別（デフォルト: streamable-http）
   --timeout-connect SEC  接続タイムアウト（デフォルト: 10秒）
   --timeout-read SEC     読み取りタイムアウト（デフォルト: 120秒）
+  --sse-read-timeout SEC SSE GET ストリームのアイドル読み取りタイムアウト
+                         （デフォルト: 300秒、0 で無効、SSE トランスポートのみ）
+  --no-tcp-keepalive     HTTP ソケットの TCP keepalive を無効化する
+  --no-cancel-filter     cancel-aware レスポンスフィルタを無効化する
+                         （notifications/cancelled でキャンセルされた id の
+                         遅延レスポンスを drop する機能）
+  --no-normalize-arguments
+                         tools/call リクエストの arguments:null を転送前に
+                         {} へ書き換える正規化を無効化する
   --check                接続確認して終了
   -V, --version          バージョン表示
   -h, --help             ヘルプ表示

--- a/README.md
+++ b/README.md
@@ -185,12 +185,22 @@ Options:
   --no-resource-indicator
                          Omit the RFC 8707 resource parameter from all OAuth
                          requests. Required for AS that reject it, such as
-                         Microsoft Entra ID v2 with api:// scopes (AADSTS9010010)
+                         Microsoft Entra ID v2 with api:// scopes (AADSTS9010010).
+                         Persisted in the token store so proactive refreshes
+                         and step-up flows stay consistent
   -H, --header 'Key: Value'  Custom header (can be repeated)
   --transport {streamable-http,sse}
                          Transport type (default: streamable-http)
   --timeout-connect SEC  Connection timeout (default: 10)
   --timeout-read SEC     Read timeout (default: 120)
+  --sse-read-timeout SEC Idle read timeout on the SSE GET stream
+                         (default: 300; 0 disables; SSE transport only)
+  --no-tcp-keepalive     Disable TCP keepalive on the HTTP socket
+  --no-cancel-filter     Disable the cancel-aware response filter (drops late
+                         responses for ids cancelled via notifications/cancelled)
+  --no-normalize-arguments
+                         Disable rewriting a tools/call request's
+                         arguments:null to {} before forwarding
   --check                Check connection and exit
   -V, --version          Show version
   -h, --help             Show help


### PR DESCRIPTION
Fixes surfaced by the full main-branch code review (Opus 4.8, adversarially verified).

## Findings fixed

### README Usage omitted four real flags (medium)
The `## Usage` options reference omitted four flags that gate documented behavior: `--sse-read-timeout`, `--no-tcp-keepalive`, `--no-cancel-filter`, `--no-normalize-arguments`. The omission was self-contradictory — the Features section tells the reader to "opt out with `--no-normalize-arguments`", yet the flag never appeared in Usage. Added all four to both `README.md` and `README.ja.md` (the two were already in sync, so this is a completeness gap, not an EN/JA desync).

### `--no-resource-indicator` persistence note (low)
Documented that the setting is persisted in the token store so proactive refreshes and step-up flows stay consistent, in both READMEs — matching cli.py's `--help` and WORKAROUNDS.md.

### CHANGELOG dead link (low)
The 0.8.0 entry's `typescript-sdk#1892` link pointed at `shigechika/mcp-stdio/issues/1892` (dead) instead of `modelcontextprotocol/typescript-sdk/issues/1892` — a release-please bare-`#NNNN` auto-link artifact. Fixed the href (WORKAROUNDS.md:30 already links it correctly).

Docs-only; no code or tests changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)