### PR TITLE
fix(relay): gate notification error-synthesis in POST helpers; no protocol downgrade on recovery

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"080dd90c-eaf0-447e-9e28-d8ddfc4792ff","pid":1985,"procStart":"Sun May 31 13:25:50 2026","acquiredAt":1780277009014}

--- a/src/mcp_stdio/relay.py
+++ b/src/mcp_stdio/relay.py
@@ -654,6 +654,7 @@ def _post_and_stream(
     tracker: _CancelTracker | None = None,
     *,
     capture_init: bool = False,
+    has_id: bool = True,
 ) -> _StreamResult | None:
     """Send a POST and stream the response to stdout with retry.
 
@@ -666,6 +667,12 @@ def _post_and_stream(
     version from an InitializeResult), surfaced via
     ``_StreamResult.protocol_version``. Parsing is read-only and never
     affects what is written to stdout.
+
+    ``has_id`` mirrors the run() loop's notification policy one frame
+    deeper: a notification (no JSON-RPC id) must never receive a
+    synthesized error response, so the retry-exhausted / stream-interrupted
+    error writes below are suppressed when ``has_id`` is False (the failure
+    is still logged to stderr), matching the ``req_has_id`` gating in run().
     """
     last_error: Exception | None = None
     for attempt in range(1, MAX_RETRIES + 1):
@@ -731,15 +738,17 @@ def _post_and_stream(
                 # the POST would duplicate it. Surface a stream-interrupted
                 # error (at-most-once) rather than retry.
                 log("upstream stream interrupted after partial delivery; not retrying")
-                _write_line(
-                    _error_response(f"upstream stream interrupted: {e}", req_id)
-                )
+                if has_id:
+                    _write_line(
+                        _error_response(f"upstream stream interrupted: {e}", req_id)
+                    )
                 return None
             if attempt < MAX_RETRIES:
                 time.sleep(RETRY_DELAY * attempt)
 
     log(f"request failed after retries: {last_error}")
-    _write_line(_error_response(str(last_error), req_id))
+    if has_id:
+        _write_line(_error_response(str(last_error), req_id))
     return None
 
 
@@ -749,6 +758,8 @@ def _post_parsed(
     content: str,
     headers: dict[str, str],
     req_id: Any,
+    *,
+    has_id: bool = True,
 ) -> tuple[dict[str, Any] | None, _StreamResult | None]:
     """Send a POST and return the parsed JSON-RPC response.
 
@@ -761,6 +772,9 @@ def _post_parsed(
     decoded response dict on success, or ``None`` on non-200 / parse
     failure. ``stream_result`` is ``None`` only when all retries are
     exhausted (and the error was already printed to stdout).
+
+    ``has_id`` suppresses the retry-exhausted error write for a
+    notification, matching ``_post_and_stream`` and the run() loop.
     """
     last_error: Exception | None = None
     for attempt in range(1, MAX_RETRIES + 1):
@@ -812,7 +826,8 @@ def _post_parsed(
                 time.sleep(RETRY_DELAY * attempt)
 
     log(f"request failed after retries: {last_error}")
-    _write_line(_error_response(str(last_error), req_id))
+    if has_id:
+        _write_line(_error_response(str(last_error), req_id))
     return None, None
 
 
@@ -882,6 +897,8 @@ def _paginate_and_stream(
     req_id: Any,
     result_key: str,
     tracker: _CancelTracker | None = None,
+    *,
+    has_id: bool = True,
 ) -> _StreamResult | None:
     """Transparently follow ``result.nextCursor`` and emit one merged response.
 
@@ -898,7 +915,9 @@ def _paginate_and_stream(
     try:
         request = json.loads(line)
     except json.JSONDecodeError:
-        return _post_and_stream(client, url, line, headers, req_id, tracker)
+        return _post_and_stream(
+            client, url, line, headers, req_id, tracker, has_id=has_id
+        )
 
     base_params = request.get("params")
     params: dict[str, Any] = dict(base_params) if isinstance(base_params, dict) else {}
@@ -911,7 +930,9 @@ def _paginate_and_stream(
         page_request["params"] = params
         page_content = json.dumps(page_request)
 
-        parsed, stream = _post_parsed(client, url, page_content, headers, req_id)
+        parsed, stream = _post_parsed(
+            client, url, page_content, headers, req_id, has_id=has_id
+        )
         if stream is None:
             if page == 1:
                 return None  # error already printed
@@ -935,7 +956,9 @@ def _paginate_and_stream(
 
         if parsed is None:
             if page == 1:
-                return _post_and_stream(client, url, line, headers, req_id, tracker)
+                return _post_and_stream(
+                    client, url, line, headers, req_id, tracker, has_id=has_id
+                )
             log(
                 f"pagination: page {page} response not parseable, "
                 f"returning partial result"
@@ -1011,6 +1034,14 @@ def _reinitialize(
     Returns ``(new_session_id, negotiated_protocol_version)``. The session id
     is ``None`` on failure; the protocol version falls back to the passed-in
     ``protocol_version`` when the response omits ``result.protocolVersion``.
+
+    The initialize request advertises the previously-negotiated
+    ``protocol_version`` when known, rather than the 2024-11-05 floor: this
+    is a *recovery* handshake, so a higher version was already in force and
+    volunteering the floor would invite a silent downgrade. A first-contact
+    probe (``check_connection``) legitimately requests the floor; recovery
+    must not. The re-capture below still adopts whatever the server actually
+    returns, so a server that genuinely dropped support degrades gracefully.
     """
     initialize_msg = json.dumps(
         {
@@ -1018,7 +1049,7 @@ def _reinitialize(
             "method": "initialize",
             "id": 0,
             "params": {
-                "protocolVersion": "2024-11-05",
+                "protocolVersion": protocol_version or "2024-11-05",
                 "capabilities": {},
                 "clientInfo": {"name": "mcp-stdio", "version": __version__},
             },
@@ -1429,7 +1460,8 @@ def run(
                     # PAGINATED_LIST_METHODS, so an initialize request can never
                     # take this branch — keep that invariant if the table grows.
                     return _paginate_and_stream(
-                        client, url, content, h, req_id, detected[1], tracker
+                        client, url, content, h, req_id, detected[1], tracker,
+                        has_id=req_has_id,
                     )
                 # Capture-once semantics: we only learn the version from the
                 # first initialize. A later client-driven re-initialize that
@@ -1443,7 +1475,8 @@ def run(
                 # omits it and enforces the header would be self-contradictory.
                 capture_init = protocol_version is None and _looks_like_initialize(content)
                 result = _post_and_stream(
-                    client, url, content, h, req_id, tracker, capture_init=capture_init
+                    client, url, content, h, req_id, tracker,
+                    capture_init=capture_init, has_id=req_has_id,
                 )
                 if (
                     result is not None

--- a/tests/test_relay.py
+++ b/tests/test_relay.py
@@ -399,6 +399,70 @@ class TestPostAndStream:
         emitted = json.loads(stdout.getvalue().strip())
         assert emitted["result"] == {"ok": True}
 
+    def test_notification_retry_exhaustion_emits_no_error(self, httpx_mock):
+        """has_id=False (a notification): retry exhaustion must NOT synthesize an
+        id:null error — a notification can never receive a response."""
+        for _ in range(3):
+            httpx_mock.add_exception(httpx.ConnectError("net down"))
+        client = httpx.Client()
+        stdout = StringIO()
+        with patch("sys.stdout", stdout), patch("mcp_stdio.relay.time.sleep"):
+            result = _post_and_stream(
+                client,
+                "https://example.com/mcp",
+                '{"jsonrpc":"2.0","method":"notifications/progress"}',
+                {},
+                None,
+                has_id=False,
+            )
+        assert result is None
+        assert stdout.getvalue() == ""  # no id:null error written
+
+    def test_request_retry_exhaustion_still_emits_error(self, httpx_mock):
+        """has_id=True (a request): retry exhaustion still synthesizes the error
+        for the request id — the gate must not suppress legitimate responses."""
+        for _ in range(3):
+            httpx_mock.add_exception(httpx.ConnectError("net down"))
+        client = httpx.Client()
+        stdout = StringIO()
+        with patch("sys.stdout", stdout), patch("mcp_stdio.relay.time.sleep"):
+            result = _post_and_stream(
+                client, "https://example.com/mcp", '{"id":7}', {}, 7, has_id=True
+            )
+        assert result is None
+        emitted = json.loads(stdout.getvalue().strip())
+        assert emitted["id"] == 7
+        assert "error" in emitted
+
+    def test_notification_midstream_interrupt_emits_no_error(self, httpx_mock):
+        """has_id=False: a mid-stream disconnect after partial delivery passes the
+        already-emitted server payload through but synthesizes NO id:null error."""
+        delivered = '{"jsonrpc":"2.0","method":"server/event","params":{}}'
+
+        def gen():
+            yield f"event: message\ndata: {delivered}\n\n".encode()
+            raise httpx.ReadError("dropped mid-stream")
+
+        httpx_mock.add_response(
+            stream=IteratorStream(gen()),
+            headers={"content-type": "text/event-stream"},
+        )
+        client = httpx.Client()
+        stdout = StringIO()
+        with patch("sys.stdout", stdout), patch("mcp_stdio.relay.time.sleep"):
+            result = _post_and_stream(
+                client,
+                "https://example.com/mcp",
+                '{"jsonrpc":"2.0","method":"x"}',
+                {},
+                None,
+                has_id=False,
+            )
+        assert result is None
+        lines = [x for x in stdout.getvalue().strip().splitlines() if x]
+        # The server payload is passed through; no synthesized id:null error.
+        assert lines == [delivered]
+
 
 class TestIterSseEvents:
     """WHATWG Server-Sent Events line decoder shared by all SSE-decode sites."""
@@ -792,6 +856,34 @@ class TestRun:
         parsed = json.loads(output.strip())
         assert parsed["id"] == 5 and "error" in parsed
 
+    def test_notification_transport_failure_gets_no_synthesized_response(
+        self, httpx_mock
+    ):
+        """End-to-end: a notification whose POST exhausts all retries with a
+        transport error must NOT receive a synthesized id:null error. This
+        covers the helper-level gate (_post_and_stream has_id=False), one frame
+        deeper than the loop-level 4xx gate above."""
+        for _ in range(3):
+            httpx_mock.add_exception(httpx.ConnectError("net down"))
+        with patch("mcp_stdio.relay.time.sleep"):
+            output = self._run_with_stdin(
+                httpx_mock,
+                ['{"jsonrpc":"2.0","method":"notifications/progress","params":{}}'],
+            )
+        assert output.strip() == ""
+
+    def test_request_transport_failure_still_gets_error(self, httpx_mock):
+        """Contrast with the notification case: a request that exhausts retries
+        with a transport error still receives its JSON-RPC error response."""
+        for _ in range(3):
+            httpx_mock.add_exception(httpx.ConnectError("net down"))
+        with patch("mcp_stdio.relay.time.sleep"):
+            output = self._run_with_stdin(
+                httpx_mock, ['{"jsonrpc":"2.0","method":"tools/call","id":9}']
+            )
+        parsed = json.loads(output.strip())
+        assert parsed["id"] == 9 and "error" in parsed
+
     def test_401_retry_returns_404_cascades_into_reinitialize(self, httpx_mock):
         """The documented cross-branch cascade: a 401 whose refreshed retry
         returns 404 flows into the 404 re-initialize branch and recovers."""
@@ -1167,6 +1259,41 @@ class TestProtocolVersionHeader:
         assert reqs[3].headers["mcp-protocol-version"] == "2024-11-05"
         assert reqs[4].headers["mcp-protocol-version"] == "2024-11-05"
         assert reqs[5].headers["mcp-protocol-version"] == "2024-11-05"
+
+    def test_reinitialize_advertises_previously_negotiated_version(self, httpx_mock):
+        """The 404-recovery initialize must request the previously-negotiated
+        version, not the 2024-11-05 floor — volunteering the floor would invite
+        a silent downgrade of a session that had negotiated something newer."""
+        # 1: initialize -> negotiate 2025-06-18, session sess-1
+        httpx_mock.add_response(
+            text='{"jsonrpc":"2.0","result":{"protocolVersion":"2025-06-18"},"id":1}',
+            headers={"content-type": "application/json", "mcp-session-id": "sess-1"},
+        )
+        # 2: tools/call -> 404 (session expired)
+        httpx_mock.add_response(
+            status_code=404, text="", headers={"content-type": "application/json"}
+        )
+        # 3: reinit initialize -> server keeps 2025-06-18, new session
+        httpx_mock.add_response(
+            text='{"jsonrpc":"2.0","result":{"protocolVersion":"2025-06-18"},"id":0}',
+            headers={"content-type": "application/json", "mcp-session-id": "sess-2"},
+        )
+        httpx_mock.add_response(status_code=202, text="")  # reinit initialized
+        httpx_mock.add_response(
+            text='{"jsonrpc":"2.0","result":{},"id":2}',
+            headers={"content-type": "application/json"},
+        )
+        self._run_with_stdin(
+            [
+                '{"jsonrpc":"2.0","method":"initialize","id":1}',
+                '{"jsonrpc":"2.0","method":"tools/call","id":2}',
+            ]
+        )
+        reqs = httpx_mock.get_requests()
+        # reqs[2] is the recovery initialize; its body must advertise the
+        # already-negotiated version, not the floor.
+        reinit_body = json.loads(reqs[2].read())
+        assert reinit_body["params"]["protocolVersion"] == "2025-06-18"
 
     def test_reinitialize_recaptures_version_from_sse_framed_response(self, httpx_mock):
         """The 404-recovery re-initialize response may itself be SSE-framed —


### PR DESCRIPTION
## Overview

Two correctness fixes on the Streamable HTTP `run()` path, found by the ongoing Opus 4.8 multi-agent review (round 8, #1 MEDIUM and #5 LOW).

## 1. Notification `id:null` error response (JSON-RPC violation) — #1

PR #109 made the `run()` loop meticulous about never synthesizing a response for a notification: every loop-level `_error_response` site is gated on `req_has_id`. But the two POST helpers — `_post_and_stream` and `_post_parsed` — write their **own** retry-exhausted / stream-interrupted error responses one stack frame deeper, and those were not gated. A notification (no `id`, e.g. `notifications/progress`) forwarded during a 3× transient network failure or a post-emit disconnect therefore received an unsolicited `{"jsonrpc":"2.0","error":{...},"id":null}` on stdout — exactly the violation the `req_has_id` gating was built to prevent.

**Fix:** thread a `has_id` flag down through `_dispatch` → `_paginate_and_stream` → `_post_and_stream` / `_post_parsed`, and gate the three internal `_write_line(_error_response(...))` calls. When `has_id` is False the failure is logged to stderr only, matching the loop's notification policy.

## 2. Silent protocol downgrade on 404 session recovery — #5

`_reinitialize` already receives the previously-negotiated `protocol_version`, but the recovery `initialize` request always advertised the `2024-11-05` floor. A spec-conformant server picks the highest mutually-supported version, so volunteering the floor invites a silent downgrade of a session that had negotiated something newer (e.g. `2025-06-18`).

**Fix:** advertise `protocol_version or "2024-11-05"`. The existing re-capture logic still adopts whatever the server actually returns, so a server that genuinely dropped support degrades gracefully. First-contact probes (`check_connection`) legitimately keep requesting the floor — only recovery changes.

## Tests

- `_post_and_stream`: notification retry-exhaustion and mid-stream-interrupt emit **no** `id:null` error; request path still emits its error.
- End-to-end through `run()`: a notification whose POST exhausts retries with a transport error produces empty stdout; a request still gets its JSON-RPC error.
- `TestProtocolVersionHeader`: the 404-recovery initialize body advertises the previously-negotiated version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)