### PR TITLE
fix(relay): split inbound SSE on CR/LF/CRLF only (U+2028/U+2029/U+0085 corruption)

### DIFF
--- a/src/mcp_stdio/relay.py
+++ b/src/mcp_stdio/relay.py
@@ -484,6 +484,54 @@ def _parse_www_authenticate_scope(header: str | None) -> str | None:
     return None
 
 
+# WHATWG Server-Sent Events recognises only CR, LF, and CRLF as line
+# terminators. Python's ``str.splitlines()`` and httpx's ``iter_lines`` split on
+# a much larger set (``\n \r \x0b \x0c \x1c \x1d \x1e \x85 U+2028 U+2029``), but
+# U+2028 / U+2029 / U+0085 are legal *unescaped* inside JSON strings (RFC 8259).
+# Splitting an SSE ``data:`` payload on one of them tears the JSON-RPC message in
+# half — the first fragment is emitted truncated and the continuation is dropped
+# as an unknown field. This is the inbound mirror of the outbound hazard
+# ``_escape_js_line_separators`` already guards (typescript-sdk#2155), so the SSE
+# decoders below split on CR/LF/CRLF only.
+_SSE_LINE_SPLIT_RE = re.compile(r"\r\n|\r|\n")
+
+
+def _split_sse_text(text: str) -> list[str]:
+    """Split a fully-buffered SSE body into lines on CR / LF / CRLF only."""
+    return _SSE_LINE_SPLIT_RE.split(text)
+
+
+def _iter_sse_lines(chunks: Iterable[str]) -> Iterator[str]:
+    """Yield SSE lines from a text-chunk stream, splitting on CR/LF/CRLF only.
+
+    Buffers across chunk boundaries so a ``\\r\\n`` straddling two chunks counts
+    as a single terminator (a trailing ``\\r`` is held back until the next chunk
+    resolves whether it is a lone CR or the first half of a CRLF). The final
+    unterminated remainder is yielded last. Used for the streaming SSE paths,
+    where httpx's ``iter_lines`` would over-split (see ``_SSE_LINE_SPLIT_RE``).
+    """
+    buf = ""
+    for chunk in chunks:
+        if not chunk:
+            continue
+        buf += chunk
+        hold = ""
+        if buf.endswith("\r"):
+            # A trailing CR may be the first half of a CRLF whose LF is in the
+            # next chunk; hold it so the pair is not split into two lines.
+            hold = "\r"
+            buf = buf[:-1]
+        parts = _SSE_LINE_SPLIT_RE.split(buf)
+        buf = parts.pop() + hold
+        for line in parts:
+            yield line
+    if buf.endswith("\r"):
+        # A held CR at end of input is itself a terminator.
+        buf = buf[:-1]
+    if buf:
+        yield buf
+
+
 def _iter_sse_events(lines: Iterable[str]) -> Iterator[tuple[str, str]]:
     """Yield ``(event_type, data)`` pairs from SSE lines per the WHATWG spec.
 
@@ -582,7 +630,7 @@ def _post_and_stream(
                 pv: str | None = None
                 content_type = resp.headers.get("content-type", "")
                 if "text/event-stream" in content_type:
-                    for event_type, payload in _iter_sse_events(resp.iter_lines()):
+                    for event_type, payload in _iter_sse_events(_iter_sse_lines(resp.iter_text())):
                         if event_type != "message":
                             continue
                         if capture_init and pv is None:
@@ -664,7 +712,7 @@ def _post_parsed(
 
             content_type = resp.headers.get("content-type", "")
             if "text/event-stream" in content_type:
-                for event_type, payload in _iter_sse_events(resp.text.splitlines()):
+                for event_type, payload in _iter_sse_events(_split_sse_text(resp.text)):
                     if event_type != "message":
                         continue
                     try:
@@ -921,7 +969,7 @@ def _reinitialize(
     # the recovered session's header matches the version actually in force.
     negotiated = protocol_version
     if "text/event-stream" in resp.headers.get("content-type", ""):
-        for event_type, payload in _iter_sse_events(resp.text.splitlines()):
+        for event_type, payload in _iter_sse_events(_split_sse_text(resp.text)):
             if event_type == "message":
                 pv = _extract_protocol_version(payload)
                 if pv:
@@ -998,7 +1046,7 @@ def check_connection(
         result_data: dict[str, Any] | None = None
 
         if "text/event-stream" in content_type:
-            for event_type, payload in _iter_sse_events(resp.text.splitlines()):
+            for event_type, payload in _iter_sse_events(_split_sse_text(resp.text)):
                 if event_type != "message":
                     continue
                 try:
@@ -1324,7 +1372,7 @@ def _sse_reader_loop(
                     state.ready.set()
                     return
 
-                for event_type, data in _iter_sse_events(resp.iter_lines()):
+                for event_type, data in _iter_sse_events(_iter_sse_lines(resp.iter_text())):
                     if state.stop.is_set():
                         return
                     if event_type == "endpoint":

--- a/tests/test_relay.py
+++ b/tests/test_relay.py
@@ -28,11 +28,13 @@ from mcp_stdio.relay import (
     _extract_id,
     _handle_rate_limit,
     _iter_sse_events,
+    _iter_sse_lines,
     _make_httpx_transport,
     _normalize_null_arguments,
     _parse_retry_after,
     _parse_www_authenticate_scope,
     _post_and_stream,
+    _split_sse_text,
     _sse_reader_loop,
     _tcp_keepalive_socket_options,
     _write_line,
@@ -295,6 +297,31 @@ class TestPostAndStream:
             _post_and_stream(client, "https://example.com/mcp", '{"id":1}', {}, 1)
         assert stdout.getvalue().strip() == "a\nb\nc"
 
+    def test_sse_payload_with_raw_unicode_separators_not_corrupted(self, httpx_mock):
+        """A spec-compliant server SSE-framing a JSON-RPC response whose string
+        value contains a raw U+2028/U+2029/U+0085 must reach stdout whole — not
+        torn in half by over-eager inbound line splitting."""
+        seps = "\u2028\u2029\x85"  # escapes in source; raw chars go on the wire
+        payload = json.dumps(
+            {"jsonrpc": "2.0", "result": {"text": f"a{seps}b"}, "id": 1},
+            ensure_ascii=False,
+        )
+        httpx_mock.add_response(
+            stream=IteratorStream([f"data:{payload}\n\n".encode()]),
+            headers={"content-type": "text/event-stream"},
+        )
+        client = httpx.Client()
+        stdout = StringIO()
+        with patch("sys.stdout", stdout):
+            _post_and_stream(client, "https://example.com/mcp", '{"id":1}', {}, 1)
+        out = stdout.getvalue().strip()
+        # One NDJSON line (split on LF, the wire delimiter); U+2028/U+2029 are
+        # escaped (the JS line terminators that break clients) and the payload
+        # round-trips losslessly to all three separators intact.
+        assert len(out.split("\n")) == 1
+        assert "\u2028" not in out and "\u2029" not in out  # outbound-escaped
+        assert json.loads(out)["result"]["text"] == f"a{seps}b"
+
     def test_midstream_failure_does_not_retry_or_duplicate(self, httpx_mock):
         """A transient error AFTER a payload was delivered must not replay the
         non-idempotent POST (which would duplicate the response). Instead a
@@ -382,6 +409,43 @@ class TestIterSseEvents:
 
     def test_event_without_data_not_dispatched(self):
         assert list(_iter_sse_events(["event:message", ""])) == []
+
+
+class TestSseLineSplitting:
+    """SSE lines split on CR/LF/CRLF only — NOT the wider str.splitlines() set
+    that would tear a JSON payload containing raw U+2028/U+2029/U+0085."""
+
+    # U+2028 LINE SEP, U+2029 PARAGRAPH SEP, U+0085 NEL, plus VT/FF/FS/GS/RS —
+    # all legal unescaped inside JSON strings (RFC 8259) but split by
+    # str.splitlines(). Written as escapes; the raw chars exist only at runtime.
+    SEPS = "\u2028\u2029\x85\x0b\x0c\x1c\x1d\x1e"
+
+    def test_split_sse_text_only_cr_lf_crlf(self):
+        assert _split_sse_text("a\r\nb\nc\rd") == ["a", "b", "c", "d"]
+
+    def test_split_sse_text_preserves_unicode_separators(self):
+        text = f'data:{{"t":"x{self.SEPS}y"}}\n\n'
+        lines = _split_sse_text(text)
+        # The separators stay inside the single data: line, not split out.
+        assert lines[0] == f'data:{{"t":"x{self.SEPS}y"}}'
+
+    def test_iter_sse_lines_only_cr_lf_crlf(self):
+        assert list(_iter_sse_lines(["a\r", "\nb\n", "c"])) == ["a", "b", "c"]
+
+    def test_iter_sse_lines_crlf_across_chunk_boundary(self):
+        # A \r\n straddling two chunks must count as one terminator.
+        assert list(_iter_sse_lines(["line1\r", "\nline2\n"])) == ["line1", "line2"]
+
+    def test_iter_sse_lines_lone_cr_across_chunks(self):
+        assert list(_iter_sse_lines(["line1\r", "line2"])) == ["line1", "line2"]
+
+    def test_iter_sse_lines_preserves_unicode_separators(self):
+        chunks = [f'data:{{"t":"x{self.SEPS}', 'y"}\n\n']
+        lines = list(_iter_sse_lines(chunks))
+        assert lines[0] == f'data:{{"t":"x{self.SEPS}y"}}'
+
+    def test_iter_sse_lines_trailing_cr_at_eof(self):
+        assert list(_iter_sse_lines(["abc\r"])) == ["abc"]
 
 
 # --- run (integration) ---
@@ -1641,6 +1705,21 @@ class TestCheckConnection:
             'data:{"jsonrpc":"2.0","id":1,"result":'
             '{"protocolVersion":"2024-11-05","serverInfo":{"name":"sse","version":"0.1"},'
             '"capabilities":{}}}\n\n'
+        )
+        httpx_mock.add_response(
+            text=body,
+            headers={"content-type": "text/event-stream"},
+        )
+        assert check_connection(self.URL, dict(self.HEADERS)) is True
+
+    def test_sse_initialize_with_raw_unicode_separator(self, httpx_mock):
+        """A raw U+2028 in the serverInfo string of an SSE-framed initialize
+        must not split the buffered data: line — --check still parses it."""
+        name = "demo" + chr(0x2028) + "server"  # real U+2028 on the wire
+        body = (
+            f'data:{{"jsonrpc":"2.0","id":1,"result":'
+            f'{{"protocolVersion":"2024-11-05",'
+            f'"serverInfo":{{"name":"{name}","version":"1"}},"capabilities":{{}}}}}}\n\n'
         )
         httpx_mock.add_response(
             text=body,


### PR DESCRIPTION
**High-severity inbound data-corruption fix** surfaced by a round-3 re-review.

## The bug
All five SSE-decode sites fed lines into `_iter_sse_events` via `resp.iter_lines()` (streaming) or `resp.text.splitlines()` (buffered). Both split on Python's full `str.splitlines()` set — which includes **U+2028, U+2029, U+0085** and the C0/C1 separators — but WHATWG SSE recognises only **CR, LF, CRLF** as line terminators, and RFC 8259 permits U+2028/U+2029/U+0085 **unescaped inside JSON strings**.

So a fully spec-compliant server (any `ensure_ascii=False` serializer over documents, code, or non-ASCII text) that SSE-frames a response containing one of these characters had its single `data:` line **torn in two**: `_iter_sse_events` emitted only the truncated first half (unparseable, `Unterminated string`) and dropped the continuation as an unknown field — **silent payload loss** on both transports and in the pagination path.

This is the inbound mirror of the outbound hazard `_escape_js_line_separators` already guards (typescript-sdk#2155): the gateway escaped these chars going **out** to the client but corrupted them coming **in** from the server before parsing.

## The fix
Added `_split_sse_text` (buffered) and `_iter_sse_lines` (streaming — buffers across chunk boundaries so a CRLF straddling two chunks counts as one terminator) that split on **CR/LF/CRLF only**, and routed all five SSE-decode sites through them. Streaming sites now feed from `resp.iter_text()` instead of `resp.iter_lines()`.

## Tests
+9 tests: splitter units (terminator handling, CRLF-across-chunks, lone CR at EOF, separator preservation); `_post_and_stream` end-to-end with a raw U+2028/U+2029/U+0085 payload reaching stdout whole (U+2028/U+2029 outbound-escaped, lossless round-trip); `check_connection` buffered path with a raw U+2028 in `serverInfo`. (No raw separator bytes in test source — all `chr()`/`\u` escapes per project convention.) Suite: **496 passed, 3 skipped**; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)