### PR TITLE
fix(relay): cancel filter consume-on-match + untrack reused ids; SSE polish

### DIFF
--- a/src/mcp_stdio/relay.py
+++ b/src/mcp_stdio/relay.py
@@ -230,13 +230,16 @@ class _CancelTracker:
 
     Callers on the stdin side push ids with ``add(id)`` when they see a
     ``notifications/cancelled``; the response-emit path queries with
-    ``contains(id)`` and drops matching responses. Entries expire after
-    ``ttl`` seconds (monotonic clock — immune to NTP jumps), and the
-    internal map is opportunistically garbage-collected when it grows
-    past ``_CANCEL_GC_THRESHOLD`` entries so an adversarial peer cannot
-    leak memory. Both transports share one instance; the SSE reader
-    thread in ``run_sse`` reads concurrently with the main loop, hence
-    the lock.
+    ``consume(id)`` and drops a matching response. ``consume`` removes the
+    entry on the first match, so a cancelled id's late response is dropped
+    exactly once — a later request that legitimately *reuses* the same id
+    (permitted by JSON-RPC once the prior call is done) is then forwarded
+    normally instead of being dropped for the whole TTL window. Entries
+    expire after ``ttl`` seconds (monotonic clock — immune to NTP jumps),
+    and the internal map is opportunistically garbage-collected when it
+    grows past ``_CANCEL_GC_THRESHOLD`` entries so an adversarial peer cannot
+    leak memory. Both transports share one instance; the SSE reader thread
+    in ``run_sse`` reads concurrently with the main loop, hence the lock.
     """
 
     __slots__ = ("_seen", "_lock", "_ttl", "_now")
@@ -271,6 +274,33 @@ class _CancelTracker:
                 return False
             return True
 
+    def consume(self, req_id: Any) -> bool:
+        """Return True for a still-live cancelled id, removing it on match.
+
+        Consuming on the first match bounds the drop to a single response per
+        cancelled id, so a request that reuses the id within the TTL is not
+        collateral-dropped. An expired entry is also removed and returns False.
+        """
+        if req_id is None:
+            return False
+        with self._lock:
+            ts = self._seen.pop(req_id, None)
+            if ts is None:
+                return False
+            return self._now() - ts <= self._ttl
+
+    def discard(self, req_id: Any) -> None:
+        """Untrack an id when the client forwards a fresh request reusing it.
+
+        A new request with a previously-cancelled id supersedes the cancel
+        (JSON-RPC permits id reuse once the prior call is done), so its response
+        must be delivered rather than dropped as a "late cancelled response".
+        """
+        if req_id is None:
+            return
+        with self._lock:
+            self._seen.pop(req_id, None)
+
     def _gc_locked(self) -> None:
         cutoff = self._now() - self._ttl
         expired = [k for k, ts in self._seen.items() if ts < cutoff]
@@ -285,6 +315,12 @@ def _extract_cancel_id(line: str) -> Any:
     stdin line — only cancellation notifications go through the slow
     path. Returns ``None`` if the line is not a cancellation (malformed
     JSON, wrong method, missing params, or missing requestId).
+
+    Only a single (non-batch) ``notifications/cancelled`` is tracked: a
+    cancellation buried inside a JSON-RPC batch array is intentionally not
+    extracted, consistent with the cancel filter passing batches through
+    untouched (the filter's narrow scope mirrors exactly what the spec
+    covers, and batch responses are forwarded verbatim).
     """
     if not _CANCELLED_METHOD_RE.search(line):
         return None
@@ -429,7 +465,7 @@ def _emit(line: str, tracker: "_CancelTracker | None") -> None:
         return
     rid = msg.get("id")
     if rid is not None and ("result" in msg or "error" in msg):
-        if tracker.contains(rid):
+        if tracker.consume(rid):
             log(f"dropped late response for cancelled id {rid!r}")
             return
     _write_line(line)
@@ -1193,6 +1229,10 @@ def run(
                     tracker.add(cid)
 
             req_id = _extract_id(line)
+            if tracker is not None and req_id is not None:
+                # A request reusing a previously-cancelled id supersedes that
+                # cancel — untrack it so its response is delivered, not dropped.
+                tracker.discard(req_id)
 
             req_headers = _prepare_headers()
 
@@ -1567,17 +1607,24 @@ def run_sse(
                 if cid is not None:
                     tracker.add(cid)
 
-            if state.endpoint_url is None:
-                if not state.ready.wait(timeout=timeout_read):
-                    req_id = _extract_id(line)
-                    _write_line(_error_response("SSE endpoint unavailable", req_id))
-                    continue
-
             req_id = _extract_id(line)
+            if tracker is not None and req_id is not None:
+                # A request reusing a previously-cancelled id supersedes that
+                # cancel — untrack it so its response is delivered, not dropped.
+                tracker.discard(req_id)
+            # Resolve the POST endpoint, waiting out a reconnect in progress.
+            # endpoint_url is published lock-free, so a reconnect may clear it in
+            # the TOCTOU window between this check and the read below; if the
+            # capture comes back None, wait on ``ready`` (up to timeout_read) and
+            # re-read once before giving up, rather than failing an otherwise
+            # recoverable in-flight request with a spurious error.
             endpoint = state.endpoint_url
             if endpoint is None:
-                _write_line(_error_response("SSE endpoint unavailable", req_id))
-                continue
+                if state.ready.wait(timeout=timeout_read):
+                    endpoint = state.endpoint_url
+                if endpoint is None:
+                    _write_line(_error_response("SSE endpoint unavailable", req_id))
+                    continue
 
             try:
                 post_timeout = httpx.Timeout(
@@ -1669,10 +1716,13 @@ def run_sse(
                 _write_line(_error_response(str(e), req_id))
     finally:
         state.stop.set()
-        # Give the reader a moment to observe stop at a checkpoint and exit its
-        # own stream context (closing the connection from the owning thread)
-        # before we close the client out from under it. The daemon flag already
-        # guarantees process exit is never blocked; this just avoids closing an
-        # in-flight GET stream from another thread.
+        # Set stop first, then briefly join so the reader can exit its own
+        # stream context when it next reaches a checkpoint. An *idle* GET (the
+        # steady state — the reader is parked in iter_text() between events)
+        # never reaches a checkpoint within the join, so client.close() below
+        # then tears down the pool under it; that is safe — the reader catches
+        # the resulting HTTPError and, because stop is already set, returns
+        # without logging a reconnect. The daemon flag guarantees process exit
+        # is never blocked regardless.
         reader.join(timeout=1.0)
         client.close()

--- a/tests/test_relay.py
+++ b/tests/test_relay.py
@@ -2185,6 +2185,92 @@ class TestSseReaderLoop:
         # Both GETs were issued (the first one raised, the second succeeded)
         assert len(httpx_mock.get_requests()) == 2
 
+    def test_clean_stream_end_triggers_reconnect(self, httpx_mock):
+        """A GET stream that ends *normally* (server closed it, no exception)
+        must reconnect — exercising the graceful-EOF reconnect branch, not the
+        HTTPError one."""
+        state = _SseState()
+
+        # First GET ends cleanly (generator returns without setting stop).
+        httpx_mock.add_response(
+            url=self.URL,
+            method="GET",
+            stream=IteratorStream([b"event: endpoint\ndata: /first\n\n"]),
+            headers={"content-type": "text/event-stream"},
+        )
+
+        # Second GET re-resolves a new endpoint, then ends the test.
+        def healthy_gen():
+            yield b"event: endpoint\ndata: /second\n\n"
+            state.stop.set()
+
+        httpx_mock.add_response(
+            url=self.URL,
+            method="GET",
+            stream=IteratorStream(healthy_gen()),
+            headers={"content-type": "text/event-stream"},
+        )
+
+        client = httpx.Client()
+        try:
+            with (
+                patch("sys.stdout", StringIO()),
+                patch("mcp_stdio.relay.RETRY_DELAY", 0),
+            ):
+                _sse_reader_loop(client, self.URL, {}, state)
+        finally:
+            client.close()
+
+        # The graceful EOF on GET #1 must have triggered GET #2.
+        assert state.endpoint_url == "https://example.com/second"
+        assert len(httpx_mock.get_requests()) == 2
+
+    def test_reconnect_resnapshot_uses_refreshed_headers(self, httpx_mock):
+        """When headers are mutated (as a 401 refresh would) between connects,
+        the reader's per-reconnect locked snapshot picks up the new value — the
+        reconnected GET carries the refreshed Authorization, not the stale one."""
+        state = _SseState()
+        headers = {"Authorization": "Bearer old"}
+        headers_lock = threading.Lock()
+        seen_auth: list[str | None] = []
+
+        def first_gen():
+            # End cleanly; simulate a mid-session token refresh by mutating the
+            # shared headers under the lock before the reader re-snapshots.
+            yield b"event: endpoint\ndata: /first\n\n"
+            with headers_lock:
+                headers["Authorization"] = "Bearer new"
+
+        def second_gen():
+            yield b"event: endpoint\ndata: /second\n\n"
+            state.stop.set()
+
+        def get_callback(request):
+            seen_auth.append(request.headers.get("authorization"))
+            gen = first_gen if len(seen_auth) == 1 else second_gen
+            return httpx.Response(
+                200,
+                stream=IteratorStream(gen()),
+                headers={"content-type": "text/event-stream"},
+            )
+
+        httpx_mock.add_callback(get_callback, url=self.URL, method="GET", is_reusable=True)
+
+        client = httpx.Client()
+        try:
+            with (
+                patch("sys.stdout", StringIO()),
+                patch("mcp_stdio.relay.RETRY_DELAY", 0),
+            ):
+                _sse_reader_loop(
+                    client, self.URL, headers, state, headers_lock=headers_lock
+                )
+        finally:
+            client.close()
+
+        assert seen_auth[0] == "Bearer old"
+        assert seen_auth[1] == "Bearer new"  # reconnect re-snapshotted the update
+
 
 class _BlockingStdin:
     """Stdin iterator that yields one line then blocks until released.
@@ -2974,6 +3060,26 @@ class TestCancelTracker:
         clock.advance(31)  # past 60 s
         assert not t.contains(5)
 
+    def test_consume_drops_once_then_id_reuse_passes(self):
+        """consume() removes the entry on first match, so a cancelled id's late
+        response is dropped exactly once; a reused id within the TTL passes."""
+        t = _CancelTracker()
+        t.add(7)
+        assert t.consume(7) is True  # the cancelled request's late response
+        assert t.consume(7) is False  # a reused id=7 now passes through
+
+    def test_consume_expired_returns_false_and_removes(self):
+        clock = _FakeClock()
+        t = _CancelTracker(ttl=60.0, now=clock)
+        t.add(5)
+        clock.advance(61)
+        assert t.consume(5) is False
+        # entry removed even though expired
+        assert t.consume(5) is False
+
+    def test_consume_none(self):
+        assert _CancelTracker().consume(None) is False
+
     def test_gc_bounds_memory(self):
         clock = _FakeClock()
         t = _CancelTracker(ttl=10.0, now=clock)
@@ -3222,13 +3328,16 @@ class TestRunCancelFilter:
         )
         assert '"ok":true' in output
 
-    def test_subsequent_response_for_cancelled_id_is_dropped(self, httpx_mock):
-        # Emits the cancel FIRST, then sends a subsequent request whose
-        # id collides with the cancelled one. The late response should
-        # be dropped.
-        httpx_mock.add_response(status_code=202, text="")  # cancel
+    def test_reused_id_after_cancel_is_forwarded(self, httpx_mock):
+        # A request that reuses a previously-cancelled id is a brand-new call;
+        # its response must be FORWARDED, not dropped (JSON-RPC permits id reuse
+        # once the prior call is done). Forwarding the new request untracks the
+        # cancel for that id. (The genuine "late response for an in-flight
+        # cancelled request is dropped" case is async-only — see
+        # TestRunSseCancelFilter.)
+        httpx_mock.add_response(status_code=202, text="")  # cancel ACK
         httpx_mock.add_response(
-            text='{"jsonrpc":"2.0","result":{"should":"drop"},"id":7}',
+            text='{"jsonrpc":"2.0","result":{"keep":true},"id":7}',
             headers={"content-type": "application/json"},
         )
         output = self._run_with_stdin(
@@ -3241,7 +3350,7 @@ class TestRunCancelFilter:
                 '{"jsonrpc":"2.0","method":"tools/call","id":7}',
             ],
         )
-        assert "drop" not in output
+        assert '"keep":true' in output
 
     def test_cancel_is_forwarded_upstream(self, httpx_mock):
         httpx_mock.add_response(status_code=202, text="")


### PR DESCRIPTION
Round-5 re-review (low + nits).

## Findings fixed
### Cancel filter id-reuse (low)
The cancel filter dropped **every** response carrying a cancelled id for the whole 60s TTL — but JSON-RPC permits reusing an id once the prior call is done, so a client that cancels id 7 and then issues a **brand-new** request with id 7 had its valid response silently dropped and hung. Fixed two ways:
- `_CancelTracker.consume()` removes the entry on first match → a cancelled id's late response is dropped **exactly once**.
- forwarding a fresh request with a tracked id calls `tracker.discard()` to untrack it → the reused request's response is delivered.

The genuine async late-response drop (SSE) is unaffected (no reuse there).

### endpoint_url TOCTOU (nit)
A stdin line arriving in the lock-free reconnect window could capture `endpoint_url` as `None` and immediately error; it now waits on `ready` (up to `timeout_read`) and re-reads once before giving up, so a recoverable reconnect is waited out.

### Docs (nits)
Softened the `run_sse` shutdown-join comment (an idle GET stream IS closed under the reader; that path is safe via the reader's stop-guarded `except`), and documented that a cancellation inside a JSON-RPC batch is intentionally not tracked (consistent with batch passthrough).

## Tests
+5: `consume` drops-once then reused id passes; reused-id-after-cancel forwarded end-to-end; clean stream-ended (graceful EOF) reconnect; reconnect re-snapshot picks up the refreshed `Authorization` under `headers_lock`. Suite: **525 passed, 3 skipped**; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)