### PR TITLE
docs(readme): add "MCP SDKs" to the WORKAROUNDS pointer

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -213,7 +213,7 @@ mcp-stdio [OPTIONS] URL
 
 ## ワークアラウンド
 
-Claude Code・mcp-remote・Windows の既知の問題については [WORKAROUNDS.md](WORKAROUNDS.md) を参照してください。
+Claude Code・mcp-remote・MCP SDK・Windows の既知の問題については [WORKAROUNDS.md](WORKAROUNDS.md) を参照してください。
 
 ## 仕組み
 

--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ Run `mcp-stdio --help` for the full per-flag detail (platform notes and issue re
 
 ## Workarounds
 
-See [WORKAROUNDS.md](WORKAROUNDS.md) for known issues in Claude Code, mcp-remote, and Windows that mcp-stdio addresses.
+See [WORKAROUNDS.md](WORKAROUNDS.md) for known issues in Claude Code, mcp-remote, the MCP SDKs, and Windows that mcp-stdio addresses.
 
 ## How It Works
 


### PR DESCRIPTION
## Overview

`WORKAROUNDS.md` now has four sections — `## Claude Code`, `## mcp-remote`, `## MCP SDKs`, `## Windows` — but the README pointer sentence still listed only three, omitting the recently-added **MCP SDKs** section (the U+2028/U+2029 escaping, `MCP-Protocol-Version` header, and `arguments:null` normalization entries). A reader scanning the README would not know those cross-cutting SDK interop fixes are documented.

Updated the pointer in both `README.md` and `README.ja.md` to include the MCP SDKs.

Docs-only. Found by the Opus 4.8 review (round 8, #14/#19).

🤖 Generated with [Claude Code](https://claude.com/claude-code)