### PR TITLE
fix(token_store): stop concurrent-migration clobber; harden _normalize_key

### DIFF
--- a/src/mcp_stdio/token_store.py
+++ b/src/mcp_stdio/token_store.py
@@ -44,14 +44,23 @@ def _normalize_key(server_url: str) -> str:
     indicator, so end-to-end behaviour is unchanged. Anything that does not
     parse as http(s) with a host is returned unchanged.
     """
+    # ``urlsplit`` is lazy: ``.hostname`` / ``.port`` are what actually raise
+    # ValueError on a malformed authority (e.g. a non-numeric or out-of-range
+    # port), so the whole parse must sit inside the try to honour the
+    # return-unchanged-on-failure contract.
     try:
         parsed = urlsplit(server_url)
+        if parsed.scheme not in ("http", "https") or not parsed.hostname:
+            return server_url
+        host = parsed.hostname  # urlsplit lowercases the host and strips userinfo
+        port = parsed.port
     except ValueError:
         return server_url
-    if parsed.scheme not in ("http", "https") or not parsed.hostname:
-        return server_url
-    host = parsed.hostname  # urlsplit lowercases the host and strips userinfo
-    port = parsed.port
+    # ``hostname`` strips the brackets from an IPv6 literal; re-add them so the
+    # rebuilt netloc is a valid, re-parsable URL and ``[::1]:8443`` cannot
+    # collide with another address whose final hextet equals a port.
+    if ":" in host:
+        host = f"[{host}]"
     if port is not None and port != _DEFAULT_PORTS.get(parsed.scheme):
         netloc = f"{host}:{port}"
     else:
@@ -117,20 +126,30 @@ def _migrate_legacy_store() -> None:
             _LEGACY_STORE_FILE.rename(_STORE_FILE)
             os.chmod(_STORE_FILE, stat.S_IRUSR | stat.S_IWUSR)
         except OSError:
-            # rename() raises EXDEV when the legacy and XDG paths are on
-            # different filesystems. Fall back to copy-via-_write_store (which
-            # creates the target 0o600 and atomically replaces) so a
-            # cross-device layout cannot brick every token operation.
-            try:
-                data = json.loads(_LEGACY_STORE_FILE.read_text())
-            except (json.JSONDecodeError, OSError):
-                data = {}
-            if isinstance(data, dict):
-                _write_store(data)
-            try:
-                _LEGACY_STORE_FILE.unlink()
-            except OSError:
-                pass
+            # rename() can fail for two reasons:
+            #  - EXDEV: the legacy and XDG paths are on different filesystems.
+            #  - a concurrent migration (this runs unlocked from load_token)
+            #    already moved the legacy file — racer A's rename() succeeded
+            #    and unlinked the source, so racer B's rename() raises ENOENT.
+            # Only copy-through when the target is still ABSENT and the legacy
+            # file still has REAL data. Guarding on existence is what prevents
+            # the catastrophe: without it, the ENOENT racer would read the now
+            # gone legacy file as {} and _write_store({}) would clobber the
+            # just-migrated store, silently destroying every cached token.
+            if _STORE_FILE.exists() or not _LEGACY_STORE_FILE.exists():
+                pass  # another process won the migration race — leave it intact
+            else:
+                try:
+                    data = json.loads(_LEGACY_STORE_FILE.read_text())
+                except (json.JSONDecodeError, OSError):
+                    data = None
+                # Never write an empty/failed read over the target.
+                if isinstance(data, dict) and data:
+                    _write_store(data)
+                    try:
+                        _LEGACY_STORE_FILE.unlink()
+                    except OSError:
+                        pass
     # Remove legacy directory if empty
     try:
         _LEGACY_STORE_DIR.rmdir()

--- a/tests/test_token_store.py
+++ b/tests/test_token_store.py
@@ -1,5 +1,6 @@
 """Tests for mcp_stdio.token_store module."""
 
+import json
 import os
 import stat
 import sys
@@ -246,6 +247,23 @@ class TestNormalizeKey:
     def test_non_http_returned_unchanged(self):
         assert _normalize_key("not a url") == "not a url"
 
+    def test_malformed_port_returned_unchanged_not_raised(self):
+        """A non-numeric / out-of-range port must not raise (the ValueError
+        comes from the lazy .port access) — return the URL verbatim."""
+        assert (
+            _normalize_key("http://example.com:notaport/mcp")
+            == "http://example.com:notaport/mcp"
+        )
+        huge = "https://example.com:99999999999999999999/mcp"
+        assert _normalize_key(huge) == huge
+
+    def test_ipv6_brackets_preserved(self):
+        """IPv6 literals keep their brackets so the key is re-parsable and two
+        addresses cannot collide via the host/port colon ambiguity."""
+        assert _normalize_key("https://[::1]:8443/mcp") == "https://[::1]:8443/mcp"
+        # Default port still folds out, brackets retained.
+        assert _normalize_key("https://[::1]:443/mcp") == "https://[::1]/mcp"
+
 
 class TestKeyNormalizationInStore:
     def _patch(self, tmp_path, monkeypatch):
@@ -340,6 +358,46 @@ class TestLegacyMigration:
         assert loaded is not None and loaded.access_token == "old"
         assert new_file.exists()
         assert not legacy_file.exists()
+
+    def test_concurrent_migration_race_does_not_clobber_store(
+        self, tmp_path, monkeypatch
+    ):
+        """If a concurrent migration already moved the legacy file (racer B's
+        rename raises ENOENT after racer A migrated), the fallback must NOT
+        overwrite the just-migrated store with an empty dict — the cached
+        tokens must survive."""
+        legacy_dir = tmp_path / "legacy"
+        legacy_file = legacy_dir / "tokens.json"
+        new_dir = tmp_path / "new"
+        new_file = new_dir / "tokens.json"
+        legacy_dir.mkdir()
+        legacy_file.write_text(
+            '{"https://example.com/mcp": {"access_token": "SECRET"}}'
+        )
+
+        monkeypatch.setattr("mcp_stdio.token_store._STORE_DIR", new_dir)
+        monkeypatch.setattr("mcp_stdio.token_store._STORE_FILE", new_file)
+        monkeypatch.setattr("mcp_stdio.token_store._LEGACY_STORE_DIR", legacy_dir)
+        monkeypatch.setattr("mcp_stdio.token_store._LEGACY_STORE_FILE", legacy_file)
+
+        real_rename = os.rename
+
+        def racing_rename(src, dst, *a, **k):
+            # Simulate racer A winning between our exists()-check and rename():
+            # actually migrate, then raise ENOENT as racer B would observe.
+            new_dir.mkdir(parents=True, exist_ok=True)
+            real_rename(src, dst)
+            raise FileNotFoundError(2, "No such file or directory")
+
+        monkeypatch.setattr("mcp_stdio.token_store.os.rename", racing_rename)
+        loaded = load_token("https://example.com/mcp")
+        monkeypatch.setattr("mcp_stdio.token_store.os.rename", real_rename)
+
+        # The migrated token must still be there — not clobbered to {}.
+        assert loaded is not None and loaded.access_token == "SECRET"
+        assert json.loads(new_file.read_text()) == {
+            "https://example.com/mcp": {"access_token": "SECRET"}
+        }
 
     def test_migrate_legacy_to_xdg(self, tmp_path, monkeypatch):
         """Legacy ~/.mcp-stdio/tokens.json is moved to new XDG path."""


### PR DESCRIPTION
Round-3 re-review surfaced a **high-severity data-loss regression** plus two `_normalize_key` correctness gaps.

## Findings fixed

### Concurrent-migration clobber → silent total token loss (high)
`_migrate_legacy_store` runs **unlocked** from `load_token`, so two processes (e.g. multiple MCP clients autostarting after an upgrade/reboot) can both pass the `exists()` guards and enter the move branch. Racer A's `rename()` succeeds and unlinks the legacy file; racer B's `rename()` then raises **ENOENT**, which the EXDEV `except OSError` caught — the fallback read the now-missing legacy file as `{}` and `_write_store({})` **overwrote the just-migrated store**, silently destroying every cached OAuth token on first run after upgrade (forcing re-auth of every server).

Fix: guard the fallback on file existence — only copy-through when the target is still **absent** AND the legacy file still has **real data** — and never write an empty/failed read over the target.

### `_normalize_key` ValueError leak (low)
The `try` wrapped only `urlsplit()`, but `urlsplit` is lazy — `.hostname`/`.port` are what raise `ValueError` on a malformed port (e.g. `:notaport`, out-of-range). That propagated out of `load`/`save`/`delete_token`. Widened the `try` to cover the attribute accesses, honouring the return-unchanged-on-failure contract.

### `_normalize_key` IPv6 brackets (low)
`urlsplit().hostname` strips the brackets from an IPv6 literal, so `[::1]:8443` produced the unparsable/ambiguous key `::1:8443`. Re-bracket IPv6 hosts when rebuilding the netloc.

## Tests
+3 tests: concurrent-migration race (ENOENT after a racer migrated) keeps the `SECRET` token instead of clobbering to `{}`; malformed port returns unchanged without raising; IPv6 brackets preserved with default-port folding. Suite: **490 passed, 3 skipped**; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)