### PR TITLE
fix(cli): catch refresher() exceptions; treat empty leeway env var as unset

### DIFF
--- a/src/mcp_stdio/cli.py
+++ b/src/mcp_stdio/cli.py
@@ -102,6 +102,14 @@ def _build_token_refresher(
             new_headers = dict(headers)
             new_headers["Authorization"] = f"Bearer {data.access_token}"
             return new_headers
+        except Exception as e:
+            # Mirror upgrader(): a refresh failure beyond the network call
+            # (e.g. save_token re-raising OSError on a full/read-only disk)
+            # must degrade to None so the relay's 401 handler emits a JSON-RPC
+            # auth error and keeps the session alive, instead of an uncaught
+            # crash that drops the stdio connection mid-session (#11 contract).
+            print(f"error: token refresh failed: {e}", file=sys.stderr)
+            return None
         finally:
             client.close()
 
@@ -209,7 +217,11 @@ def main() -> None:
         # Pass as string so argparse re-applies _non_negative_float to the
         # default — invalid env var values (negative, non-numeric) surface
         # as argparse errors instead of a raw Python ValueError on startup.
-        default=os.environ.get("MCP_OAUTH_REFRESH_LEEWAY", "60"),
+        # `or "60"` treats an exported-but-EMPTY env var (a common CI artifact
+        # of `export VAR=$MAYBE_UNSET`) as unset rather than aborting startup
+        # with "invalid float value: ''"; a genuinely malformed value still
+        # errors.
+        default=(os.environ.get("MCP_OAUTH_REFRESH_LEEWAY") or "60"),
         metavar="SECONDS",
         help=(
             "Proactively refresh access tokens this many seconds before they "

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -185,6 +185,22 @@ class TestMain:
             main()
         assert mock_ensure.call_args.kwargs["refresh_leeway"] == 120.0
 
+    def test_oauth_refresh_leeway_empty_env_var_falls_back_to_default(
+        self, monkeypatch
+    ):
+        """An exported-but-EMPTY MCP_OAUTH_REFRESH_LEEWAY (a common CI artifact
+        of `export VAR=$MAYBE_UNSET`) must fall back to the 60 s default, not
+        abort startup with an argparse 'invalid float value' error."""
+        monkeypatch.setenv("MCP_OAUTH_REFRESH_LEEWAY", "")
+        with (
+            patch("sys.argv", ["mcp-stdio", "--oauth", "https://example.com/mcp"]),
+            patch("mcp_stdio.oauth.ensure_token") as mock_ensure,
+            patch("mcp_stdio.cli.run"),
+        ):
+            mock_ensure.return_value.access_token = "tok"
+            main()
+        assert mock_ensure.call_args.kwargs["refresh_leeway"] == 60.0
+
     def test_oauth_refresh_leeway_negative_rejected(self, capsys):
         """#56: negative leeway values are rejected at parse time."""
         with patch(
@@ -732,10 +748,26 @@ class TestBuildTokenRefresher:
         assert refresher() is None
         assert _SpyClient.instances[-1].closed
 
+    def test_returns_none_when_refresh_raises_and_closes(self, monkeypatch, capsys):
+        """A refresh that RAISES (e.g. save_token re-raising OSError on a
+        read-only disk) must degrade to None — not crash the relay mid-session
+        — and still close the client. Symmetric with the upgrader."""
+        _SpyClient.instances.clear()
+        monkeypatch.setattr("mcp_stdio.cli.httpx.Client", _SpyClient)
+
+        def boom(url, client):
+            raise OSError("read-only file system")
+
+        monkeypatch.setattr("mcp_stdio.oauth.refresh_cached_token", boom)
+        refresher = _build_token_refresher("https://example.com/mcp", {}, 10, 120)
+        assert refresher() is None
+        assert _SpyClient.instances[-1].closed
+        assert "token refresh failed" in capsys.readouterr().err
+
 
 class TestBuildScopeUpgrader:
     """The upgrader closure runs RFC 9470 step-up and returns broader-scope
-    headers, catching exceptions (unlike the refresher)."""
+    headers; like the refresher, it catches exceptions and degrades to None."""
 
     def test_returns_bearer_headers_and_closes_client(self, monkeypatch):
         _SpyClient.instances.clear()


### PR DESCRIPTION
## Overview

Two `cli.py` robustness fixes from the Opus 4.8 review (round 8, #3 MEDIUM and #17 NIT).

## 1. `refresher()` did not catch exceptions, unlike `upgrader()` — #3

The `refresher()` closure called `refresh_cached_token` with no `try/except`, while the sibling `upgrader()` wraps `step_up_authorize` in `try/except Exception` and returns `None` on failure. `refresh_cached_token` only guards its network call, so a failure further along — `save_token` → `_write_store` re-raising `OSError` on a full / read-only disk, or token parsing — propagated out of `refresher()`, then out of `run()` (whose per-line loop has only `try ... finally: client.close()`, no `except`), crashing the process and dropping the stdio connection mid-session.

The relay's 401 handler is explicitly designed to treat a `None` return as graceful (emit a JSON-RPC auth error and continue), which the "never hang/crash mid-session" contract depends on. The unguarded refresher bypassed that. Now it mirrors `upgrader()`: print to stderr, return `None`.

## 2. Empty `MCP_OAUTH_REFRESH_LEEWAY` aborts startup — #17

`default=os.environ.get("MCP_OAUTH_REFRESH_LEEWAY", "60")` returns `""` (not the default) when the var is exported empty — a common CI artifact of `export VAR=$MAYBE_UNSET`. argparse then re-applies the float parser to `""` and aborts with `invalid float value: ''` (exit 2). Changed to `or "60"` so empty-is-unset; a genuinely malformed value (`"abc"`, `"-1"`) still errors as before.

## Tests

- `test_returns_none_when_refresh_raises_and_closes`: a refresh raising `OSError` returns `None`, closes the client, logs to stderr.
- `test_oauth_refresh_leeway_empty_env_var_falls_back_to_default`: empty env var → `refresh_leeway=60`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)