### PR TITLE
fix(oauth): persist AS issuer (RFC 9207); strip userinfo from default endpoints; cap device-flow lifetime

### DIFF
--- a/src/mcp_stdio/oauth.py
+++ b/src/mcp_stdio/oauth.py
@@ -32,6 +32,14 @@ from .token_store import TokenData, delete_token, load_token, save_token
 # a single sleep cannot block for hours, mirroring relay.py's Retry-After cap.
 _DEVICE_POLL_CAP_SECS = 60
 
+# Upper bound on the whole device-flow lifetime. ``expires_in`` from the AS
+# drives the poll loop's deadline; the per-sleep interval is already capped, but
+# without a ceiling on the total an AS returning ``expires_in: 999999999`` would
+# keep the process polling the token endpoint for years. RFC 8628 device codes
+# are typically ~1800 s; 3600 s is a generous bound that still kills the
+# pathological case.
+_DEVICE_FLOW_MAX_LIFETIME_SECS = 3600
+
 
 def _safe_int(value: Any, default: int) -> int:
     """Coerce an AS-supplied JSON value to int, falling back on bad input."""
@@ -64,9 +72,25 @@ def _authorization_base_url(server_url: str) -> str:
     """Derive authorization base URL by stripping the path component.
 
     Per MCP spec: https://api.example.com/v1/mcp -> https://api.example.com
+
+    Any embedded userinfo (``user:pass@``) is dropped. ``_validate_endpoint_url``
+    rejects AS-declared endpoints carrying userinfo as a parser-confusion /
+    exfiltration vector (#13); the default ``/authorize`` and ``/token``
+    endpoints synthesised from this base must not reintroduce it, or a
+    ``https://user:pass@host/mcp`` server URL would cause credentials and
+    authorization codes to be POSTed to ``https://user:pass@host/token``.
     """
     parsed = urlparse(server_url)
-    return f"{parsed.scheme}://{parsed.netloc}"
+    host = parsed.hostname or ""
+    # urlparse strips the brackets from an IPv6 literal host — restore them.
+    if ":" in host:
+        host = f"[{host}]"
+    try:
+        port = parsed.port
+    except ValueError:
+        port = None
+    netloc = f"{host}:{port}" if port is not None else host
+    return f"{parsed.scheme}://{netloc}"
 
 
 # Default ports used when normalising a parsed URL into a RFC 6454 origin
@@ -846,6 +870,7 @@ def _token_response_to_data(
         token_endpoint=metadata.token_endpoint,
         authorization_endpoint=metadata.authorization_endpoint,
         registration_endpoint=metadata.registration_endpoint,
+        issuer=metadata.issuer,
         token_endpoint_auth_method=auth_method,
         no_resource_indicator=no_resource_indicator,
     )
@@ -894,6 +919,9 @@ def refresh_cached_token(
         authorization_endpoint=cached.authorization_endpoint,
         token_endpoint=cached.token_endpoint,
         registration_endpoint=cached.registration_endpoint,
+        # Carry the persisted issuer through so a refresh does not wipe it
+        # (_token_response_to_data now writes metadata.issuer into TokenData).
+        issuer=cached.issuer,
     )
     data = _token_response_to_data(
         raw,
@@ -1175,8 +1203,12 @@ def _run_device_authorization_flow(
     )
     # Coerce defensively: a JSON float-as-string or non-numeric value from a
     # malformed/hostile AS must fall back to the default, not raise ValueError
-    # out of the flow.
-    expires_in = _safe_int(da.get("expires_in"), 1800)
+    # out of the flow. Clamp to a max lifetime so an inflated expires_in cannot
+    # keep the poll loop (and the process) alive indefinitely — the per-sleep
+    # interval cap above does not bound the overall deadline on its own.
+    expires_in = max(
+        1, min(_safe_int(da.get("expires_in"), 1800), _DEVICE_FLOW_MAX_LIFETIME_SECS)
+    )
     # Clamp the AS-supplied polling interval to a sane window so a hostile or
     # misconfigured AS cannot make a single time.sleep block for hours (or
     # raise on a negative value), mirroring the cap-gated Retry-After sleep in
@@ -1405,6 +1437,11 @@ def step_up_authorize(
             authorization_endpoint=cached.authorization_endpoint,
             token_endpoint=cached.token_endpoint,
             registration_endpoint=cached.registration_endpoint,
+            # Rehydrate the persisted issuer so the RFC 9207 `iss` mix-up check
+            # in _run_authorization_flow stays active on this cache-hit path —
+            # step-up runs a full browser+callback flow, the case most exposed
+            # to AS mix-up, so the defence must not silently no-op here.
+            issuer=cached.issuer,
         )
     else:
         metadata = discover_oauth_metadata(server_url, client)

--- a/src/mcp_stdio/token_store.py
+++ b/src/mcp_stdio/token_store.py
@@ -99,6 +99,10 @@ class TokenData:
     token_endpoint: str = ""
     authorization_endpoint: str = ""
     registration_endpoint: str | None = None
+    # RFC 8414 issuer identifier of the authorization server. Persisted so the
+    # RFC 9207 `iss` mix-up check survives across invocations (e.g. a step-up
+    # that reconstructs OAuthMetadata from this cached entry).
+    issuer: str | None = None
     # Token endpoint authentication method (RFC 6749 §2.3 / RFC 8414)
     token_endpoint_auth_method: str = "none"
     # Suppress RFC 8707 resource parameter (for AS that reject it, e.g. Entra ID v2)

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -73,6 +73,28 @@ class TestAuthorizationBaseUrl:
             == "https://api.example.com"
         )
 
+    def test_strips_embedded_userinfo(self):
+        """#9: userinfo must be dropped so the synthesised default /authorize
+        and /token endpoints never carry credentials (bypassing the #13
+        endpoint-userinfo rejection)."""
+        assert (
+            _authorization_base_url("https://user:pass@api.example.com/v1/mcp")
+            == "https://api.example.com"
+        )
+
+    def test_strips_userinfo_keeps_port(self):
+        assert (
+            _authorization_base_url("https://user:pass@api.example.com:8443/mcp")
+            == "https://api.example.com:8443"
+        )
+
+    def test_ipv6_host_rebracketed(self):
+        """An IPv6 literal host must keep its brackets after userinfo stripping."""
+        assert (
+            _authorization_base_url("https://user@[2001:db8::1]:9000/mcp")
+            == "https://[2001:db8::1]:9000"
+        )
+
 
 # --- PKCE ---
 
@@ -1072,6 +1094,41 @@ class TestRefreshCachedToken:
         req = httpx_mock.get_requests()[0]
         assert b"resource=https%3A%2F%2Fapi.example.com%2Fmcp" in req.content
 
+    def test_refresh_preserves_persisted_issuer(
+        self, tmp_path, monkeypatch, httpx_mock
+    ):
+        """#6/#8: a refresh must not wipe the persisted AS issuer — otherwise the
+        RFC 9207 iss check would silently go dark after the first refresh."""
+        store_file = tmp_path / "tokens.json"
+        monkeypatch.setattr("mcp_stdio.token_store._STORE_DIR", tmp_path)
+        monkeypatch.setattr("mcp_stdio.token_store._STORE_FILE", store_file)
+
+        from mcp_stdio.token_store import load_token, save_token
+
+        save_token(
+            "https://api.example.com/mcp",
+            TokenData(
+                access_token="old_at",
+                refresh_token="rt123",
+                expires_at=time.time() - 10,
+                client_id="cid",
+                token_endpoint="https://auth.example.com/token",
+                authorization_endpoint="https://auth.example.com/authorize",
+                issuer="https://auth.example.com",
+            ),
+        )
+        httpx_mock.add_response(
+            url="https://auth.example.com/token",
+            json={"access_token": "new_at", "expires_in": 3600},
+        )
+        client = httpx.Client()
+        data = refresh_cached_token("https://api.example.com/mcp", client)
+        assert data is not None and data.issuer == "https://auth.example.com"
+        # And it survives the round-trip back to disk.
+        assert load_token("https://api.example.com/mcp").issuer == (
+            "https://auth.example.com"
+        )
+
     def test_returns_none_when_no_cached_token(self, tmp_path, monkeypatch):
         store_file = tmp_path / "tokens.json"
         monkeypatch.setattr("mcp_stdio.token_store._STORE_DIR", tmp_path)
@@ -1211,6 +1268,18 @@ class TestTokenResponseToData:
         data = _token_response_to_data(raw, meta, "cid", None)
         assert data.access_token == "at"
         assert data.expires_at is None  # no expiry known
+
+    def test_persists_issuer_for_rfc9207(self):
+        """#6/#8: the AS issuer is persisted so the RFC 9207 iss mix-up check
+        survives a step-up that reconstructs metadata from the cached token."""
+        raw = {"access_token": "at", "expires_in": 3600}
+        meta = OAuthMetadata(
+            authorization_endpoint="https://ex.com/auth",
+            token_endpoint="https://ex.com/token",
+            issuer="https://ex.com",
+        )
+        data = _token_response_to_data(raw, meta, "cid", None)
+        assert data.issuer == "https://ex.com"
 
     def test_no_refresh_token(self):
         """FastMCP #1356: no refresh_token in response."""
@@ -3440,6 +3509,30 @@ class TestDeviceAuthorizationFlow:
         assert data.access_token == "acc"
         assert data.refresh_token == "ref"
         assert data.client_id == "cid"
+
+    def test_expires_in_clamped_to_max_lifetime(
+        self, httpx_mock, tmp_path, monkeypatch, capsys
+    ):
+        """#7: an inflated expires_in is clamped to the max device-flow lifetime
+        so the poll loop cannot stay alive for years."""
+        from mcp_stdio.oauth import _DEVICE_FLOW_MAX_LIFETIME_SECS
+
+        self._patch_store(tmp_path, monkeypatch)
+        httpx_mock.add_response(url=REG_URL, json={"client_id": "cid"})
+        httpx_mock.add_response(
+            url=DEVICE_AUTH_URL, json=_da_response(expires_in=999999999)
+        )
+        httpx_mock.add_response(
+            url=TOKEN_URL, json={"access_token": "acc", "token_type": "Bearer"}
+        )
+
+        client = httpx.Client()
+        _run_device_authorization_flow(
+            MCP_URL, client, metadata=_device_meta(), cached=None
+        )
+        err = capsys.readouterr().err
+        assert f"expires in {_DEVICE_FLOW_MAX_LIFETIME_SECS}s" in err
+        assert "999999999" not in err
 
     def test_verification_uri_complete_printed(self, httpx_mock, tmp_path, monkeypatch, capsys):
         """verification_uri_complete is shown when present."""


### PR DESCRIPTION
## Overview

Three defense-in-depth hardening fixes from the Opus 4.8 review (round 8, all LOW: #6/#8, #9, #7).

## 1. RFC 9207 `iss` mix-up check went dark on step-up — #6/#8

`TokenData` never persisted the AS issuer, so `step_up_authorize` reconstructed `OAuthMetadata` with `issuer=None`. The RFC 9207 `iss` check in `_run_authorization_flow` is gated on `metadata.issuer` being truthy, so it no-op'd — **precisely** on the step-up path, which runs a full browser+callback authorization flow (the case most exposed to AS mix-up). PKCE+state still cover the primary attacks, so this was missing defense-in-depth, not an open hole.

**Fix:** add `issuer` to `TokenData`; write it in `_token_response_to_data`; rehydrate it into the reconstructed metadata in `step_up_authorize`; and carry `cached.issuer` through `refresh_cached_token` so a refresh doesn't wipe it (`_token_response_to_data` now writes `metadata.issuer`). The field is forward/backward compatible: old stores load (default `None`), new stores round-trip.

## 2. Embedded userinfo leaked into self-constructed default endpoints — #9

`_authorization_base_url` returned `f"{scheme}://{parsed.netloc}"`, and `netloc` retains any userinfo. The default `/authorize` and `/token` endpoints are built from this base, so a `https://user:pass@host/mcp` server URL would POST credentials and authorization codes to `https://user:pass@host/token` — bypassing the `_validate_endpoint_url` userinfo rejection (#13) that guards AS-*declared* endpoints.

**Fix:** rebuild the base from `parsed.hostname` (re-bracketing IPv6 literals) plus an explicit port, dropping userinfo.

## 3. Device-flow `expires_in` had no upper bound — #7

The per-sleep polling interval was capped, but the overall `deadline = monotonic() + expires_in` was not. A hostile/misconfigured AS returning `expires_in: 999999999` would keep the process polling the token endpoint for years.

**Fix:** clamp `expires_in` to `_DEVICE_FLOW_MAX_LIFETIME_SECS` (3600), mirroring the existing interval cap.

## Tests

- `_token_response_to_data` persists `issuer`; `refresh_cached_token` preserves it across a disk round-trip.
- `_authorization_base_url` strips userinfo (incl. IPv6, keeping the port).
- Device-flow `expires_in: 999999999` is clamped to the max lifetime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)