### PR TITLE
fix(token_store): guard legacy unlink in migration; isolate post-rename chmod

### DIFF
--- a/src/mcp_stdio/token_store.py
+++ b/src/mcp_stdio/token_store.py
@@ -124,8 +124,16 @@ def _migrate_legacy_store() -> None:
     if not _LEGACY_STORE_FILE.exists():
         return
     if _STORE_FILE.exists():
-        # New file already exists — just remove legacy
-        _LEGACY_STORE_FILE.unlink()
+        # New file already exists — best-effort removal of the now-redundant
+        # legacy file. This runs UNLOCKED from load_token, so the unlink can
+        # lose a TOCTOU race against a concurrent migration (ENOENT) or hit a
+        # read-only / permission-locked legacy FS. Neither must be allowed to
+        # crash a read of the already-migrated store, so guard it like every
+        # other filesystem op in this function.
+        try:
+            _LEGACY_STORE_FILE.unlink()
+        except OSError:
+            pass
     else:
         _ensure_store_dir()
         # Tighten the legacy file's mode BEFORE moving it, so the secrets never
@@ -137,7 +145,6 @@ def _migrate_legacy_store() -> None:
             pass
         try:
             _LEGACY_STORE_FILE.rename(_STORE_FILE)
-            os.chmod(_STORE_FILE, stat.S_IRUSR | stat.S_IWUSR)
         except OSError:
             # rename() can fail for two reasons:
             #  - EXDEV: the legacy and XDG paths are on different filesystems.
@@ -163,6 +170,16 @@ def _migrate_legacy_store() -> None:
                         _LEGACY_STORE_FILE.unlink()
                     except OSError:
                         pass
+        else:
+            # rename() succeeded — re-assert 0o600 on the moved inode as a
+            # belt-and-suspenders step (the line-143 pre-tighten already set
+            # it). This is in its OWN guard, not the rename try, so a chmod
+            # failure here is not misread as a rename/EXDEV failure and routed
+            # into the copy-through recovery above.
+            try:
+                os.chmod(_STORE_FILE, stat.S_IRUSR | stat.S_IWUSR)
+            except OSError:
+                pass
     # Remove legacy directory if empty
     try:
         _LEGACY_STORE_DIR.rmdir()

--- a/tests/test_token_store.py
+++ b/tests/test_token_store.py
@@ -510,6 +510,70 @@ class TestLegacyMigration:
         assert loaded.access_token == "new"
         assert not legacy_file.exists()
 
+    def test_legacy_unlink_failure_when_new_exists_does_not_crash(
+        self, tmp_path, monkeypatch
+    ):
+        """If the new store already exists, a failure to remove the redundant
+        legacy file (read-only FS, or a TOCTOU race that already unlinked it)
+        must NOT crash load_token — the migrated store is still readable."""
+        legacy_dir = tmp_path / "legacy"
+        legacy_file = legacy_dir / "tokens.json"
+        new_dir = tmp_path / "new"
+        new_file = new_dir / "tokens.json"
+
+        legacy_dir.mkdir()
+        legacy_file.write_text('{"https://example.com/mcp": {"access_token": "old"}}')
+        new_dir.mkdir()
+        new_file.write_text('{"https://example.com/mcp": {"access_token": "new"}}')
+
+        monkeypatch.setattr("mcp_stdio.token_store._STORE_DIR", new_dir)
+        monkeypatch.setattr("mcp_stdio.token_store._STORE_FILE", new_file)
+        monkeypatch.setattr("mcp_stdio.token_store._LEGACY_STORE_DIR", legacy_dir)
+        monkeypatch.setattr("mcp_stdio.token_store._LEGACY_STORE_FILE", legacy_file)
+
+        real_unlink = os.unlink
+
+        def failing_unlink(path, *a, **k):
+            if os.fspath(path) == os.fspath(legacy_file):
+                raise PermissionError(13, "read-only legacy fs")
+            return real_unlink(path, *a, **k)
+
+        monkeypatch.setattr("mcp_stdio.token_store.os.unlink", failing_unlink)
+
+        # Must not raise — the already-migrated store is returned intact.
+        loaded = load_token("https://example.com/mcp")
+        assert loaded is not None and loaded.access_token == "new"
+
+    def test_post_rename_chmod_failure_completes_migration(
+        self, tmp_path, monkeypatch
+    ):
+        """A chmod failure after a successful rename must not abort or divert the
+        migration into the copy-through recovery — the moved file stands."""
+        if sys.platform == "win32":
+            pytest.skip("POSIX mode bits don't model NTFS ACLs")
+        legacy_dir = tmp_path / "legacy"
+        legacy_file = legacy_dir / "tokens.json"
+        new_dir = tmp_path / "new"
+        new_file = new_dir / "tokens.json"
+
+        legacy_dir.mkdir()
+        legacy_file.write_text('{"https://example.com/mcp": {"access_token": "old"}}')
+
+        monkeypatch.setattr("mcp_stdio.token_store._STORE_DIR", new_dir)
+        monkeypatch.setattr("mcp_stdio.token_store._STORE_FILE", new_file)
+        monkeypatch.setattr("mcp_stdio.token_store._LEGACY_STORE_DIR", legacy_dir)
+        monkeypatch.setattr("mcp_stdio.token_store._LEGACY_STORE_FILE", legacy_file)
+
+        def failing_chmod(*a, **k):
+            raise PermissionError(1, "operation not permitted")
+
+        monkeypatch.setattr("mcp_stdio.token_store.os.chmod", failing_chmod)
+
+        loaded = load_token("https://example.com/mcp")
+        assert loaded is not None and loaded.access_token == "old"
+        assert new_file.exists()
+        assert not legacy_file.exists()  # genuinely renamed, not copy-through
+
     def test_no_migration_if_no_legacy(self, tmp_path, monkeypatch):
         """No error when legacy path does not exist."""
         new_dir = tmp_path / "new"


### PR DESCRIPTION
## Overview

Two robustness fixes in `_migrate_legacy_store`, which runs **unlocked** from `load_token` → `_read_store`. Found by the ongoing Opus 4.8 review (round 8, #2 MEDIUM and #16 NIT).

## 1. Unguarded legacy unlink can crash every `load_token` — #2

The "new store already exists" branch removed the redundant legacy file with a bare `_LEGACY_STORE_FILE.unlink()`. Two failure modes:

- **TOCTOU race**: between the `exists()` check and the `unlink()`, a concurrent migration removes the legacy file first → `FileNotFoundError`.
- **Durable failure**: a read-only legacy FS or a permission anomaly makes the unlink raise `OSError` on **every** `load_token` call, permanently breaking token loading even though a perfectly good migrated store exists.

Either propagates straight out of `load_token` (which has no `try/except` around `_read_store`), crashing the OAuth/relay path. Now wrapped in `try/except OSError`, matching every other filesystem op in the function. Cleanup of the redundant legacy file must never fail a read of the already-migrated store.

## 2. Post-rename chmod conflated with EXDEV/race recovery — #16

The post-rename `os.chmod` shared the rename's `try` block, so a chmod failure fell into the `except` and was handled by the EXDEV / concurrent-race recovery logic. Moved into an `else` clause with its own guard, so a chmod failure is no longer indistinguishable from a rename failure and cannot divert a successfully-renamed file into the copy-through path.

## Tests

- `test_legacy_unlink_failure_when_new_exists_does_not_crash`: legacy-unlink raises `PermissionError`; `load_token` still returns the migrated store.
- `test_post_rename_chmod_failure_completes_migration`: `os.chmod` always raises; the rename migration still completes (file moved, not copy-through).

🤖 Generated with [Claude Code](https://claude.com/claude-code)