### PR TITLE
fix(cli): make --check honour --transport sse

### DIFF
--- a/src/mcp_stdio/cli.py
+++ b/src/mcp_stdio/cli.py
@@ -451,6 +451,7 @@ def main() -> None:
             headers=headers,
             timeout_connect=args.timeout_connect,
             timeout_read=args.timeout_read,
+            transport=args.transport,
         )
         sys.exit(0 if ok else 1)
 

--- a/src/mcp_stdio/relay.py
+++ b/src/mcp_stdio/relay.py
@@ -1071,17 +1071,178 @@ def _reinitialize(
     return new_session_id, negotiated
 
 
+def _report_initialize(result_data: dict[str, Any] | None) -> bool:
+    """Log a parsed ``initialize`` response and return the probe verdict.
+
+    Shared by the Streamable HTTP and SSE ``--check`` paths. Returns False
+    only when the response is a JSON-RPC error; an unparseable / missing
+    result still counts as "the server responded" (True).
+    """
+    if result_data and "result" in result_data:
+        result = result_data["result"]
+        if not isinstance(result, dict):
+            # Spec guarantees an object, but a malformed server could send a
+            # scalar/array — treat as "responded" rather than crashing on .get.
+            log("✓ Server responded (initialize result is not an object)")
+            return True
+        server_info = result.get("serverInfo") or {}
+        name = server_info.get("name", "unknown")
+        version = server_info.get("version", "?")
+        protocol = result.get("protocolVersion", "?")
+        log(f"✓ MCP initialize: server={name} v{version}, protocol={protocol}")
+
+        caps = result.get("capabilities") or {}
+        # MCP capabilities are presence-based: ``"tools": {}`` means tools ARE
+        # supported (an empty object, not "disabled"). Test membership, not
+        # truthiness, so an empty-but-present capability reports "yes".
+        tools = "yes" if "tools" in caps else "no"
+        resources = "yes" if "resources" in caps else "no"
+        prompts = "yes" if "prompts" in caps else "no"
+        log(f"✓ Capabilities: tools={tools}, resources={resources}, prompts={prompts}")
+        return True
+    if result_data and "error" in result_data:
+        err = result_data["error"]
+        log(f"✗ MCP error: {err.get('message', err)}")
+        return False
+    log("✓ Server responded (could not parse initialize result)")
+    return True
+
+
+def _check_connection_sse(
+    url: str,
+    headers: dict[str, str],
+    *,
+    timeout_connect: float,
+    timeout_read: float,
+) -> bool:
+    """Check legacy SSE (2024-11-05) connectivity via the full handshake.
+
+    Streamable HTTP can be probed with a single POST, but the legacy SSE
+    transport delivers JSON-RPC responses asynchronously over the long-lived
+    GET stream — a bare POST to the SSE URL would not work. This mirrors
+    ``run_sse``'s bootstrap as a one-shot: open the GET stream, wait for the
+    ``endpoint`` event, POST ``initialize`` to that endpoint, and read the
+    response off the stream. Returns True if the server completes the
+    handshake.
+    """
+    initialize_msg = json.dumps(
+        {
+            "jsonrpc": "2.0",
+            "method": "initialize",
+            "id": 1,
+            "params": {
+                "protocolVersion": "2024-11-05",
+                "capabilities": {},
+                "clientInfo": {"name": "mcp-stdio", "version": __version__},
+            },
+        }
+    )
+
+    client = httpx.Client(
+        timeout=httpx.Timeout(connect=timeout_connect, read=timeout_read, write=30, pool=10)
+    )
+
+    # The GET stream read blocks in the main thread; the POST runs in a helper
+    # thread. On a POST failure the helper closes the stream so the probe fails
+    # fast instead of hanging until the read timeout for a response that will
+    # never arrive.
+    holder: dict[str, Any] = {"resp": None, "post_error": None}
+
+    def do_post(endpoint: str) -> None:
+        try:
+            r = client.post(endpoint, content=initialize_msg, headers=headers)
+            if r.status_code not in (200, 202):
+                holder["post_error"] = f"HTTP {r.status_code}"
+        except Exception as e:  # noqa: BLE001 — surfaced via holder below
+            holder["post_error"] = str(e)
+        if holder["post_error"] is not None:
+            stream = holder["resp"]
+            if stream is not None:
+                try:
+                    stream.close()
+                except Exception:  # noqa: BLE001
+                    pass
+
+    try:
+        log(f"testing SSE connection to {url}")
+        with client.stream("GET", url, headers=headers) as resp:
+            holder["resp"] = resp
+            if resp.status_code != 200:
+                log(f"✗ HTTP {resp.status_code}")
+                return False
+            log(f"✓ SSE stream open (HTTP {resp.status_code})")
+
+            endpoint_seen = False
+            for event_type, data in _iter_sse_events(_iter_sse_lines(resp.iter_text())):
+                if event_type == "endpoint":
+                    resolved = urljoin(url, data)
+                    # Same cross-origin credential guard as the relay reader:
+                    # never POST an Authorization header to a different origin.
+                    has_auth = any(k.lower() == "authorization" for k in headers)
+                    if has_auth and not _same_origin(resolved, url):
+                        log(
+                            f"✗ refusing cross-origin SSE endpoint {resolved!r} "
+                            f"(differs from {url!r})"
+                        )
+                        return False
+                    log(f"✓ SSE endpoint: {resolved}")
+                    endpoint_seen = True
+                    threading.Thread(
+                        target=do_post, args=(resolved,), daemon=True
+                    ).start()
+                elif event_type == "message":
+                    if not endpoint_seen:
+                        continue
+                    try:
+                        result_data = json.loads(data)
+                    except json.JSONDecodeError:
+                        continue
+                    if isinstance(result_data, dict) and (
+                        "result" in result_data or "error" in result_data
+                    ):
+                        return _report_initialize(result_data)
+                    # A server-initiated notification, not our response — keep
+                    # reading until the initialize result arrives.
+
+            # Stream ended (or was closed by the POST helper) before a response.
+            if holder["post_error"] is not None:
+                log(f"✗ POST to SSE endpoint failed: {holder['post_error']}")
+            else:
+                log("✗ SSE stream ended before initialize response")
+            return False
+    except Exception as e:  # noqa: BLE001
+        if holder["post_error"] is not None:
+            log(f"✗ POST to SSE endpoint failed: {holder['post_error']}")
+        else:
+            log(f"✗ Connection failed: {e}")
+        return False
+    finally:
+        client.close()
+
+
 def check_connection(
     url: str,
     headers: dict[str, str],
     *,
     timeout_connect: float = 10,
     timeout_read: float = 120,
+    transport: str = "streamable-http",
 ) -> bool:
     """Check MCP server connectivity by sending an initialize request.
 
-    Returns True if the server responds successfully.
+    Returns True if the server responds successfully. ``transport`` selects
+    the probe: ``"streamable-http"`` (default) POSTs ``initialize`` directly,
+    while ``"sse"`` runs the legacy GET/endpoint/POST handshake so the probe
+    matches what ``run_sse`` would actually do.
     """
+    if transport == "sse":
+        return _check_connection_sse(
+            url,
+            headers,
+            timeout_connect=timeout_connect,
+            timeout_read=timeout_read,
+        )
+
     initialize_msg = json.dumps(
         {
             "jsonrpc": "2.0",
@@ -1132,30 +1293,12 @@ def check_connection(
             except json.JSONDecodeError:
                 pass
 
-        if result_data and "result" in result_data:
-            result = result_data["result"]
-            server_info = result.get("serverInfo", {})
-            name = server_info.get("name", "unknown")
-            version = server_info.get("version", "?")
-            protocol = result.get("protocolVersion", "?")
-            log(f"✓ MCP initialize: server={name} v{version}, protocol={protocol}")
-
-            caps = result.get("capabilities", {})
-            tools = "yes" if caps.get("tools") else "no"
-            resources = "yes" if caps.get("resources") else "no"
-            prompts = "yes" if caps.get("prompts") else "no"
-            log(f"✓ Capabilities: tools={tools}, resources={resources}, prompts={prompts}")
-        elif result_data and "error" in result_data:
-            err = result_data["error"]
-            log(f"✗ MCP error: {err.get('message', err)}")
-            return False
-        else:
-            log("✓ Server responded (could not parse initialize result)")
+        ok = _report_initialize(result_data)
 
         if "mcp-session-id" in resp.headers:
             log(f"✓ Session ID: {resp.headers['mcp-session-id']}")
 
-        return True
+        return ok
     except Exception as e:
         log(f"✗ Connection failed: {e}")
         return False

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -467,6 +467,37 @@ class TestMain:
             assert exc_info.value.code == 0
             assert mock_check.called
 
+    def test_check_forwards_transport_streamable_default(self):
+        """--check without --transport probes via the default streamable-http."""
+        with (
+            patch("sys.argv", ["mcp-stdio", "https://example.com/mcp", "--check"]),
+            patch("mcp_stdio.cli.check_connection", return_value=True) as mock_check,
+        ):
+            with pytest.raises(SystemExit):
+                main()
+            assert mock_check.call_args.kwargs["transport"] == "streamable-http"
+
+    def test_check_forwards_transport_sse(self):
+        """#11: --check --transport sse must run the SSE-aware probe, not the
+        default streamable-http POST."""
+        with (
+            patch(
+                "sys.argv",
+                [
+                    "mcp-stdio",
+                    "https://example.com/sse",
+                    "--check",
+                    "--transport",
+                    "sse",
+                ],
+            ),
+            patch("mcp_stdio.cli.check_connection", return_value=True) as mock_check,
+        ):
+            with pytest.raises(SystemExit) as exc_info:
+                main()
+            assert exc_info.value.code == 0
+            assert mock_check.call_args.kwargs["transport"] == "sse"
+
     def test_test_flag_deprecated_alias_works(self, capsys):
         """--test still works for backward compatibility but emits a deprecation warning."""
         with (

--- a/tests/test_relay.py
+++ b/tests/test_relay.py
@@ -2039,6 +2039,51 @@ class TestCheckConnection:
         )
         assert check_connection(self.URL, dict(self.HEADERS)) is True
 
+    def test_empty_capability_object_reports_yes(self, httpx_mock, capsys):
+        """MCP capabilities are presence-based: ``"tools": {}`` means supported,
+        so the probe reports tools=yes even though the object is empty."""
+        body = json.dumps(
+            {
+                "jsonrpc": "2.0",
+                "id": 1,
+                "result": {
+                    "protocolVersion": "2024-11-05",
+                    "capabilities": {"tools": {}, "resources": {}},
+                },
+            }
+        )
+        httpx_mock.add_response(
+            text=body, headers={"content-type": "application/json"}
+        )
+        assert check_connection(self.URL, dict(self.HEADERS)) is True
+        err = capsys.readouterr().err
+        assert "tools=yes" in err
+        assert "resources=yes" in err
+        assert "prompts=no" in err  # absent → no
+
+    def test_null_capabilities_does_not_crash(self, httpx_mock):
+        """A server sending ``"capabilities": null`` must not crash the probe."""
+        body = json.dumps(
+            {
+                "jsonrpc": "2.0",
+                "id": 1,
+                "result": {"protocolVersion": "2024-11-05", "capabilities": None},
+            }
+        )
+        httpx_mock.add_response(
+            text=body, headers={"content-type": "application/json"}
+        )
+        assert check_connection(self.URL, dict(self.HEADERS)) is True
+
+    def test_non_object_result_does_not_crash(self, httpx_mock):
+        """A malformed server returning a scalar ``result`` is reported as
+        reachable rather than crashing on attribute access."""
+        body = json.dumps({"jsonrpc": "2.0", "id": 1, "result": "ok"})
+        httpx_mock.add_response(
+            text=body, headers={"content-type": "application/json"}
+        )
+        assert check_connection(self.URL, dict(self.HEADERS)) is True
+
     def test_connect_error_returns_false(self, httpx_mock):
         httpx_mock.add_exception(httpx.ConnectError("refused"))
         assert check_connection(self.URL, dict(self.HEADERS)) is False
@@ -2058,6 +2103,165 @@ class TestCheckConnection:
         assert check_connection(self.URL, dict(self.HEADERS)) is True
         captured = capsys.readouterr()
         assert "sess-xyz" in captured.err
+
+
+class TestCheckConnectionSse:
+    """``check_connection(transport="sse")`` runs the legacy GET/endpoint/POST
+    handshake instead of POSTing initialize directly (round-7 #11)."""
+
+    SSE_URL = "https://example.com/sse"
+    HEADERS = {"Content-Type": "application/json"}
+
+    _INIT_RESULT = (
+        '{"jsonrpc":"2.0","id":1,"result":'
+        '{"protocolVersion":"2024-11-05",'
+        '"serverInfo":{"name":"sse-demo","version":"9.9"},'
+        '"capabilities":{"tools":{}}}}'
+    )
+
+    def test_sse_handshake_success(self, httpx_mock):
+        """endpoint event → POST initialize → response on the stream → True."""
+        # The GET stream carries the endpoint bootstrap and then the
+        # initialize response (legacy SSE delivers POST responses on the
+        # stream, not in the POST body).
+        httpx_mock.add_response(
+            url=self.SSE_URL,
+            method="GET",
+            stream=IteratorStream(
+                [
+                    b"event: endpoint\ndata: /messages?sid=xyz\n\n",
+                    f"event: message\ndata: {self._INIT_RESULT}\n\n".encode(),
+                ]
+            ),
+            headers={"content-type": "text/event-stream"},
+        )
+        httpx_mock.add_response(
+            url="https://example.com/messages?sid=xyz",
+            method="POST",
+            status_code=202,
+        )
+        assert (
+            check_connection(self.SSE_URL, dict(self.HEADERS), transport="sse")
+            is True
+        )
+        # The probe actually POSTed initialize to the resolved endpoint.
+        posts = [r for r in httpx_mock.get_requests() if r.method == "POST"]
+        assert len(posts) == 1
+        assert str(posts[0].url) == "https://example.com/messages?sid=xyz"
+        assert b'"method":"initialize"' in posts[0].read().replace(b" ", b"")
+
+    def test_sse_reports_server_info(self, httpx_mock, capsys):
+        """serverInfo / capabilities from the streamed response reach the log."""
+        httpx_mock.add_response(
+            url=self.SSE_URL,
+            method="GET",
+            stream=IteratorStream(
+                [
+                    b"event: endpoint\ndata: /messages\n\n",
+                    f"event: message\ndata: {self._INIT_RESULT}\n\n".encode(),
+                ]
+            ),
+            headers={"content-type": "text/event-stream"},
+        )
+        httpx_mock.add_response(
+            url="https://example.com/messages", method="POST", status_code=202
+        )
+        assert (
+            check_connection(self.SSE_URL, dict(self.HEADERS), transport="sse")
+            is True
+        )
+        err = capsys.readouterr().err
+        assert "sse-demo" in err
+        assert "tools=yes" in err
+
+    def test_sse_get_non_200_returns_false(self, httpx_mock):
+        """The GET stream itself failing (e.g. 401) → False, no POST attempted."""
+        httpx_mock.add_response(url=self.SSE_URL, method="GET", status_code=401)
+        assert (
+            check_connection(self.SSE_URL, dict(self.HEADERS), transport="sse")
+            is False
+        )
+        assert not [r for r in httpx_mock.get_requests() if r.method == "POST"]
+
+    def test_sse_mcp_error_returns_false(self, httpx_mock):
+        """A JSON-RPC error delivered on the stream → False."""
+        err_body = '{"jsonrpc":"2.0","id":1,"error":{"code":-32603,"message":"boom"}}'
+        httpx_mock.add_response(
+            url=self.SSE_URL,
+            method="GET",
+            stream=IteratorStream(
+                [
+                    b"event: endpoint\ndata: /messages\n\n",
+                    f"event: message\ndata: {err_body}\n\n".encode(),
+                ]
+            ),
+            headers={"content-type": "text/event-stream"},
+        )
+        httpx_mock.add_response(
+            url="https://example.com/messages", method="POST", status_code=202
+        )
+        assert (
+            check_connection(self.SSE_URL, dict(self.HEADERS), transport="sse")
+            is False
+        )
+
+    def test_sse_stream_ends_before_response_returns_false(self, httpx_mock):
+        """endpoint arrives but no initialize response before EOF → False."""
+        httpx_mock.add_response(
+            url=self.SSE_URL,
+            method="GET",
+            stream=IteratorStream([b"event: endpoint\ndata: /messages\n\n"]),
+            headers={"content-type": "text/event-stream"},
+        )
+        httpx_mock.add_response(
+            url="https://example.com/messages", method="POST", status_code=202
+        )
+        assert (
+            check_connection(self.SSE_URL, dict(self.HEADERS), transport="sse")
+            is False
+        )
+
+    def test_sse_cross_origin_endpoint_refused_with_credentials(
+        self, httpx_mock, capsys
+    ):
+        """A cross-origin endpoint event is refused (no credential leak) → False,
+        and the probe never POSTs the Authorization header off-origin."""
+        httpx_mock.add_response(
+            url=self.SSE_URL,
+            method="GET",
+            stream=IteratorStream(
+                [b"event: endpoint\ndata: https://evil.example/steal\n\n"]
+            ),
+            headers={"content-type": "text/event-stream"},
+        )
+        headers = {"Content-Type": "application/json", "Authorization": "Bearer s3cr3t"}
+        assert check_connection(self.SSE_URL, headers, transport="sse") is False
+        assert "cross-origin" in capsys.readouterr().err
+        assert not [r for r in httpx_mock.get_requests() if r.method == "POST"]
+
+    def test_sse_server_notification_before_response_is_skipped(self, httpx_mock):
+        """A server-initiated notification on the stream is not mistaken for the
+        initialize response — the probe keeps reading until the real result."""
+        notif = '{"jsonrpc":"2.0","method":"notifications/message","params":{}}'
+        httpx_mock.add_response(
+            url=self.SSE_URL,
+            method="GET",
+            stream=IteratorStream(
+                [
+                    b"event: endpoint\ndata: /messages\n\n",
+                    f"event: message\ndata: {notif}\n\n".encode(),
+                    f"event: message\ndata: {self._INIT_RESULT}\n\n".encode(),
+                ]
+            ),
+            headers={"content-type": "text/event-stream"},
+        )
+        httpx_mock.add_response(
+            url="https://example.com/messages", method="POST", status_code=202
+        )
+        assert (
+            check_connection(self.SSE_URL, dict(self.HEADERS), transport="sse")
+            is True
+        )
 
 
 # --- SSE transport ---


### PR DESCRIPTION
## Overview

`--check` always POSTed `initialize` directly to the configured URL — the Streamable HTTP probe. But under `--transport sse` the relay performs the legacy 2024-11-05 handshake (open a `GET` stream → receive the `endpoint` event → `POST` to that endpoint → read the JSON-RPC response off the stream). A bare POST to the SSE GET URL did **not** reflect what `run_sse` actually does, so `--check --transport sse` could pass or fail for the wrong reason.

## Change

- Add a `transport` parameter to `check_connection`; `cli.py` forwards `args.transport`.
- New `_check_connection_sse` runs the one-shot legacy handshake:
  - open the GET stream, confirm 200,
  - wait for the `endpoint` event (applying the **same cross-origin credential guard** as the relay reader — never POST an `Authorization` header off-origin),
  - POST `initialize` from a helper thread, and read the response that the server delivers back over the stream,
  - the helper closes the stream on POST failure so the probe fails fast instead of hanging until the read timeout.
- Extract the result reporting shared by both transports into `_report_initialize`, and harden it:
  - MCP capabilities are **presence-based**: `"tools": {}` now reports `tools=yes` (membership test, not truthiness — an empty object means *supported*, the previous truthiness check wrongly printed `no`).
  - Tolerate `serverInfo: null`, `capabilities: null`, and a non-object `result` without crashing on attribute access.

## Tests

- `TestCheckConnectionSse` — handshake success (+ asserts initialize is POSTed to the resolved endpoint), serverInfo/capabilities logging, GET non-200, MCP error on the stream, stream-ends-before-response, cross-origin endpoint refused with credentials (no off-origin POST), and a server notification skipped before the real response.
- `TestCheckConnection` — empty capability object reports `yes`, `capabilities: null` and non-object `result` no longer crash.
- `test_cli.py` — `--check` forwards `transport=streamable-http` by default and `transport=sse` with `--transport sse`.

Found by the ongoing Opus 4.8 multi-agent review (round 7, #11).

🤖 Generated with [Claude Code](https://claude.com/claude-code)