### PR TITLE
docs(readme): document the cancel filter and --oauth-device

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -52,6 +52,7 @@ Bearer token、カスタムヘッダー、OAuth 2.1 認証情報をリモート�
 - **ストリーミング耐性** — SSE レスポンスをリアルタイムで転送、ストリーム切断時に自動再接続
 - **行区切り文字の安全化** — 上流レスポンス中の生の `U+2028` / `U+2029`（JSON では合法だが JavaScript の行終端文字）をエスケープし、これらを改行として扱うクライアントによるフレーム崩れを防止。ロスレス（cf. modelcontextprotocol/typescript-sdk#2155）
 - **引数の正規化** — `tools/call` の `arguments` が `null` の場合は `{}` に書き換え、null 形式を拒否する厳格なサーバーでも呼び出せるようにする。デフォルト有効、`--no-normalize-arguments` で無効化（cf. modelcontextprotocol/typescript-sdk#2012）
+- **キャンセル対応フィルタ** — stdin の `notifications/cancelled` でキャンセルされた id を追跡し、その id を持つ遅延レスポンスがクライアントに届く前に drop する（MCP キャンセル仕様準拠）。デフォルト有効（TTL 60 秒）、`--no-cancel-filter` で無効化
 - **セッション回復** — 404 でセッション ID をリセットして再試行
 - **プロトコルバージョンヘッダー** — `initialize` 応答から交渉済みの `protocolVersion` を捕捉し、以降の Streamable HTTP リクエストすべてに `MCP-Protocol-Version` を付与（MCP 仕様 rev 2025-06-18）。このヘッダーを強制するサーバーは未送信時に初期化後リクエストを `400 Bad Request` で拒否する
 - **401 時の自動トークンリフレッシュ** — セッション中に OAuth トークンが失効しても自動更新
@@ -216,7 +217,7 @@ Claude Code・mcp-remote・Windows の既知の問題については [WORKAROUND
 
 ## 仕組み
 
-1. `--oauth` 指定時、アクセストークンを取得（キャッシュ → リフレッシュ → ブラウザ認証）
+1. `--oauth`（ブラウザ）または `--oauth-device`（ヘッドレス、RFC 8628）指定時、アクセストークンを取得（キャッシュ → リフレッシュ → ブラウザ/デバイス認証）
 2. stdin から JSON-RPC メッセージを読み取り（Claude Desktop/Code が送信）
 3. HTTPS でリモート MCP サーバーへ転送
 4. レスポンスをパースして stdout に書き出し

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ Bearer tokens, custom headers, and OAuth 2.1 credentials are forwarded to the re
 - **Streaming resilience** — streams SSE responses in real time; auto-reconnects on mid-stream disconnect
 - **Line-separator safety** — escapes raw `U+2028` / `U+2029` (legal in JSON, but JavaScript line terminators) in upstream responses so clients that treat them as line breaks cannot mis-frame the output; lossless (cf. modelcontextprotocol/typescript-sdk#2155)
 - **Argument normalization** — rewrites a `tools/call` request whose `arguments` is `null` to `{}` so strict servers that reject the null form accept the call; on by default, opt out with `--no-normalize-arguments` (cf. modelcontextprotocol/typescript-sdk#2012)
+- **Cancellation-aware filtering** — tracks request ids cancelled via `notifications/cancelled` on stdin and drops any late upstream response carrying one of those ids before it reaches the client, per the MCP cancellation spec; on by default (60 s TTL), opt out with `--no-cancel-filter`
 - **Session recovery** — resets MCP session ID on 404 and retries
 - **Protocol version header** — captures the negotiated `protocolVersion` from the `initialize` response and injects `MCP-Protocol-Version` on every subsequent Streamable HTTP request (MCP spec rev 2025-06-18); servers that enforce the header would otherwise reject post-initialize requests with `400 Bad Request`
 - **Token refresh on 401** — automatically refreshes expired OAuth tokens mid-session
@@ -217,7 +218,7 @@ See [WORKAROUNDS.md](WORKAROUNDS.md) for known issues in Claude Code, mcp-remote
 
 ## How It Works
 
-1. If `--oauth` is set, obtains an access token (cached → refresh → browser flow)
+1. If `--oauth` (browser) or `--oauth-device` (headless, RFC 8628) is set, obtains an access token (cached → refresh → browser/device flow)
 2. Reads JSON-RPC messages from stdin (sent by Claude Desktop/Code)
 3. Relays them over HTTPS to the remote MCP server
 4. Parses responses and writes them to stdout


### PR DESCRIPTION
## Overview

Two documentation gaps surfaced by the ongoing Opus 4.8 review (round 7, #19/#20):

- **Cancellation filter not in Features.** The `--no-cancel-filter` flag was listed under Usage but the cancel-aware response filter itself was never described as a feature. Added a "Cancellation-aware filtering" bullet explaining the `notifications/cancelled` id tracking, the 60 s TTL, and the opt-out.
- **`--oauth-device` missing from How It Works.** Step 1 only mentioned `--oauth` (browser flow); it now also names `--oauth-device` (RFC 8628 headless device flow), which equally obtains an access token.

Both edits are mirrored in `README.ja.md`.

Docs-only; no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)