### PR TITLE
fix(relay): uniform session reset, re-capture renegotiated version, lock-symmetric SSE POST

### DIFF
--- a/src/mcp_stdio/relay.py
+++ b/src/mcp_stdio/relay.py
@@ -869,7 +869,7 @@ def _reinitialize(
     url: str,
     headers: dict[str, str],
     protocol_version: str | None = None,
-) -> str | None:
+) -> tuple[str | None, str | None]:
     """Send an initialize handshake to establish a new MCP session.
 
     Used to recover after a session expires (server returns 404 on the
@@ -879,14 +879,18 @@ def _reinitialize(
     2. POST a ``notifications/initialized`` notification to signal
        readiness (required by the MCP spec before any other requests)
 
-    ``notifications/initialized`` is the first "subsequent request" of the
-    recovered session, so it carries the ``MCP-Protocol-Version`` header
-    when ``protocol_version`` is known. The initialize POST itself omits it
-    — it is the (re)negotiation and predates a known version.
+    The re-handshake may renegotiate a different protocol version than the
+    one originally captured (e.g. a downgrade), so the InitializeResult is
+    parsed for ``result.protocolVersion`` and the freshly negotiated value is
+    used for the ``notifications/initialized`` header and returned to the
+    caller. ``notifications/initialized`` is the first "subsequent request"
+    of the recovered session, so it carries ``MCP-Protocol-Version``; the
+    initialize POST itself omits it — it is the (re)negotiation and predates
+    a known version.
 
-    Returns the new session ID on success, or None on failure. The
-    initialize response payload is discarded — the caller only needs
-    the session ID for subsequent requests.
+    Returns ``(new_session_id, negotiated_protocol_version)``. The session id
+    is ``None`` on failure; the protocol version falls back to the passed-in
+    ``protocol_version`` when the response omits ``result.protocolVersion``.
     """
     initialize_msg = json.dumps(
         {
@@ -904,14 +908,29 @@ def _reinitialize(
         resp = client.post(url, content=initialize_msg, headers=headers)
     except httpx.HTTPError as e:
         log(f"re-initialize request failed: {e}")
-        return None
+        return None, protocol_version
     if resp.status_code != 200:
         log(f"re-initialize returned HTTP {resp.status_code}")
-        return None
+        return None, protocol_version
     new_session_id = resp.headers.get("mcp-session-id")
     if not new_session_id:
         log("re-initialize response missing mcp-session-id header")
-        return None
+        return None, protocol_version
+
+    # Re-capture the negotiated protocol version from the InitializeResult so
+    # the recovered session's header matches the version actually in force.
+    negotiated = protocol_version
+    if "text/event-stream" in resp.headers.get("content-type", ""):
+        for event_type, payload in _iter_sse_events(resp.text.splitlines()):
+            if event_type == "message":
+                pv = _extract_protocol_version(payload)
+                if pv:
+                    negotiated = pv
+                    break
+    else:
+        pv = _extract_protocol_version(resp.text.strip())
+        if pv:
+            negotiated = pv
 
     # MCP spec: send notifications/initialized before any other requests
     initialized_msg = json.dumps(
@@ -919,17 +938,17 @@ def _reinitialize(
     )
     initialized_headers = dict(headers)
     initialized_headers["Mcp-Session-Id"] = new_session_id
-    if protocol_version:
-        initialized_headers["MCP-Protocol-Version"] = protocol_version
+    if negotiated:
+        initialized_headers["MCP-Protocol-Version"] = negotiated
     try:
         resp = client.post(url, content=initialized_msg, headers=initialized_headers)
     except httpx.HTTPError as e:
         log(f"notifications/initialized failed: {e}")
-        return None
+        return None, protocol_version
     if resp.status_code not in (200, 202):
         log(f"notifications/initialized returned HTTP {resp.status_code}")
-        return None
-    return new_session_id
+        return None, protocol_version
+    return new_session_id, negotiated
 
 
 def check_connection(
@@ -1133,6 +1152,10 @@ def run(
                 nonlocal protocol_version
                 detected = _detect_paginated_list(content)
                 if detected:
+                    # The pagination branch never captures protocol_version.
+                    # That is correct because `initialize` is not in
+                    # PAGINATED_LIST_METHODS, so an initialize request can never
+                    # take this branch — keep that invariant if the table grows.
                     return _paginate_and_stream(
                         client, url, content, h, req_id, detected[1], tracker
                     )
@@ -1174,6 +1197,9 @@ def run(
                     req_headers = _prepare_headers()
                     result = _dispatch(line, req_headers)
                     if result is None:
+                        # Retries exhausted ⇒ the session may be stale too;
+                        # reset for symmetry with the top-level None handling.
+                        session_id = None
                         continue
                 else:
                     log("token refresh failed, returning error")
@@ -1196,6 +1222,9 @@ def run(
                         req_headers = _prepare_headers()
                         result = _dispatch(line, req_headers)
                         if result is None:
+                            # Retries exhausted ⇒ assume the session is stale,
+                            # for symmetry with the top-level None handling.
+                            session_id = None
                             continue
                     else:
                         log("step-up authorization failed, returning error")
@@ -1206,7 +1235,7 @@ def run(
             if result.status_code == 404 and session_id:
                 log("session expired, re-initializing and retrying")
                 session_id = None
-                new_session_id = _reinitialize(
+                new_session_id, renegotiated = _reinitialize(
                     client, url, dict(headers), protocol_version
                 )
                 if new_session_id is None:
@@ -1214,6 +1243,11 @@ def run(
                     _write_line(_error_response("session lost", req_id))
                     continue
                 session_id = new_session_id
+                # Track the re-negotiated version so the MCP-Protocol-Version
+                # header on the retried request matches the recovered session.
+                if renegotiated and renegotiated != protocol_version:
+                    log(f"re-negotiated MCP protocol version: {renegotiated}")
+                    protocol_version = renegotiated
                 req_headers = _prepare_headers()
                 result = _dispatch(line, req_headers)
                 if result is None:
@@ -1234,7 +1268,17 @@ def run(
 
 
 class _SseState:
-    """Shared state between SSE reader thread and main stdin loop."""
+    """Shared state between SSE reader thread and main stdin loop.
+
+    ``endpoint_url`` is written by the reader thread (set on the ``endpoint``
+    event, cleared to ``None`` on stream end / disconnect) and read by the main
+    loop. It is deliberately a plain single-word attribute relied upon to be
+    atomically published under the CPython GIL — no lock — because the only
+    consumer re-checks it after a local capture and emits "SSE endpoint
+    unavailable" if it raced to ``None``. A stale-after-reconnect read is
+    acceptable in practice: legacy SSE reconnect endpoints are stable. ``ready``
+    / ``stop`` are ``threading.Event``s, which carry their own synchronization.
+    """
 
     __slots__ = ("endpoint_url", "ready", "stop")
 
@@ -1433,6 +1477,16 @@ def run_sse(
         client.close()
         sys.exit(1)
 
+    def _snapshot_headers() -> dict[str, str]:
+        """Take a consistent copy of ``headers`` under the lock for a POST.
+
+        Symmetric with the reader thread's snapshot and the 401/403 mutations
+        so every cross-thread access to ``headers`` is serialised — no POST
+        ever iterates the dict while a refresh is updating it.
+        """
+        with headers_lock:
+            return dict(headers)
+
     try:
         for line in sys.stdin:
             line = line.strip()
@@ -1474,7 +1528,7 @@ def run_sse(
                     resp = client.post(
                         endpoint,
                         content=line,
-                        headers=headers,
+                        headers=_snapshot_headers(),
                         timeout=post_timeout,
                     )
                     if resp.status_code != 429:
@@ -1497,7 +1551,7 @@ def run_sse(
                         resp = client.post(
                             endpoint,
                             content=line,
-                            headers=headers,
+                            headers=_snapshot_headers(),
                             timeout=httpx.Timeout(
                                 connect=timeout_connect,
                                 read=timeout_read,
@@ -1526,7 +1580,7 @@ def run_sse(
                             resp = client.post(
                                 endpoint,
                                 content=line,
-                                headers=headers,
+                                headers=_snapshot_headers(),
                                 timeout=httpx.Timeout(
                                     connect=timeout_connect,
                                     read=timeout_read,

--- a/tests/test_relay.py
+++ b/tests/test_relay.py
@@ -530,6 +530,46 @@ class TestRun:
         assert replay_body["method"] == "call"
         assert replay_body["id"] == 2
 
+    def test_401_retry_exhaustion_resets_session_id(self, httpx_mock):
+        """When a 401-refresh retry exhausts all retries (connection dead), the
+        session id is reset — the next request must not re-send a maybe-stale
+        Mcp-Session-Id, matching the top-level retries-exhausted policy."""
+        # 1: init -> establishes sess-1
+        httpx_mock.add_response(
+            text='{"jsonrpc":"2.0","result":{},"id":1}',
+            headers={"content-type": "application/json", "mcp-session-id": "sess-1"},
+        )
+        # 2: call -> 401 (triggers refresh)
+        httpx_mock.add_response(
+            status_code=401, text="", headers={"content-type": "application/json"}
+        )
+        # 3-5: refreshed retry exhausts all retries with connection errors
+        for _ in range(MAX_RETRIES):
+            httpx_mock.add_exception(httpx.ConnectError("dead"))
+        # 6: a later call -> 200 (must carry NO session header)
+        httpx_mock.add_response(
+            text='{"jsonrpc":"2.0","result":{},"id":3}',
+            headers={"content-type": "application/json"},
+        )
+
+        def refresher():
+            return {"Authorization": "Bearer new"}
+
+        with patch("mcp_stdio.relay.time.sleep"):
+            self._run_with_stdin(
+                httpx_mock,
+                [
+                    '{"jsonrpc":"2.0","method":"init","id":1}',
+                    '{"jsonrpc":"2.0","method":"call","id":2}',
+                    '{"jsonrpc":"2.0","method":"call","id":3}',
+                ],
+                token_refresher=refresher,
+            )
+
+        reqs = httpx_mock.get_requests()
+        # The final request must not carry the (possibly stale) session id.
+        assert "mcp-session-id" not in reqs[-1].headers
+
     def test_reinitialize_failure_returns_error(self, httpx_mock):
         """If the post-404 re-initialize fails, we surface a JSON-RPC error
         instead of silently dropping the original request."""
@@ -891,6 +931,49 @@ class TestProtocolVersionHeader:
         assert "mcp-protocol-version" not in reqs[2].headers  # renegotiation
         assert reqs[3].headers["mcp-protocol-version"] == "2025-06-18"
         assert reqs[4].headers["mcp-protocol-version"] == "2025-06-18"
+
+    def test_reinitialize_recaptures_renegotiated_version(self, httpx_mock):
+        """If the 404-recovery handshake renegotiates a DIFFERENT version, the
+        gateway must switch to it — not keep injecting the stale original."""
+        # 1: initialize -> negotiate 2025-06-18, session sess-1
+        httpx_mock.add_response(
+            text='{"jsonrpc":"2.0","result":{"protocolVersion":"2025-06-18"},"id":1}',
+            headers={"content-type": "application/json", "mcp-session-id": "sess-1"},
+        )
+        # 2: tools/call -> 404 (session expired)
+        httpx_mock.add_response(
+            status_code=404, text="", headers={"content-type": "application/json"}
+        )
+        # 3: reinit initialize -> server DOWNGRADES to 2024-11-05, new session
+        httpx_mock.add_response(
+            text='{"jsonrpc":"2.0","result":{"protocolVersion":"2024-11-05"},"id":0}',
+            headers={"content-type": "application/json", "mcp-session-id": "sess-2"},
+        )
+        # 4: reinit notifications/initialized -> 202
+        httpx_mock.add_response(status_code=202, text="")
+        # 5: tools/call retry -> 200
+        httpx_mock.add_response(
+            text='{"jsonrpc":"2.0","result":{},"id":2}',
+            headers={"content-type": "application/json"},
+        )
+        # 6: a later request -> 200 (must still carry the renegotiated version)
+        httpx_mock.add_response(
+            text='{"jsonrpc":"2.0","result":{},"id":3}',
+            headers={"content-type": "application/json"},
+        )
+        self._run_with_stdin(
+            [
+                '{"jsonrpc":"2.0","method":"initialize","id":1}',
+                '{"jsonrpc":"2.0","method":"tools/call","id":2}',
+                '{"jsonrpc":"2.0","method":"tools/call","id":3}',
+            ]
+        )
+        reqs = httpx_mock.get_requests()
+        # reqs: 0=init, 1=call(404), 2=reinit-init, 3=reinit-initialized,
+        #       4=call-retry, 5=later-call
+        assert reqs[3].headers["mcp-protocol-version"] == "2024-11-05"
+        assert reqs[4].headers["mcp-protocol-version"] == "2024-11-05"
+        assert reqs[5].headers["mcp-protocol-version"] == "2024-11-05"
 
 
 # --- step-up authorization (anthropics/claude-code#44652) ---


### PR DESCRIPTION
Round-2 fixes from a re-review of the main branch. All findings were low/nit — no behavioral bugs, hangs, data loss, or security issues — so these are correctness/robustness/clarity refinements.

## Findings fixed

### `session_id` reset symmetry (low)
The top-level "retries exhausted ⇒ assume session stale" reset (`session_id = None`) was not applied in the 401/403 recovery branches when their re-dispatch also returned `None`, so a possibly-dead session id was re-sent on the next stdin line. Now reset in both branches.

### Re-negotiated protocol version after 404 recovery (low)
`_reinitialize` hardcoded the `2024-11-05` offer and discarded the response, while `run()` kept injecting the originally-negotiated `MCP-Protocol-Version`. If the server re-negotiated a different (e.g. downgraded) version, the header went stale. `_reinitialize` now parses `result.protocolVersion` from the handshake response, uses it for `notifications/initialized`, and returns it so `run()` tracks it. (Return type is now `(session_id, protocol_version)`.)

### SSE POST header lock symmetry (low)
`run_sse`'s main-loop POSTs read the shared `headers` dict lock-free while the reader snapshot and the 401/403 mutations hold `headers_lock`. Added a `_snapshot_headers()` helper that copies under the lock, used at all three POST sites — removing the reliance on an unasserted single-writer invariant.

### Docs (nit)
Documented `_SseState.endpoint_url`'s GIL-published cross-thread contract, and noted the pagination branch intentionally skips protocol-version capture (initialize is never a paginated method).

## Tests
+2 tests: 404 recovery re-captures a downgraded `protocolVersion` and applies it to the retried + subsequent requests; a 401-refresh retry exhaustion resets `session_id` so the next request omits `Mcp-Session-Id`. Suite: **479 passed, 3 skipped**; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)