### PR TITLE
fix(relay): never synthesize a response for a notification; cover 401→404 cascade

### DIFF
--- a/src/mcp_stdio/relay.py
+++ b/src/mcp_stdio/relay.py
@@ -170,6 +170,21 @@ def _extract_id(line: str) -> Any:
         return None
 
 
+def _has_id(line: str) -> bool:
+    """Return True if the line is a JSON-RPC request (carries an ``id`` key).
+
+    A notification has no ``id`` and must never receive a response, so the relay
+    suppresses synthesized error responses for it. Distinguishes a present
+    ``id:null`` (a request) from an absent id (a notification). Unparseable input
+    is treated as id-less (no response synthesized).
+    """
+    try:
+        msg = json.loads(line)
+    except (json.JSONDecodeError, TypeError):
+        return False
+    return isinstance(msg, dict) and "id" in msg
+
+
 _DEFAULT_SCHEME_PORTS = {"http": 80, "https": 443, "ws": 80, "wss": 443}
 
 
@@ -1250,6 +1265,11 @@ def run(
                     tracker.add(cid)
 
             req_id = _extract_id(line)
+            # A notification (no id) must never receive a response — even when an
+            # upstream misbehaves and returns a 4xx/5xx to a POSTed notification,
+            # synthesizing an `id:null` error to stdout would be a JSON-RPC
+            # violation. Gate all synthesized error responses on this.
+            req_has_id = _has_id(line)
             if tracker is not None and req_id is not None:
                 # A request reusing a previously-cancelled id supersedes that
                 # cancel — untrack it so its response is delivered, not dropped.
@@ -1330,7 +1350,8 @@ def run(
                         continue
                 else:
                     log("token refresh failed, returning error")
-                    _write_line(_error_response("authentication failed", req_id))
+                    if req_has_id:
+                        _write_line(_error_response("authentication failed", req_id))
                     continue
 
             # Insufficient scope (403) — step-up authorization and retry once
@@ -1355,7 +1376,8 @@ def run(
                             continue
                     else:
                         log("step-up authorization failed, returning error")
-                        _write_line(_error_response("authorization failed", req_id))
+                        if req_has_id:
+                            _write_line(_error_response("authorization failed", req_id))
                         continue
 
             # Session expired (404) — reset, re-initialize, then retry
@@ -1367,7 +1389,8 @@ def run(
                 )
                 if new_session_id is None:
                     log("re-initialize failed, dropping request")
-                    _write_line(_error_response("session lost", req_id))
+                    if req_has_id:
+                        _write_line(_error_response("session lost", req_id))
                     continue
                 session_id = new_session_id
                 # Track the re-negotiated version so the MCP-Protocol-Version
@@ -1386,10 +1409,12 @@ def run(
             # Fall-through error for any unhandled 4xx/5xx so the MCP client
             # never hangs waiting for a response. 200 bodies were already
             # streamed by _post_and_stream; 202 is reserved for notifications
-            # and intentionally produces no stdout. See #11.
+            # and intentionally produces no stdout. A notification (no id) that
+            # draws a 4xx/5xx is logged but gets no synthesized response. See #11.
             if result.status_code >= 400:
                 log(f"upstream returned HTTP {result.status_code}")
-                _write_line(_error_response(f"HTTP {result.status_code}", req_id))
+                if req_has_id:
+                    _write_line(_error_response(f"HTTP {result.status_code}", req_id))
     finally:
         client.close()
 
@@ -1648,6 +1673,11 @@ def run_sse(
                     tracker.add(cid)
 
             req_id = _extract_id(line)
+            # A notification (no id) must never receive a response — even when an
+            # upstream misbehaves and returns a 4xx/5xx to a POSTed notification,
+            # synthesizing an `id:null` error to stdout would be a JSON-RPC
+            # violation. Gate all synthesized error responses on this.
+            req_has_id = _has_id(line)
             if tracker is not None and req_id is not None:
                 # A request reusing a previously-cancelled id supersedes that
                 # cancel — untrack it so its response is delivered, not dropped.
@@ -1663,7 +1693,8 @@ def run_sse(
                 if state.ready.wait(timeout=timeout_read):
                     endpoint = state.endpoint_url
                 if endpoint is None:
-                    _write_line(_error_response("SSE endpoint unavailable", req_id))
+                    if req_has_id:
+                        _write_line(_error_response("SSE endpoint unavailable", req_id))
                     continue
 
             try:
@@ -1714,7 +1745,8 @@ def run_sse(
                         )
                     else:
                         log("token refresh failed, returning error")
-                        _write_line(_error_response("authentication failed", req_id))
+                        if req_has_id:
+                            _write_line(_error_response("authentication failed", req_id))
                         continue
 
                 if resp.status_code == 403 and scope_upgrader:
@@ -1745,15 +1777,18 @@ def run_sse(
                             log(
                                 "step-up authorization failed, returning error"
                             )
-                            _write_line(_error_response("authorization failed", req_id))
+                            if req_has_id:
+                                _write_line(_error_response("authorization failed", req_id))
                             continue
 
                 if resp.status_code not in (200, 202):
                     log(f"POST returned HTTP {resp.status_code}")
-                    _write_line(_error_response(f"HTTP {resp.status_code}", req_id))
+                    if req_has_id:
+                        _write_line(_error_response(f"HTTP {resp.status_code}", req_id))
             except httpx.HTTPError as e:
                 log(f"POST failed: {e}")
-                _write_line(_error_response(str(e), req_id))
+                if req_has_id:
+                    _write_line(_error_response(str(e), req_id))
     finally:
         state.stop.set()
         # Set stop first, then briefly join so the reader can exit its own

--- a/tests/test_relay.py
+++ b/tests/test_relay.py
@@ -769,6 +769,74 @@ class TestRun:
         assert len(requests) == 2
         assert requests[1].headers["authorization"] == "Bearer new-token"
 
+    def test_notification_drawing_4xx_gets_no_synthesized_response(self, httpx_mock):
+        """A notification (no id) that a misbehaving server answers with 4xx must
+        NOT receive a synthesized id:null error — notifications expect no reply."""
+        httpx_mock.add_response(
+            status_code=400, text="", headers={"content-type": "application/json"}
+        )
+        output = self._run_with_stdin(
+            httpx_mock,
+            ['{"jsonrpc":"2.0","method":"notifications/progress","params":{}}'],
+        )
+        assert output.strip() == ""
+
+    def test_request_drawing_4xx_still_gets_error(self, httpx_mock):
+        """A request (with id) that draws a 4xx still gets a JSON-RPC error."""
+        httpx_mock.add_response(
+            status_code=400, text="", headers={"content-type": "application/json"}
+        )
+        output = self._run_with_stdin(
+            httpx_mock, ['{"jsonrpc":"2.0","method":"tools/call","id":5}']
+        )
+        parsed = json.loads(output.strip())
+        assert parsed["id"] == 5 and "error" in parsed
+
+    def test_401_retry_returns_404_cascades_into_reinitialize(self, httpx_mock):
+        """The documented cross-branch cascade: a 401 whose refreshed retry
+        returns 404 flows into the 404 re-initialize branch and recovers."""
+        httpx_mock.add_response(
+            text='{"jsonrpc":"2.0","result":{},"id":1}',
+            headers={"content-type": "application/json", "mcp-session-id": "sess-1"},
+        )
+        # tools/call -> 401
+        httpx_mock.add_response(
+            status_code=401, text="", headers={"content-type": "application/json"}
+        )
+        # refreshed retry -> 404 (session expired)
+        httpx_mock.add_response(
+            status_code=404, text="", headers={"content-type": "application/json"}
+        )
+        # reinit initialize -> sess-2
+        httpx_mock.add_response(
+            text='{"jsonrpc":"2.0","result":{},"id":0}',
+            headers={"content-type": "application/json", "mcp-session-id": "sess-2"},
+        )
+        httpx_mock.add_response(status_code=202, text="")  # reinit initialized
+        # final retry -> 200
+        httpx_mock.add_response(
+            text='{"jsonrpc":"2.0","result":{"ok":true},"id":2}',
+            headers={"content-type": "application/json"},
+        )
+
+        def refresher():
+            return {"Authorization": "Bearer new"}
+
+        output = self._run_with_stdin(
+            httpx_mock,
+            [
+                '{"jsonrpc":"2.0","method":"init","id":1}',
+                '{"jsonrpc":"2.0","method":"tools/call","id":2}',
+            ],
+            token_refresher=refresher,
+        )
+        lines = [json.loads(x) for x in output.strip().splitlines() if x]
+        # The cascade must deliver the final result, not a synthesized error.
+        assert any(m.get("result") == {"ok": True} for m in lines)
+        # The retried call after reinit carried the recovered session id.
+        reqs = httpx_mock.get_requests()
+        assert reqs[-1].headers.get("mcp-session-id") == "sess-2"
+
     def test_401_response_rotated_session_id_used_on_retry(self, httpx_mock):
         """If the server assigns a NEW Mcp-Session-Id on the 401 response, the
         refreshed retry must carry it, not the stale/absent one."""


### PR DESCRIPTION
Round-7 re-review (low + medium-coverage).

### Notification error synthesis (low)
`run()` / `run_sse()` synthesized a JSON-RPC error for any non-recovered 4xx/5xx, but `req_id` (from `_extract_id`) is `None` for **both** a request and a notification. So a misbehaving server that answered a POSTed notification with a 4xx/5xx made the relay write `{"error":...,"id":null}` to stdout — a **response to a notification**, which JSON-RPC 2.0 forbids. Added `_has_id()` (distinguishes an absent id from `id:null`) and gated every loop-level synthesized error on it; a notification that draws a 4xx/5xx is logged to stderr only.

### Coverage (medium gap)
The documented 401-refresh → 404-reinitialize **cross-branch recovery cascade** in `run()` was untested. Added a test driving 401 → refresh → 404 → reinit → 200, asserting the final result is delivered with the recovered session id; plus tests that a notification drawing a 4xx gets no response while a request still does.

Suite: **551 passed, 3 skipped**; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)