### PR TITLE
fix(cli): env MCP_OAUTH_CLIENT_ID no longer warns; validate bearer token CR/LF/NUL

### DIFF
--- a/src/mcp_stdio/cli.py
+++ b/src/mcp_stdio/cli.py
@@ -181,7 +181,10 @@ def main() -> None:
     )
     parser.add_argument(
         "--client-id",
-        default=os.environ.get("MCP_OAUTH_CLIENT_ID", ""),
+        # Default None (not the env value) so an ambient MCP_OAUTH_CLIENT_ID is
+        # distinguishable from an explicit flag — the env var alone must not trip
+        # the "ignored without --oauth" warning below.
+        default=None,
         help="Pre-registered OAuth client ID (or set MCP_OAUTH_CLIENT_ID env var)",
     )
     parser.add_argument(
@@ -333,9 +336,17 @@ def main() -> None:
         )
         sys.exit(1)
 
-    # Warn if OAuth-only options are set without an OAuth flow — they are
-    # silently ignored otherwise. --client-id / --oauth-scope also accept env
-    # defaults, so only treat them as "set" when non-empty.
+    # Resolve --client-id: the explicit flag wins; otherwise the env var. The
+    # warning below only counts an EXPLICIT --client-id (args.client_id is not
+    # None), so an ambient MCP_OAUTH_CLIENT_ID does not trip it.
+    client_id = (
+        args.client_id
+        if args.client_id is not None
+        else os.environ.get("MCP_OAUTH_CLIENT_ID", "")
+    )
+
+    # Warn if OAuth-only options are explicitly set without an OAuth flow — they
+    # are silently ignored otherwise.
     if not (args.oauth or args.oauth_device) and (
         args.client_id or args.oauth_scope or args.no_resource_indicator
     ):
@@ -349,6 +360,17 @@ def main() -> None:
     # the flow below sets the Authorization header itself.
     if args.oauth or args.oauth_device:
         bearer_token = ""
+
+    # A bearer token reaches the wire as the Authorization header value, so it
+    # must satisfy the same CR/LF/NUL ban as -H values (RFC 7230 §3.2) — a
+    # newline in the token would otherwise inject arbitrary headers. See #14.
+    if bearer_token and any(c in bearer_token for c in _HEADER_VALUE_FORBIDDEN):
+        print(
+            "error: bearer token contains a forbidden control character "
+            "(CR, LF, or NUL)",
+            file=sys.stderr,
+        )
+        sys.exit(1)
 
     # Build headers
     headers: dict[str, str] = {
@@ -391,7 +413,7 @@ def main() -> None:
             token_data = ensure_token(
                 args.url,
                 client,
-                client_id=args.client_id or None,
+                client_id=client_id or None,
                 scope=args.oauth_scope or None,
                 device_flow=args.oauth_device,
                 refresh_leeway=args.oauth_refresh_leeway,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -398,6 +398,43 @@ class TestMain:
             main()
         assert "ignored without --oauth" not in capsys.readouterr().err
 
+    def test_env_client_id_alone_does_not_warn(self, monkeypatch, capsys):
+        """An ambient MCP_OAUTH_CLIENT_ID without --oauth must NOT trip the
+        'ignored without --oauth' warning (only an explicit --client-id does)."""
+        monkeypatch.setenv("MCP_OAUTH_CLIENT_ID", "cid")
+        with (
+            patch("sys.argv", ["mcp-stdio", "https://example.com/mcp"]),
+            patch("mcp_stdio.cli.run"),
+        ):
+            main()
+        assert "ignored without --oauth" not in capsys.readouterr().err
+
+    def test_explicit_client_id_without_oauth_warns(self, monkeypatch, capsys):
+        monkeypatch.delenv("MCP_OAUTH_CLIENT_ID", raising=False)
+        with (
+            patch(
+                "sys.argv",
+                ["mcp-stdio", "--client-id", "cid", "https://example.com/mcp"],
+            ),
+            patch("mcp_stdio.cli.run"),
+        ):
+            main()
+        assert "ignored without --oauth" in capsys.readouterr().err
+
+    @pytest.mark.parametrize(
+        "bad", ["tok\nInjected: x", "tok\rx", "tok\x00x", "tok\r\nInjected: x"]
+    )
+    def test_bearer_token_control_chars_rejected(self, bad, capsys):
+        """A bearer token with CR/LF/NUL must be rejected (header injection),
+        the same ban -H values get."""
+        with patch(
+            "sys.argv", ["mcp-stdio", "--bearer-token", bad, "https://example.com/mcp"]
+        ):
+            with pytest.raises(SystemExit) as exc_info:
+                main()
+            assert exc_info.value.code == 1
+        assert "forbidden control character" in capsys.readouterr().err
+
     def test_dash_h_overrides_default_content_type_case_insensitively(self):
         with (
             patch(


### PR DESCRIPTION
Round-7 re-review (low).

- **Spurious warning (low, regression from round-6 #16)**: `--client-id` defaulted to the `MCP_OAUTH_CLIENT_ID` env var, so an ambient env var (which the README promotes for OAuth) made `args.client_id` truthy even without `--oauth`, tripping the new "ignored without --oauth" warning. Now `--client-id` defaults to `None` and the env is resolved separately, so only an **explicit** `--client-id` counts — mirroring `--bearer-token`.
- **Bearer token validation (low, header injection)**: a `--bearer-token` / env value was written to the `Authorization` header verbatim, bypassing the CR/LF/NUL ban that `-H` values get (#14). A newline in the token would inject arbitrary headers. Now rejected with a clear error.

Tests: env `MCP_OAUTH_CLIENT_ID` alone does not warn; an explicit `--client-id` without `--oauth` does; a bearer token with CR/LF/NUL/CRLF is rejected. ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)