### PR TITLE
docs: scope the How-It-Works 401-refresh step to OAuth mode

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -218,7 +218,7 @@ Claude Code・mcp-remote・Windows の既知の問題については [WORKAROUND
 2. stdin から JSON-RPC メッセージを読み取り（Claude Desktop/Code が送信）
 3. HTTPS でリモート MCP サーバーへ転送
 4. レスポンスをパースして stdout に書き出し
-5. 401 で OAuth トークンをリフレッシュしてリトライ
+5. 401 で（OAuth モードのみ）アクセストークンをリフレッシュしてリトライ。静的な `--bearer-token` / `-H` 認証では 401 をそのままクライアントに返す
 
 トランスポート別の挙動：
 

--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ See [WORKAROUNDS.md](WORKAROUNDS.md) for known issues in Claude Code, mcp-remote
 2. Reads JSON-RPC messages from stdin (sent by Claude Desktop/Code)
 3. Relays them over HTTPS to the remote MCP server
 4. Parses responses and writes them to stdout
-5. On 401, refreshes the OAuth token and retries
+5. On 401 (OAuth mode only), refreshes the access token and retries; with static `--bearer-token` / `-H` auth the 401 is surfaced to the client
 
 Transport details:
 


### PR DESCRIPTION
Round-3 re-review (nit). "How It Works" step 5 read "On 401, refreshes the OAuth token and retries", which could be read as unconditional. 401-triggered refresh only fires when a `token_refresher` is wired — the `--oauth` / `--oauth-device` path; with static `--bearer-token` / `-H` auth a 401 is surfaced to the client. Clarified in both README.md and README.ja.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)