### PR TITLE
fix(oauth): close localhost callback server when DCR fails

### DIFF
--- a/src/mcp_stdio/oauth.py
+++ b/src/mcp_stdio/oauth.py
@@ -947,7 +947,13 @@ def _run_authorization_flow(
             auth_method = cached.token_endpoint_auth_method
         else:
             log("registering OAuth client")
-            reg = register_client(metadata, redirect_uri, client)
+            # DCR runs before the callback server is closed on the success path
+            # below; close it on failure so the listening socket does not leak.
+            try:
+                reg = register_client(metadata, redirect_uri, client)
+            except BaseException:
+                callback_server.server_close()
+                raise
             cid = reg.client_id
             csecret = reg.client_secret
             cse_at = reg.client_secret_expires_at

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -2981,6 +2981,37 @@ class TestAuthorizationFlowFailurePaths:
                 timeout=5,
             )
 
+    def test_dcr_failure_closes_callback_server(self, monkeypatch):
+        """If DCR raises before the success-path close, the localhost callback
+        server is still closed so its listening socket is not leaked."""
+        import mcp_stdio.oauth as oauth_mod
+
+        closed: list[bool] = []
+        real_server_close = oauth_mod.HTTPServer.server_close
+
+        def spying_close(self) -> None:
+            closed.append(True)
+            real_server_close(self)
+
+        monkeypatch.setattr(oauth_mod.HTTPServer, "server_close", spying_close)
+
+        def boom(*_args, **_kwargs):
+            raise RuntimeError("registration refused")
+
+        monkeypatch.setattr("mcp_stdio.oauth.register_client", boom)
+        # No client_id_override and no cached client → DCR path is taken.
+        client = httpx.Client()
+        with pytest.raises(RuntimeError, match="registration refused"):
+            _run_authorization_flow(
+                "https://ex.com/mcp",
+                client,
+                metadata=self.META,
+                cached=None,
+                client_id_override=None,
+                timeout=5,
+            )
+        assert closed, "callback server was not closed on the DCR error path"
+
 
 class TestRfc9207IssValidation:
     """RFC 9207: validate the authorization-response `iss` parameter against the


### PR DESCRIPTION
## Overview

`_run_authorization_flow` opens a localhost `HTTPServer` to receive the OAuth authorization-code callback, then performs dynamic client registration (DCR) **before** the success path closes the server. If `register_client` raised (network error, AS rejecting the registration, etc.), the listening socket leaked for the lifetime of the process.

## Change

- Wrap the DCR call so the callback server is closed before the exception propagates.
- Code exchange and `iss`/state validation already run **after** the existing `server_close()`, so they were never part of the leak — only the DCR path needed protection.

## Test

- `TestAuthorizationFlowFailurePaths::test_dcr_failure_closes_callback_server` — spies on `HTTPServer.server_close`, forces `register_client` to raise, and asserts the callback server is closed and the error propagates.

Found by the ongoing Opus 4.8 multi-agent review (round 7, oauth #7 [low]).

🤖 Generated with [Claude Code](https://claude.com/claude-code)