### PR TITLE
fix(cli): reject negative --timeout-connect/--timeout-read/--sse-read-timeout

### DIFF
--- a/src/mcp_stdio/cli.py
+++ b/src/mcp_stdio/cli.py
@@ -221,19 +221,19 @@ def main() -> None:
     )
     parser.add_argument(
         "--timeout-connect",
-        type=float,
+        type=_non_negative_float,
         default=10,
         help="Connection timeout in seconds (default: 10)",
     )
     parser.add_argument(
         "--timeout-read",
-        type=float,
+        type=_non_negative_float,
         default=120,
         help="Read timeout in seconds (default: 120)",
     )
     parser.add_argument(
         "--sse-read-timeout",
-        type=float,
+        type=_non_negative_float,
         default=300,
         help=(
             "Idle read timeout (seconds) on the SSE GET stream "

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -195,6 +195,39 @@ class TestMain:
             assert exc_info.value.code == 2  # argparse error
         assert "must be >= 0" in capsys.readouterr().err
 
+    @pytest.mark.parametrize(
+        "flag", ["--timeout-connect", "--timeout-read", "--sse-read-timeout"]
+    )
+    def test_negative_timeouts_rejected(self, flag, capsys):
+        """Negative duration flags are rejected at parse time, consistent with
+        --oauth-refresh-leeway, instead of flowing into httpx.Timeout."""
+        with patch(
+            "sys.argv", ["mcp-stdio", flag, "-5", "https://example.com/mcp"]
+        ):
+            with pytest.raises(SystemExit) as exc_info:
+                main()
+            assert exc_info.value.code == 2
+        assert "must be >= 0" in capsys.readouterr().err
+
+    def test_sse_read_timeout_zero_still_accepted(self):
+        """--sse-read-timeout 0 (disable) must remain valid — 0 is allowed."""
+        with (
+            patch(
+                "sys.argv",
+                [
+                    "mcp-stdio",
+                    "--transport",
+                    "sse",
+                    "--sse-read-timeout",
+                    "0",
+                    "https://example.com/mcp",
+                ],
+            ),
+            patch("mcp_stdio.cli.run_sse") as mock_run_sse,
+        ):
+            main()
+            assert mock_run_sse.call_args.kwargs["sse_read_timeout"] == 0.0
+
     def test_oauth_refresh_leeway_invalid_env_var_rejected(self, monkeypatch, capsys):
         """#56: invalid env var values surface as argparse errors, not ValueError."""
         monkeypatch.setenv("MCP_OAUTH_REFRESH_LEEWAY", "not-a-number")


### PR DESCRIPTION
Round-2 fix from a re-review of the main branch (low).

`--oauth-refresh-leeway` already rejects negatives via `_non_negative_float`, but the three duration flags used the bare `float` type, so a typo like `--timeout-connect -5` silently flowed into `httpx.Timeout` (which accepts negative values) instead of producing a clear `error: value must be >= 0`. Applied `_non_negative_float` to all three; it permits 0, preserving `--sse-read-timeout 0` as the disable escape hatch.

## Tests
+4 tests: each of `--timeout-connect` / `--timeout-read` / `--sse-read-timeout` rejects `-5` at parse time; `--sse-read-timeout 0` stays valid and is passed through to `run_sse`. ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)