### PR TITLE
fix(token_store): tighten a pre-existing loose tokens.json mode on read

### DIFF
--- a/src/mcp_stdio/token_store.py
+++ b/src/mcp_stdio/token_store.py
@@ -162,6 +162,16 @@ def _read_store() -> dict[str, Any]:
     _migrate_legacy_store()
     if not _STORE_FILE.exists():
         return {}
+    # Opportunistically tighten the file mode on read, mirroring the directory
+    # re-chmod in _ensure_store_dir. _write_store always creates the file 0o600,
+    # but a tokens.json that pre-exists with looser permissions (restored from a
+    # backup that lost mode bits, copied under a permissive umask, or written by
+    # a third-party tool) and is only ever read would otherwise keep its mode,
+    # leaving the secrets readable.
+    try:
+        os.chmod(_STORE_FILE, stat.S_IRUSR | stat.S_IWUSR)  # 0o600
+    except OSError:
+        pass
     try:
         return json.loads(_STORE_FILE.read_text())
     except (json.JSONDecodeError, OSError):

--- a/tests/test_token_store.py
+++ b/tests/test_token_store.py
@@ -160,6 +160,26 @@ class TestLoadSaveDelete:
         assert mode & stat.S_IRWXG == 0
         assert mode & stat.S_IRWXO == 0
 
+    @pytest.mark.skipif(
+        sys.platform == "win32",
+        reason="POSIX mode bits don't model NTFS ACLs",
+    )
+    def test_preexisting_loose_file_mode_tightened_on_read(self, tmp_path, monkeypatch):
+        """A tokens.json that pre-exists with loose perms (and is only read) is
+        tightened to 0o600 on read, not left world-readable."""
+        store_file = tmp_path / "tokens.json"
+        monkeypatch.setattr("mcp_stdio.token_store._STORE_DIR", tmp_path)
+        monkeypatch.setattr("mcp_stdio.token_store._STORE_FILE", store_file)
+
+        store_file.write_text('{"https://example.com/mcp": {"access_token": "t"}}')
+        os.chmod(store_file, 0o644)  # loose, as if restored from a backup
+
+        loaded = load_token("https://example.com/mcp")  # read-only path
+        assert loaded is not None and loaded.access_token == "t"
+        mode = os.stat(store_file).st_mode
+        assert mode & stat.S_IRWXG == 0
+        assert mode & stat.S_IRWXO == 0
+
     def test_concurrent_saves_of_distinct_keys_both_persist(
         self, tmp_path, monkeypatch
     ):


### PR DESCRIPTION
Round-4 re-review (low). `_ensure_store_dir` re-chmods the directory and `_write_store` always creates the file 0o600, but a `tokens.json` that **pre-exists with looser permissions** (restored from a backup that lost mode bits, copied under a permissive umask, or written by a third-party tool) and is only ever **read** would keep its mode, leaving the secrets readable. Now opportunistically chmod the file to 0o600 on read, mirroring the directory re-chmod.

Test: a pre-existing 0o644 `tokens.json` is tightened to 0o600 on the read-only `load_token` path. ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)