### PR TITLE
fix(cli): pin follow_redirects=False on the OAuth credential-bearing client

### DIFF
--- a/src/mcp_stdio/cli.py
+++ b/src/mcp_stdio/cli.py
@@ -87,7 +87,13 @@ def _build_token_refresher(
         client = httpx.Client(
             timeout=httpx.Timeout(
                 connect=timeout_connect, read=timeout_read, write=30, pool=10
-            )
+            ),
+            # AS-controlled redirects must never be auto-followed: a validated
+            # token endpoint could otherwise 302 the credential POST to a
+            # cleartext / cross-origin host, bypassing the #13 endpoint
+            # validators. httpx already defaults to False; pin it explicitly so
+            # the safety cannot regress.
+            follow_redirects=False,
         )
         try:
             data = refresh_cached_token(server_url, client)
@@ -121,7 +127,13 @@ def _build_scope_upgrader(
         client = httpx.Client(
             timeout=httpx.Timeout(
                 connect=timeout_connect, read=timeout_read, write=30, pool=10
-            )
+            ),
+            # AS-controlled redirects must never be auto-followed: a validated
+            # token endpoint could otherwise 302 the credential POST to a
+            # cleartext / cross-origin host, bypassing the #13 endpoint
+            # validators. httpx already defaults to False; pin it explicitly so
+            # the safety cannot regress.
+            follow_redirects=False,
         )
         try:
             data = step_up_authorize(server_url, client, required_scope)
@@ -355,7 +367,13 @@ def main() -> None:
                 read=args.timeout_read,
                 write=30,
                 pool=10,
-            )
+            ),
+            # Never auto-follow AS-controlled redirects on the OAuth flow — a
+            # validated token endpoint could otherwise 302 the credential POST
+            # (code + client_secret) to a cleartext / cross-origin host,
+            # bypassing the #13 endpoint validators. Explicit despite httpx's
+            # False default so the safety cannot regress.
+            follow_redirects=False,
         )
         try:
             token_data = ensure_token(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -559,12 +559,13 @@ class TestMain:
 
 
 class _SpyClient:
-    """httpx.Client stand-in that records whether close() was called."""
+    """httpx.Client stand-in that records close() and construction kwargs."""
 
     instances: list["_SpyClient"] = []
 
     def __init__(self, *a, **k):
         self.closed = False
+        self.kwargs = k
         _SpyClient.instances.append(self)
 
     def close(self):
@@ -589,6 +590,8 @@ class TestBuildTokenRefresher:
         assert out["Authorization"] == "Bearer fresh"
         assert out["X-Base"] == "1"  # base headers preserved
         assert _SpyClient.instances and _SpyClient.instances[-1].closed
+        # AS-controlled redirects must not be auto-followed on the OAuth flow.
+        assert _SpyClient.instances[-1].kwargs.get("follow_redirects") is False
 
     def test_returns_none_on_refresh_failure_and_closes(self, monkeypatch):
         _SpyClient.instances.clear()
@@ -648,3 +651,19 @@ class TestOAuthFailureExit:
                 main()
             assert exc_info.value.code == 1
         assert "OAuth authentication failed" in capsys.readouterr().err
+
+
+class TestOAuthClientHardening:
+    def test_oauth_client_disables_redirects(self, monkeypatch):
+        """The OAuth flow client must not auto-follow AS-controlled redirects."""
+        _SpyClient.instances.clear()
+        monkeypatch.setattr("mcp_stdio.cli.httpx.Client", _SpyClient)
+        with (
+            patch("sys.argv", ["mcp-stdio", "--oauth", "https://example.com/mcp"]),
+            patch("mcp_stdio.oauth.ensure_token") as mock_ensure,
+            patch("mcp_stdio.cli.run"),
+        ):
+            mock_ensure.return_value.access_token = "tok"
+            main()
+        assert _SpyClient.instances
+        assert _SpyClient.instances[0].kwargs.get("follow_redirects") is False


### PR DESCRIPTION
Round-4 re-review (low, defense-in-depth). The OAuth discovery / registration / token / device requests all use the `httpx.Client` built in cli.py, which relied on httpx's **default** `follow_redirects=False`. The #13 endpoint validators only screen the statically-declared metadata URLs, **not a runtime redirect `Location`** — so if redirects were ever enabled (a future httpx default change, or a caller flipping it), a validated token endpoint could 302 the credential POST (code + client_secret) to a cleartext / cross-origin host, bypassing all the validators. Now `follow_redirects=False` is pinned explicitly on all three OAuth clients so the safety cannot regress.

Tests: the refresher-closure client and the main `--oauth` client are both constructed with `follow_redirects=False`. ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)