### PR TITLE
fix(cli): de-dup a case-variant -H authorization against the OAuth token

### DIFF
--- a/src/mcp_stdio/cli.py
+++ b/src/mcp_stdio/cli.py
@@ -385,6 +385,11 @@ def main() -> None:
                 refresh_leeway=args.oauth_refresh_leeway,
                 resource_indicator=not args.no_resource_indicator,
             )
+            # Drop any differently-cased 'authorization' header a -H supplied
+            # earlier (the -H loop ran before this block), so the OAuth token is
+            # the single Authorization sent rather than a duplicate header pair.
+            for existing in [k for k in headers if k.lower() == "authorization"]:
+                del headers[existing]
             headers["Authorization"] = f"Bearer {token_data.access_token}"
             token_refresher = _build_token_refresher(
                 args.url, headers, args.timeout_connect, args.timeout_read

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -337,6 +337,30 @@ class TestMain:
             assert auth_keys == ["authorization"]
             assert headers["authorization"] == "Bearer override"
 
+    def test_oauth_authorization_dedups_case_variant_dash_h(self, monkeypatch):
+        """--oauth together with a differently-cased -H authorization must not
+        send two Authorization headers — the OAuth token is the only one."""
+        with (
+            patch(
+                "sys.argv",
+                [
+                    "mcp-stdio",
+                    "--oauth",
+                    "-H",
+                    "authorization: custom",
+                    "https://example.com/mcp",
+                ],
+            ),
+            patch("mcp_stdio.oauth.ensure_token") as mock_ensure,
+            patch("mcp_stdio.cli.run") as mock_run,
+        ):
+            mock_ensure.return_value.access_token = "oauth-tok"
+            main()
+        headers = mock_run.call_args.kwargs["headers"]
+        auth_keys = [k for k in headers if k.lower() == "authorization"]
+        assert auth_keys == ["Authorization"]
+        assert headers["Authorization"] == "Bearer oauth-tok"
+
     def test_dash_h_overrides_default_content_type_case_insensitively(self):
         with (
             patch(


### PR DESCRIPTION
Round-6 re-review (low). The `-H` override loop drops any built-in header that differs only in case from a user-supplied one, but the OAuth flow writes `headers["Authorization"]` **after** that loop. So `--oauth -H 'authorization: custom'` left the dict holding **both** `authorization` (from -H) and `Authorization` (from OAuth), and httpx emits two Authorization header lines on the wire. Now drops any case-variant `authorization` before the OAuth block sets the canonical one.

Test: `--oauth` + `-H 'authorization: custom'` yields a single Authorization header carrying the OAuth bearer token. ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)