### PR TITLE
fix(oauth): validate RFC 9207 iss; drop double-slash in default endpoints

### DIFF
--- a/src/mcp_stdio/oauth.py
+++ b/src/mcp_stdio/oauth.py
@@ -42,6 +42,9 @@ class OAuthMetadata:
     registration_endpoint: str | None = None
     device_authorization_endpoint: str | None = None
     token_endpoint_auth_methods_supported: list[str] | None = None
+    # RFC 8414 issuer identifier — used to validate the RFC 9207 ``iss``
+    # parameter on the authorization response (AS mix-up defence).
+    issuer: str | None = None
 
 
 # ---------------------------------------------------------------------------
@@ -296,6 +299,9 @@ def _fetch_authorization_server_metadata(
                     f"expected {auth_server_url!r}, got {issuer!r}"
                 )
             methods = data.get("token_endpoint_auth_methods_supported")
+            # Strip a trailing slash before building default endpoints so an AS
+            # URL like "https://as/" does not yield "https://as//authorize".
+            base = auth_server_url.rstrip("/")
             # Validate every endpoint the metadata declares against the #13
             # cleartext-leak policy before it can receive a secret. An unsafe
             # authorization/token endpoint falls back to the default path on
@@ -305,11 +311,11 @@ def _fetch_authorization_server_metadata(
                 authorization_endpoint=_validate_endpoint_url(
                     data.get("authorization_endpoint"), label="authorization_endpoint"
                 )
-                or f"{auth_server_url}/authorize",
+                or f"{base}/authorize",
                 token_endpoint=_validate_endpoint_url(
                     data.get("token_endpoint"), label="token_endpoint"
                 )
-                or f"{auth_server_url}/token",
+                or f"{base}/token",
                 registration_endpoint=_validate_endpoint_url(
                     data.get("registration_endpoint"), label="registration_endpoint"
                 ),
@@ -318,6 +324,7 @@ def _fetch_authorization_server_metadata(
                     label="device_authorization_endpoint",
                 ),
                 token_endpoint_auth_methods_supported=methods if isinstance(methods, list) else None,
+                issuer=issuer or auth_server_url,
             )
     except Exception:
         pass
@@ -574,6 +581,7 @@ class CallbackResult:
     auth_code: str | None = None
     state: str | None = None
     error: str | None = None
+    iss: str | None = None  # RFC 9207 issuer identifier, if the AS returned it
 
 
 def _make_callback_handler(
@@ -605,6 +613,7 @@ def _make_callback_handler(
             elif "code" in params:
                 result.auth_code = params["code"][0]
                 result.state = params.get("state", [None])[0]
+                result.iss = params.get("iss", [None])[0]
 
             self.send_response(200)
             self.send_header("Content-Type", "text/html")
@@ -986,6 +995,21 @@ def _run_authorization_flow(
     # we want it to hold up to scrutiny without caveats. See #26.
     if not secrets.compare_digest(cb_result.state or "", state):
         raise RuntimeError("OAuth state mismatch — possible CSRF attack")
+
+    # RFC 9207 §2.4: if the authorization response carries an `iss` parameter,
+    # the client MUST validate it equals the issuer the metadata was fetched
+    # from. This is the AS mix-up defence — it stops a code issued by AS-A from
+    # being exchanged at AS-B. Only checked when both the AS advertised an
+    # issuer and the callback returned `iss`; PKCE + state already cover the
+    # common attacks, so this is defence-in-depth.
+    if (
+        cb_result.iss is not None
+        and metadata.issuer
+        and cb_result.iss.rstrip("/") != metadata.issuer.rstrip("/")
+    ):
+        raise RuntimeError(
+            "OAuth issuer mismatch (RFC 9207) — possible AS mix-up attack"
+        )
 
     code = cb_result.auth_code
     assert code is not None

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -144,6 +144,29 @@ class TestDiscoverMetadata:
         assert meta.token_endpoint == "https://api.example.com/tok"
         assert meta.registration_endpoint == "https://api.example.com/reg"
 
+    def test_default_endpoints_no_double_slash_for_trailing_slash_as(
+        self, httpx_mock
+    ):
+        """An AS advertised with a trailing slash whose metadata omits the
+        endpoints must yield single-slash default endpoints, not '//authorize'."""
+        server_url = "https://mcp.example.com/mcp"
+        httpx_mock.add_response(
+            url="https://mcp.example.com/.well-known/oauth-protected-resource/mcp",
+            json={
+                "resource": server_url,
+                "authorization_servers": ["https://as.example.com/"],
+            },
+        )
+        httpx_mock.add_response(
+            url="https://as.example.com/.well-known/oauth-authorization-server",
+            json={"issuer": "https://as.example.com/"},  # no endpoints declared
+        )
+        client = httpx.Client()
+        meta = discover_oauth_metadata(server_url, client)
+        assert meta.authorization_endpoint == "https://as.example.com/authorize"
+        assert meta.token_endpoint == "https://as.example.com/token"
+        assert "//authorize" not in meta.authorization_endpoint
+
     def test_fallback_on_404(self, httpx_mock):
         self._mock_no_prm(httpx_mock)
         httpx_mock.add_response(
@@ -2938,6 +2961,97 @@ class TestAuthorizationFlowFailurePaths:
                 client_id_override="cid",
                 timeout=5,
             )
+
+
+class TestRfc9207IssValidation:
+    """RFC 9207: validate the authorization-response `iss` parameter against the
+    discovered issuer (AS mix-up defence)."""
+
+    META = OAuthMetadata(
+        authorization_endpoint="https://ex.com/authorize",
+        token_endpoint="https://ex.com/token",
+        issuer="https://ex.com",
+    )
+
+    def _driver(self, extra_query: str):
+        from urllib.parse import parse_qs, urlparse
+        from urllib.request import urlopen
+
+        def fake_open(auth_url: str) -> bool:
+            q = parse_qs(urlparse(auth_url).query)
+            redirect_uri = q["redirect_uri"][0]
+            state = q["state"][0]
+            cb = f"{redirect_uri}?code=c&state={state}"
+            if extra_query:
+                cb += f"&{extra_query}"
+
+            def hit() -> None:
+                try:
+                    urlopen(cb, timeout=5).read()
+                except Exception:
+                    pass
+
+            threading.Thread(target=hit, daemon=True).start()
+            return True
+
+        return fake_open
+
+    def test_iss_mismatch_raises(self, monkeypatch):
+        monkeypatch.setattr(
+            "mcp_stdio.oauth.webbrowser.open", self._driver("iss=https://evil.example")
+        )
+        client = httpx.Client()
+        with pytest.raises(RuntimeError, match="issuer mismatch"):
+            _run_authorization_flow(
+                "https://ex.com/mcp",
+                client,
+                metadata=self.META,
+                cached=None,
+                client_id_override="cid",
+                timeout=5,
+            )
+
+    def test_iss_match_proceeds(self, httpx_mock, tmp_path, monkeypatch):
+        store_file = tmp_path / "tokens.json"
+        monkeypatch.setattr("mcp_stdio.token_store._STORE_DIR", tmp_path)
+        monkeypatch.setattr("mcp_stdio.token_store._STORE_FILE", store_file)
+        httpx_mock.add_response(
+            url="https://ex.com/token",
+            json={"access_token": "at", "token_type": "Bearer"},
+        )
+        monkeypatch.setattr(
+            "mcp_stdio.oauth.webbrowser.open", self._driver("iss=https://ex.com")
+        )
+        client = httpx.Client()
+        data = _run_authorization_flow(
+            "https://ex.com/mcp",
+            client,
+            metadata=self.META,
+            cached=None,
+            client_id_override="cid",
+            timeout=5,
+        )
+        assert data.access_token == "at"
+
+    def test_no_iss_skips_validation(self, httpx_mock, tmp_path, monkeypatch):
+        store_file = tmp_path / "tokens.json"
+        monkeypatch.setattr("mcp_stdio.token_store._STORE_DIR", tmp_path)
+        monkeypatch.setattr("mcp_stdio.token_store._STORE_FILE", store_file)
+        httpx_mock.add_response(
+            url="https://ex.com/token",
+            json={"access_token": "at", "token_type": "Bearer"},
+        )
+        monkeypatch.setattr("mcp_stdio.oauth.webbrowser.open", self._driver(""))
+        client = httpx.Client()
+        data = _run_authorization_flow(
+            "https://ex.com/mcp",
+            client,
+            metadata=self.META,
+            cached=None,
+            client_id_override="cid",
+            timeout=5,
+        )
+        assert data.access_token == "at"
 
 
 # --- _parse_resource_metadata_hint ---


### PR DESCRIPTION
Round-5 re-review (low).

### RFC 9207 `iss` validation (AS mix-up defence)
The authorization response's `iss` parameter was ignored. Now captured in the callback, with the discovered issuer stored on `OAuthMetadata`; after the state check, `iss` is asserted to equal `issuer` when both are present. On mismatch the flow aborts with an AS-mix-up error — defence-in-depth on top of the already-correct PKCE + `state`.

### Double-slash default endpoints
When reachable AS metadata omits the authorization/token endpoints and the AS URL carries a trailing slash (a server may advertise `https://as/` in `authorization_servers`), the f-string fallback produced `https://as//authorize`. Now the trailing slash is stripped before building the defaults.

## Tests
+4: `iss` mismatch aborts, `iss` match / no-`iss` proceed; a trailing-slash AS whose metadata omits endpoints yields single-slash defaults. Suite: **524 passed, 3 skipped**; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)