### PR TITLE
fix(oauth): reject endpoint URLs with embedded userinfo; test client_secret_post device flow

### DIFF
--- a/src/mcp_stdio/oauth.py
+++ b/src/mcp_stdio/oauth.py
@@ -235,9 +235,10 @@ def _validate_endpoint_url(endpoint_url: str | None, *, label: str) -> str | Non
     hostile or compromised authorization server could declare
     ``token_endpoint="http://evil/token"`` and exfiltrate the authorization
     code, client_secret, and refresh_token in cleartext. Apply the same policy
-    here — reject non-http(s) schemes and reject plain HTTP for non-loopback
-    hosts — returning ``None`` (with a warning) so the caller drops the unsafe
-    endpoint rather than POSTing credentials to it. See #13.
+    here — reject non-http(s) schemes, reject plain HTTP for non-loopback
+    hosts, and reject embedded userinfo — returning ``None`` (with a warning) so
+    the caller drops the unsafe endpoint rather than POSTing credentials to it.
+    See #13.
     """
     if not endpoint_url:
         return None
@@ -245,6 +246,12 @@ def _validate_endpoint_url(endpoint_url: str | None, *, label: str) -> str | Non
         parsed = urlparse(endpoint_url)
     except Exception:
         log(f"warning: malformed {label} URL {endpoint_url!r}, ignoring")
+        return None
+    if parsed.username is not None or parsed.password is not None:
+        # Legitimate AS metadata never embeds credentials in its declared
+        # endpoints; userinfo (``user:pass@host``) is an exfiltration / parser-
+        # confusion vector, so refuse it outright.
+        log(f"warning: refusing {label} URL with embedded userinfo, ignoring")
         return None
     if parsed.scheme not in ("https", "http"):
         log(

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -2776,6 +2776,13 @@ class TestValidateEndpointUrl:
         assert _validate_endpoint_url("javascript:alert(1)", label="token") is None
         assert "unsupported" in capsys.readouterr().err
 
+    def test_userinfo_rejected(self, capsys):
+        assert (
+            _validate_endpoint_url("https://user:pass@as.example/token", label="token")
+            is None
+        )
+        assert "userinfo" in capsys.readouterr().err
+
     def test_empty_and_none_pass_through_silently(self, capsys):
         assert _validate_endpoint_url(None, label="token") is None
         assert _validate_endpoint_url("", label="token") is None
@@ -3671,6 +3678,47 @@ class TestDeviceAuthorizationFlow:
         ]
         assert len(da_reqs) == 1
         assert b"resource=" not in da_reqs[0].content
+
+    def test_client_secret_post_carries_secret_in_body_and_scope(
+        self, httpx_mock, tmp_path, monkeypatch
+    ):
+        """With client_secret_post auth, the device-auth POST and each poll POST
+        carry client_id + client_secret in the body (not a Basic header), and a
+        requested scope appears in the device-auth body."""
+        from urllib.parse import parse_qs
+
+        self._patch_store(tmp_path, monkeypatch)
+        httpx_mock.add_response(url=DEVICE_AUTH_URL, json=_da_response())
+        httpx_mock.add_response(
+            url=TOKEN_URL, json={"access_token": "acc", "token_type": "Bearer"}
+        )
+        cached = TokenData(
+            access_token="",
+            token_type="Bearer",
+            token_endpoint=TOKEN_URL,
+            authorization_endpoint=AUTH_URL,
+            client_id="cid",
+            client_secret="sshh",
+            token_endpoint_auth_method="client_secret_post",
+        )
+        client = httpx.Client()
+        data = _run_device_authorization_flow(
+            MCP_URL, client, metadata=_device_meta(), cached=cached, scope="hr:read"
+        )
+        assert data.access_token == "acc"
+
+        reqs = httpx_mock.get_requests()
+        da = next(r for r in reqs if str(r.url) == DEVICE_AUTH_URL)
+        da_body = parse_qs(da.content.decode())
+        assert da_body.get("client_id") == ["cid"]
+        assert da_body.get("client_secret") == ["sshh"]
+        assert da_body.get("scope") == ["hr:read"]
+        assert "authorization" not in da.headers  # not Basic auth
+
+        poll = next(r for r in reqs if str(r.url) == TOKEN_URL)
+        poll_body = parse_qs(poll.content.decode())
+        assert poll_body.get("client_id") == ["cid"]
+        assert poll_body.get("client_secret") == ["sshh"]
 
     def test_google_verification_url_fallback(
         self, httpx_mock, tmp_path, monkeypatch, capsys


### PR DESCRIPTION
Round-6 re-review (nit + coverage).

- **userinfo rejection (nit)**: `_validate_endpoint_url` accepted an AS-metadata endpoint carrying userinfo (`user:pass@host`). Legitimate AS metadata never embeds credentials in its declared endpoints, and userinfo is an exfiltration / parser-confusion vector — now rejected alongside the existing scheme / cleartext checks.
- **coverage**: device flow with `client_secret_post` (secret in the request **body**, not a Basic header) and a requested scope was untested; added a test asserting `client_id` + `client_secret` + `scope` in the device-auth body and `client_id` + `client_secret` in each poll body.

Suite: **544 passed, 3 skipped**; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)