### PR TITLE
fix(cli): warn when OAuth-only flags are set without an OAuth flow

### DIFF
--- a/src/mcp_stdio/cli.py
+++ b/src/mcp_stdio/cli.py
@@ -333,6 +333,18 @@ def main() -> None:
         )
         sys.exit(1)
 
+    # Warn if OAuth-only options are set without an OAuth flow — they are
+    # silently ignored otherwise. --client-id / --oauth-scope also accept env
+    # defaults, so only treat them as "set" when non-empty.
+    if not (args.oauth or args.oauth_device) and (
+        args.client_id or args.oauth_scope or args.no_resource_indicator
+    ):
+        print(
+            "warning: --client-id / --oauth-scope / --no-resource-indicator are "
+            "ignored without --oauth or --oauth-device",
+            file=sys.stderr,
+        )
+
     # When an OAuth flow is selected, ignore any ambient env bearer token —
     # the flow below sets the Authorization header itself.
     if args.oauth or args.oauth_device:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -361,6 +361,43 @@ class TestMain:
         assert auth_keys == ["Authorization"]
         assert headers["Authorization"] == "Bearer oauth-tok"
 
+    def test_warns_when_oauth_only_flags_set_without_oauth(self, capsys):
+        """OAuth-only flags without --oauth/--oauth-device are silently ignored;
+        emit a warning so the user notices."""
+        with (
+            patch(
+                "sys.argv",
+                [
+                    "mcp-stdio",
+                    "--oauth-scope",
+                    "hr:read",
+                    "https://example.com/mcp",
+                ],
+            ),
+            patch("mcp_stdio.cli.run"),
+        ):
+            main()
+        assert "ignored without --oauth" in capsys.readouterr().err
+
+    def test_no_warning_when_oauth_flags_with_oauth(self, capsys):
+        with (
+            patch(
+                "sys.argv",
+                [
+                    "mcp-stdio",
+                    "--oauth",
+                    "--oauth-scope",
+                    "hr:read",
+                    "https://example.com/mcp",
+                ],
+            ),
+            patch("mcp_stdio.oauth.ensure_token") as mock_ensure,
+            patch("mcp_stdio.cli.run"),
+        ):
+            mock_ensure.return_value.access_token = "tok"
+            main()
+        assert "ignored without --oauth" not in capsys.readouterr().err
+
     def test_dash_h_overrides_default_content_type_case_insensitively(self):
         with (
             patch(


### PR DESCRIPTION
Round-6 re-review (nit, UX). `--client-id` / `--oauth-scope` / `--no-resource-indicator` are silently ignored when neither `--oauth` nor `--oauth-device` is selected. Now emits a stderr warning so the misconfiguration is visible (only when the values are non-empty, since `--client-id` / `--oauth-scope` also accept env defaults).

Tests: warning printed when an OAuth-only flag is set without `--oauth`; no warning when `--oauth` is present. ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)