### PR TITLE
fix(relay): retry all transient transport errors; guard cross-origin SSE endpoint

### DIFF
--- a/src/mcp_stdio/relay.py
+++ b/src/mcp_stdio/relay.py
@@ -14,7 +14,7 @@ import time
 from collections.abc import Iterable, Iterator
 from datetime import datetime, timezone
 from typing import Any
-from urllib.parse import urljoin
+from urllib.parse import urljoin, urlsplit
 
 import httpx
 
@@ -168,6 +168,22 @@ def _extract_id(line: str) -> Any:
         return json.loads(line).get("id")
     except (json.JSONDecodeError, AttributeError):
         return None
+
+
+_DEFAULT_SCHEME_PORTS = {"http": 80, "https": 443, "ws": 80, "wss": 443}
+
+
+def _same_origin(url_a: str, url_b: str) -> bool:
+    """Return True if two URLs share an RFC 6454 origin (scheme/host/port)."""
+    try:
+        a, b = urlsplit(url_a), urlsplit(url_b)
+        oa = (a.scheme, (a.hostname or "").lower(),
+              a.port if a.port is not None else _DEFAULT_SCHEME_PORTS.get(a.scheme))
+        ob = (b.scheme, (b.hostname or "").lower(),
+              b.port if b.port is not None else _DEFAULT_SCHEME_PORTS.get(b.scheme))
+    except ValueError:
+        return False
+    return oa == ob
 
 
 # MCP-Protocol-Version header (spec rev 2025-06-18, "Protocol Version Header").
@@ -683,12 +699,13 @@ def _post_and_stream(
                         emitted = True
 
                 return _StreamResult(session, 200, protocol_version=pv)
-        except (
-            httpx.ConnectError,
-            httpx.ReadTimeout,
-            httpx.WriteTimeout,
-            httpx.ReadError,
-        ) as e:
+        except httpx.TransportError as e:
+            # TransportError is the supertype of every transient network/timeout/
+            # protocol failure: ConnectError/ReadError/Write*, ConnectTimeout/
+            # ReadTimeout/PoolTimeout, and RemoteProtocolError (mid-response
+            # server disconnect — common during half-open recovery). Catching
+            # the narrow leaf list missed several of these and let them crash the
+            # whole gateway. Non-transport (programming) errors still propagate.
             last_error = e
             log(f"attempt {attempt}/{MAX_RETRIES} failed: {e}")
             if emitted:
@@ -764,12 +781,13 @@ def _post_parsed(
                 return json.loads(text), _StreamResult(session, 200)
             except json.JSONDecodeError:
                 return None, _StreamResult(session, 200)
-        except (
-            httpx.ConnectError,
-            httpx.ReadTimeout,
-            httpx.WriteTimeout,
-            httpx.ReadError,
-        ) as e:
+        except httpx.TransportError as e:
+            # TransportError is the supertype of every transient network/timeout/
+            # protocol failure: ConnectError/ReadError/Write*, ConnectTimeout/
+            # ReadTimeout/PoolTimeout, and RemoteProtocolError (mid-response
+            # server disconnect — common during half-open recovery). Catching
+            # the narrow leaf list missed several of these and let them crash the
+            # whole gateway. Non-transport (programming) errors still propagate.
             last_error = e
             log(f"attempt {attempt}/{MAX_RETRIES} failed: {e}")
             if attempt < MAX_RETRIES:
@@ -1435,6 +1453,21 @@ def _sse_reader_loop(
                         return
                     if event_type == "endpoint":
                         resolved = urljoin(url, data)
+                        # The endpoint event may be a relative path (resolved
+                        # against the GET url) or absolute. A compromised / MITM'd
+                        # stream that injects an absolute cross-origin endpoint
+                        # would otherwise redirect every authenticated POST — and
+                        # its Authorization header — to a different origin. Refuse
+                        # a cross-origin endpoint when credentials would be sent.
+                        has_auth = any(k.lower() == "authorization" for k in req_headers)
+                        if has_auth and not _same_origin(resolved, url):
+                            log(
+                                f"warning: refusing cross-origin SSE endpoint "
+                                f"{resolved!r} (differs from {url!r}) — would leak "
+                                f"credentials. Ignoring. See #13."
+                            )
+                            state.ready.set()  # unblock startup; endpoint stays None
+                            continue
                         state.endpoint_url = resolved
                         state.ready.set()
                         log(f"SSE endpoint: {resolved}")
@@ -1444,8 +1477,12 @@ def _sse_reader_loop(
                 if state.stop.is_set():
                     return
                 log("SSE stream ended, reconnecting")
-                state.endpoint_url = None
+                # Clear ``ready`` BEFORE nulling endpoint_url so the main loop's
+                # ready.wait() blocks out the in-progress reconnect instead of
+                # returning immediately on a stale set() and surfacing a spurious
+                # "SSE endpoint unavailable".
                 state.ready.clear()
+                state.endpoint_url = None
                 # Responsive reconnect delay: exits immediately on stop.
                 if state.stop.wait(RETRY_DELAY):
                     return
@@ -1453,8 +1490,8 @@ def _sse_reader_loop(
             if state.stop.is_set():
                 return
             log(f"SSE disconnected, reconnecting: {e}")
+            state.ready.clear()  # clear before nulling endpoint_url (see above)
             state.endpoint_url = None
-            state.ready.clear()
             if state.stop.wait(RETRY_DELAY):
                 return
         except Exception as e:  # noqa: BLE001 — thread safety net

--- a/tests/test_relay.py
+++ b/tests/test_relay.py
@@ -239,6 +239,32 @@ class TestPostAndStream:
             result = _post_and_stream(client, "https://example.com/mcp", '{"id":1}', {}, 1)
         assert result is None
 
+    @pytest.mark.parametrize(
+        "exc",
+        [
+            httpx.ConnectTimeout("connect timed out"),
+            httpx.PoolTimeout("pool timed out"),
+            httpx.RemoteProtocolError("server disconnected mid-response"),
+            httpx.WriteError("write failed"),
+        ],
+    )
+    def test_all_transport_errors_are_retried_not_crashed(self, httpx_mock, exc):
+        """ConnectTimeout/PoolTimeout/RemoteProtocolError/WriteError are transient
+        TransportError subtypes — they must be retried, never propagate and crash
+        the gateway."""
+        httpx_mock.add_exception(exc)
+        httpx_mock.add_response(
+            json={"jsonrpc": "2.0", "result": {"ok": True}, "id": 1},
+            headers={"content-type": "application/json"},
+        )
+        client = httpx.Client()
+        with patch("sys.stdout", StringIO()), patch("mcp_stdio.relay.time.sleep"):
+            result = _post_and_stream(
+                client, "https://example.com/mcp", '{"id":1}', {}, 1
+            )
+        assert result is not None and result.status_code == 200
+        assert len(httpx_mock.get_requests()) == 2  # retried after the transient
+
     def test_non_200_returns_status(self, httpx_mock):
         httpx_mock.add_response(
             status_code=404, text="", headers={"content-type": "application/json"}
@@ -1966,6 +1992,58 @@ class TestSseReaderLoop:
             [b"event: endpoint\ndata: https://other.example.com/post\n\n"],
         )
         assert state.endpoint_url == "https://other.example.com/post"
+
+    def _reader_with_headers(self, httpx_mock, sse_bytes, headers):
+        state = _SseState()
+
+        def gen():
+            for chunk in sse_bytes:
+                yield chunk
+            state.stop.set()
+
+        httpx_mock.add_response(
+            url=self.URL,
+            method="GET",
+            stream=IteratorStream(gen()),
+            headers={"content-type": "text/event-stream"},
+        )
+        client = httpx.Client()
+        try:
+            with patch("sys.stdout", StringIO()):
+                _sse_reader_loop(client, self.URL, headers, state)
+        finally:
+            client.close()
+        return state
+
+    def test_cross_origin_endpoint_refused_when_authorized(self, httpx_mock, capsys):
+        """A cross-origin absolute endpoint must be refused when the GET carries
+        an Authorization header — POSTing credentials there would leak them."""
+        state = self._reader_with_headers(
+            httpx_mock,
+            [b"event: endpoint\ndata: https://evil.example/post\n\n"],
+            {"Authorization": "Bearer secret"},
+        )
+        assert state.endpoint_url is None  # refused
+        assert state.ready.is_set()  # but startup is unblocked
+        assert "cross-origin" in capsys.readouterr().err
+
+    def test_cross_origin_endpoint_allowed_without_credentials(self, httpx_mock):
+        """No Authorization header → a cross-origin endpoint is allowed (nothing
+        to leak)."""
+        state = self._reader_with_headers(
+            httpx_mock,
+            [b"event: endpoint\ndata: https://other.example.com/post\n\n"],
+            {},
+        )
+        assert state.endpoint_url == "https://other.example.com/post"
+
+    def test_same_origin_absolute_endpoint_allowed_with_credentials(self, httpx_mock):
+        state = self._reader_with_headers(
+            httpx_mock,
+            [b"event: endpoint\ndata: https://example.com/messages\n\n"],
+            {"Authorization": "Bearer secret"},
+        )
+        assert state.endpoint_url == "https://example.com/messages"
 
     def test_message_event_relayed_to_stdout(self, httpx_mock):
         payload = '{"jsonrpc":"2.0","result":{},"id":1}'


### PR DESCRIPTION
Round-6 re-review surfaced a **high-severity crash** and a **medium credential-leak vector**.

### Transport-error retry (high — gateway crash)
The retry loops in `_post_and_stream` / `_post_parsed` caught only `(ConnectError, ReadTimeout, WriteTimeout, ReadError)`. `httpx.ConnectTimeout`, `PoolTimeout`, `RemoteProtocolError` (mid-response server disconnect — common during half-open recovery), and `WriteError` are equally transient `TransportError` subtypes but **not** in that leaf list, so any of them propagated **uncaught** out of `run()`, past the bare `finally: client.close()`, out of `cli.main()` — **crashing the whole gateway** with a traceback, hanging the in-flight request, and dropping every subsequent stdin line. Now catches the `httpx.TransportError` supertype (programming errors still propagate); the at-most-once emitted-flag guard is preserved.

### Cross-origin SSE endpoint (medium — credential leak)
The legacy SSE reader resolved the `endpoint` event via `urljoin` and POSTed all authenticated requests there. An absolute **cross-origin** endpoint (compromised / MITM'd stream) would redirect every POST — and its `Authorization` header — to a different origin. Now refuses a cross-origin endpoint when an `Authorization` header is present (RFC 6454 origin compare); allows it only when no credentials are sent.

### Reconnect window (low)
Clear `ready` **before** nulling `endpoint_url` on reconnect, so the main loop's `ready.wait()` blocks out the in-progress reconnect instead of returning on a stale `set()` and surfacing a spurious `SSE endpoint unavailable`.

## Tests
+7: ConnectTimeout/PoolTimeout/RemoteProtocolError/WriteError retried (not crashed); cross-origin endpoint refused with credentials / allowed without / same-origin allowed with. Suite: **538 passed, 3 skipped**; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)