### PR TITLE
fix(token_store): fsync the parent directory after os.replace for crash-durability

### DIFF
--- a/src/mcp_stdio/token_store.py
+++ b/src/mcp_stdio/token_store.py
@@ -198,7 +198,9 @@ def _write_store(data: dict[str, Any]) -> None:
 
     Uses a temp file created with 0o600 from the start (no umask window),
     then atomically renames it over the target file so a crash mid-write
-    cannot corrupt existing tokens.
+    cannot corrupt existing tokens. After the rename the parent directory is
+    fsynced so the directory entry change is itself durable across a power
+    loss (the file data fsync alone does not guarantee the rename survives).
     """
     _ensure_store_dir()
     payload = json.dumps(data, indent=2).encode("utf-8")
@@ -217,6 +219,17 @@ def _write_store(data: dict[str, Any]) -> None:
         except OSError:
             pass
         raise
+    # Make the rename durable. Best-effort: some platforms/filesystems reject a
+    # directory fsync, and opening a directory fails on Windows — neither should
+    # fail the write.
+    try:
+        dir_fd = os.open(str(_STORE_DIR), os.O_RDONLY)
+        try:
+            os.fsync(dir_fd)
+        finally:
+            os.close(dir_fd)
+    except OSError:
+        pass
 
 
 @contextlib.contextmanager

--- a/tests/test_token_store.py
+++ b/tests/test_token_store.py
@@ -119,6 +119,26 @@ class TestLoadSaveDelete:
         store_file.write_text("not json")
         assert load_token("https://example.com/mcp") is None
 
+    def test_save_survives_unavailable_dir_fsync(self, tmp_path, monkeypatch):
+        """The post-rename parent-dir fsync is best-effort — a platform that
+        rejects it (e.g. Windows) must not fail the save."""
+        store_file = tmp_path / "tokens.json"
+        monkeypatch.setattr("mcp_stdio.token_store._STORE_DIR", tmp_path)
+        monkeypatch.setattr("mcp_stdio.token_store._STORE_FILE", store_file)
+
+        real_open = os.open
+
+        def open_no_dir_fsync(path, flags, *a, **k):
+            # Reject opening the directory (the dir-fsync path), allow the rest.
+            if os.path.isdir(path):
+                raise OSError("directory fsync unsupported")
+            return real_open(path, flags, *a, **k)
+
+        monkeypatch.setattr("mcp_stdio.token_store.os.open", open_no_dir_fsync)
+        save_token("https://example.com/mcp", TokenData(access_token="t"))
+        monkeypatch.setattr("mcp_stdio.token_store.os.open", real_open)
+        assert load_token("https://example.com/mcp").access_token == "t"
+
     def test_load_unknown_future_field_returns_none(self, tmp_path, monkeypatch):
         """Forward-compat: an entry written by a newer version carrying a field
         this version doesn't know must degrade to None, not raise."""


### PR DESCRIPTION
Round-6 re-review (low). `_write_store` fsynced the temp file's contents and then `os.replace`'d it over the target, giving in-process atomicity — but the **directory entry** change from the rename is only durable after the **parent directory** is fsynced. On a power loss immediately after `os.replace`, a delayed-allocation filesystem could leave the directory entry pointing at the old inode despite the data fsync. Now opens the store directory and fsyncs it after a successful replace. Best-effort: a platform/filesystem that rejects a directory fsync (or Windows, where opening a directory fails) must not fail the save.

Test: a save still succeeds when the directory fsync is unavailable. ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)