### PR TITLE
fix(token_store): O_NOFOLLOW on credential writes; symlink-safe read chmod; docs

### DIFF
--- a/src/mcp_stdio/token_store.py
+++ b/src/mcp_stdio/token_store.py
@@ -32,17 +32,30 @@ _LEGACY_STORE_FILE = _LEGACY_STORE_DIR / "tokens.json"
 # Default ports folded out when normalising a server URL into a store key.
 _DEFAULT_PORTS = {"https": 443, "http": 80}
 
+# O_NOFOLLOW (POSIX) makes os.open refuse a symlink at the final path component,
+# so a symlink swapped in for the store/temp/lock file cannot redirect a write
+# of secrets to an attacker-chosen target. 0 on platforms without it (Windows),
+# where the parent dir's 0o700 mode is the primary guard anyway.
+_O_NOFOLLOW = getattr(os, "O_NOFOLLOW", 0)
+
 
 def _normalize_key(server_url: str) -> str:
     """Normalise a server URL into a stable token-store key.
 
     Folds cosmetically-different spellings of the same endpoint — host case,
-    an explicit default port (``:443`` / ``:80``), and a single trailing
-    slash — to one key so they share a cached token instead of triggering a
+    an explicit default port (``:443`` / ``:80``), and trailing slashes on the
+    path — to one key so they share a cached token instead of triggering a
     redundant OAuth flow. Only the *store key* is normalised; oauth.py still
     uses the operator-supplied URL verbatim for the RFC 8707 resource
     indicator, so end-to-end behaviour is unchanged. Anything that does not
     parse as http(s) with a host is returned unchanged.
+
+    The query string is preserved (``/mcp?a=1`` and ``/mcp?a=2`` are distinct
+    servers); userinfo is dropped (``.hostname``). Note that a server URL
+    carrying secrets in its query would therefore place them in the store key
+    inside ``tokens.json`` — that file is 0o600 and MCP endpoints normally have
+    no query secrets, so this is not a disclosure vector beyond the tokens it
+    already holds.
     """
     # ``urlsplit`` is lazy: ``.hostname`` / ``.port`` are what actually raise
     # ValueError on a malformed authority (e.g. a non-numeric or out-of-range
@@ -168,8 +181,10 @@ def _read_store() -> dict[str, Any]:
     # backup that lost mode bits, copied under a permissive umask, or written by
     # a third-party tool) and is only ever read would otherwise keep its mode,
     # leaving the secrets readable.
+    # Don't chmod through a symlink (would alter the link target's mode).
     try:
-        os.chmod(_STORE_FILE, stat.S_IRUSR | stat.S_IWUSR)  # 0o600
+        if not _STORE_FILE.is_symlink():
+            os.chmod(_STORE_FILE, stat.S_IRUSR | stat.S_IWUSR)  # 0o600
     except OSError:
         pass
     try:
@@ -188,7 +203,7 @@ def _write_store(data: dict[str, Any]) -> None:
     _ensure_store_dir()
     payload = json.dumps(data, indent=2).encode("utf-8")
     tmp_path = _STORE_FILE.with_suffix(_STORE_FILE.suffix + f".tmp.{os.getpid()}")
-    flags = os.O_WRONLY | os.O_CREAT | os.O_TRUNC
+    flags = os.O_WRONLY | os.O_CREAT | os.O_TRUNC | _O_NOFOLLOW
     fd = os.open(tmp_path, flags, stat.S_IRUSR | stat.S_IWUSR)  # 0o600
     try:
         with os.fdopen(fd, "wb") as f:
@@ -219,7 +234,11 @@ def _store_lock() -> Iterator[None]:
     # so test monkeypatching of _STORE_DIR redirects the lock file too.
     lock_path = _STORE_DIR / "tokens.json.lock"
     try:
-        fd = os.open(lock_path, os.O_WRONLY | os.O_CREAT, stat.S_IRUSR | stat.S_IWUSR)
+        fd = os.open(
+            lock_path,
+            os.O_WRONLY | os.O_CREAT | _O_NOFOLLOW,
+            stat.S_IRUSR | stat.S_IWUSR,
+        )
     except OSError:
         yield
         return

--- a/tests/test_token_store.py
+++ b/tests/test_token_store.py
@@ -180,6 +180,27 @@ class TestLoadSaveDelete:
         assert mode & stat.S_IRWXG == 0
         assert mode & stat.S_IRWXO == 0
 
+    @pytest.mark.skipif(
+        sys.platform == "win32",
+        reason="POSIX symlink semantics; NTFS differs",
+    )
+    def test_read_does_not_chmod_through_a_symlink(self, tmp_path, monkeypatch):
+        """A symlinked tokens.json must NOT have its target's mode altered on
+        read — guards against a symlink-swap chmod of an attacker-chosen file."""
+        target = tmp_path / "real.json"
+        target.write_text('{"https://example.com/mcp": {"access_token": "t"}}')
+        os.chmod(target, 0o644)
+        link = tmp_path / "tokens.json"
+        link.symlink_to(target)
+
+        monkeypatch.setattr("mcp_stdio.token_store._STORE_DIR", tmp_path)
+        monkeypatch.setattr("mcp_stdio.token_store._STORE_FILE", link)
+
+        loaded = load_token("https://example.com/mcp")
+        assert loaded is not None and loaded.access_token == "t"
+        # The symlink target's mode must be untouched (chmod skipped on symlink).
+        assert os.stat(target).st_mode & stat.S_IRWXO == stat.S_IROTH
+
     def test_concurrent_saves_of_distinct_keys_both_persist(
         self, tmp_path, monkeypatch
     ):
@@ -261,8 +282,15 @@ class TestNormalizeKey:
     def test_keeps_non_default_port(self):
         assert _normalize_key("https://x.com:8443/mcp") == "https://x.com:8443/mcp"
 
-    def test_strips_single_trailing_slash(self):
+    def test_strips_trailing_slashes(self):
         assert _normalize_key("https://x.com/mcp/") == "https://x.com/mcp"
+        # rstrip removes all trailing slashes, matching the docstring.
+        assert _normalize_key("https://x.com/mcp///") == "https://x.com/mcp"
+
+    def test_query_is_preserved_in_key(self):
+        assert (
+            _normalize_key("https://x.com/mcp?t=1") == "https://x.com/mcp?t=1"
+        )
 
     def test_non_http_returned_unchanged(self):
         assert _normalize_key("not a url") == "not a url"


### PR DESCRIPTION
Round-5 re-review (low + nit, defense-in-depth).

- **O_NOFOLLOW (low)**: the temp-file write in `_write_store` and the lock-file open in `_store_lock` now pass `O_NOFOLLOW` (0 where unavailable, e.g. Windows), so a symlink swapped in for those paths cannot redirect a write of secrets to an attacker-chosen target. The opportunistic read chmod in `_read_store` now **skips symlinks** so it cannot alter a link target's mode. The 0o700 store dir remains the primary guard; this hardens the case that invariant is ever weakened.
- **Docs (nit)**: `_normalize_key`'s docstring said "a single trailing slash" but `rstrip('/')` folds all of them — corrected, and documented that the query string is part of the key (with the 0o600 implication if a URL carries query secrets).

Tests: read does not chmod through a symlink; multiple trailing slashes folded; query preserved in the key. ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)