### PR TITLE
fix(oauth): preserve granted scope across refresh (MED) + 5 defense-in-depth fixes

### DIFF
--- a/src/mcp_stdio/oauth.py
+++ b/src/mcp_stdio/oauth.py
@@ -476,6 +476,12 @@ def discover_oauth_metadata(
         authorization_endpoint=f"{base}/authorize",
         token_endpoint=f"{base}/token",
         registration_endpoint=f"{base}/register",
+        # No metadata was validated on this fallback, so it is the LEAST
+        # trustworthy discovery outcome — keep the RFC 9207 iss mix-up check
+        # active by pinning the issuer to the base the endpoints derive from.
+        # Otherwise an AS returning `iss` would be compared against None and
+        # the defence would silently no-op precisely here.
+        issuer=base,
     )
 
 
@@ -575,8 +581,15 @@ def register_client(
     # special-case it.
     raw_expiry = data.get("client_secret_expires_at")
     expiry: float | None = None
-    if raw_expiry:
-        expiry = float(raw_expiry)
+    # Coerce defensively and treat 0 as "never expires" regardless of JSON type.
+    # RFC 7591 specifies a number, but a non-conformant AS sending the string
+    # "0" would be truthy here — float("0") == 0.0 would then read as
+    # already-expired and force an unnecessary re-DCR on every refresh/step-up.
+    try:
+        v = float(raw_expiry) if raw_expiry is not None else 0.0
+        expiry = v if v else None
+    except (TypeError, ValueError):
+        expiry = None
     # RFC 7591 §3.2.1 REQUIRES client_id; use .get() with an explicit error so a
     # malformed registration response is actionable, not a bare KeyError.
     client_id = data.get("client_id")
@@ -821,6 +834,7 @@ def _token_response_to_data(
     client_secret: str | None,
     *,
     previous_refresh_token: str | None = None,
+    previous_scope: str | None = None,
     client_secret_expires_at: float | None = None,
     auth_method: str = "none",
     no_resource_indicator: bool = False,
@@ -829,7 +843,17 @@ def _token_response_to_data(
 
     If the response omits refresh_token (allowed per RFC 6749 Section 6),
     the previous_refresh_token is preserved so subsequent refreshes work.
+    Likewise ``scope`` is OPTIONAL in a token response (RFC 6749 §5.1: it
+    may be omitted when identical to the requested scope, which refreshes
+    routinely do), so ``previous_scope`` is preserved — otherwise a refresh
+    would wipe the granted scope and a later step-up could not union it.
     """
+    if not raw.get("access_token"):
+        # RFC 6749 §5.1 makes access_token REQUIRED. A response missing it is
+        # not a usable token; fail loudly here instead of constructing a
+        # TokenData with a None/empty credential that fails opaquely later.
+        raise RuntimeError("token response missing access_token (RFC 6749 §5.1)")
+
     expires_at = None
     if "expires_in" in raw:
         # ``expires_in`` is numeric in JSON responses but a string in
@@ -863,7 +887,7 @@ def _token_response_to_data(
         token_type=token_type,
         expires_at=expires_at,
         refresh_token=raw.get("refresh_token") or previous_refresh_token,
-        scope=raw.get("scope"),
+        scope=raw.get("scope") or previous_scope,
         client_id=client_id,
         client_secret=client_secret,
         client_secret_expires_at=client_secret_expires_at,
@@ -929,6 +953,7 @@ def refresh_cached_token(
         cached.client_id,
         cached.client_secret,
         previous_refresh_token=cached.refresh_token,
+        previous_scope=cached.scope,
         client_secret_expires_at=cached.client_secret_expires_at,
         auth_method=auth_method,
         no_resource_indicator=no_resource_indicator,
@@ -987,7 +1012,8 @@ def _run_authorization_flow(
             cse_at = reg.client_secret_expires_at
             auth_method = reg.auth_method
             log(f"registered client: {cid}")
-    assert cid is not None
+    if cid is None:  # -O-safe invariant (every branch above sets cid)
+        raise RuntimeError("no client_id available for authorization")
 
     code_verifier, code_challenge = generate_pkce()
 
@@ -1007,13 +1033,14 @@ def _run_authorization_flow(
         params["scope"] = scope
 
     auth_url = f"{metadata.authorization_endpoint}?{urlencode(params)}"
-    # The full URL (including the single-use CSRF ``state`` nonce and the
-    # public S256 ``code_challenge``) is logged deliberately so the user can
-    # complete the flow manually when the browser does not auto-open. ``state``
-    # is single-use and timeout-bounded and the PKCE secret (``code_verifier``)
-    # is never logged, so this is an accepted UX-over-defence-in-depth tradeoff
-    # rather than a token leak — authorize URLs do appear in stderr logs.
-    log(f"authorize URL (open in browser if not auto-opened):\n{auth_url}")
+    # Log a STATE-REDACTED URL. The user still needs a clickable URL when the
+    # browser does not auto-open, but the single-use CSRF ``state`` nonce does
+    # not need to land in stderr — MCP host logs (Claude Desktop/Code) persist
+    # to files that may be shared in bug reports. The browser receives the full
+    # URL below; the PKCE secret (``code_verifier``) is never in the URL and the
+    # S256 ``code_challenge`` is public, so only ``state`` is worth redacting.
+    log_url = f"{metadata.authorization_endpoint}?{urlencode({**params, 'state': '<redacted>'})}"
+    log(f"authorize URL (open in browser if not auto-opened):\n{log_url}")
 
     webbrowser.open(auth_url)
 
@@ -1069,7 +1096,8 @@ def _run_authorization_flow(
         )
 
     code = cb_result.auth_code
-    assert code is not None
+    if code is None:  # -O-safe; the callback error path raises before here
+        raise RuntimeError("authorization callback returned no code")
 
     log("exchanging authorization code for token")
     raw = exchange_code(
@@ -1143,7 +1171,8 @@ def _run_device_authorization_flow(
                 "Server does not support dynamic client registration. "
                 "Provide a --client-id instead."
             )
-    assert cid is not None
+    if cid is None:  # -O-safe invariant (every branch above sets cid)
+        raise RuntimeError("no client_id available for device authorization")
 
     # Step 1: Device Authorization Request (RFC 8628 §3.1)
     da_params: dict[str, str] = {}

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -205,6 +205,9 @@ class TestDiscoverMetadata:
         assert meta.authorization_endpoint == "https://api.example.com/authorize"
         assert meta.token_endpoint == "https://api.example.com/token"
         assert meta.registration_endpoint == "https://api.example.com/register"
+        # #3: the default-path fallback must still pin an issuer (the base it
+        # synthesised endpoints from) so the RFC 9207 iss check stays active.
+        assert meta.issuer == "https://api.example.com"
 
     def test_fallback_on_connection_error(self, httpx_mock):
         # ConnectError for: path-aware PRM, host-root PRM, host-root AS, path-scoped AS
@@ -783,6 +786,27 @@ class TestRegisterClient:
         reg = register_client(meta, "http://127.0.0.1:9999/callback", client)
         assert reg.client_secret_expires_at is None
 
+    def test_client_secret_expires_at_string_zero_means_never(self, httpx_mock):
+        """A non-conformant AS sending the STRING "0" must still be read as
+        'never expires' — not as already-expired (which would force a needless
+        re-DCR on every refresh/step-up)."""
+        httpx_mock.add_response(
+            url="https://api.example.com/register",
+            json={
+                "client_id": "cid",
+                "client_secret": "csec",
+                "client_secret_expires_at": "0",
+            },
+        )
+        meta = OAuthMetadata(
+            authorization_endpoint="https://api.example.com/authorize",
+            token_endpoint="https://api.example.com/token",
+            registration_endpoint="https://api.example.com/register",
+        )
+        client = httpx.Client()
+        reg = register_client(meta, "http://127.0.0.1:9999/callback", client)
+        assert reg.client_secret_expires_at is None
+
     def test_client_secret_expires_at_missing(self, httpx_mock):
         """Field absent → None (treated as no expiry)."""
         httpx_mock.add_response(
@@ -1129,6 +1153,39 @@ class TestRefreshCachedToken:
             "https://auth.example.com"
         )
 
+    def test_refresh_preserves_scope_when_response_omits_it(
+        self, tmp_path, monkeypatch, httpx_mock
+    ):
+        """#1: RFC 6749 §5.1 lets a refresh response OMIT scope. The cached scope
+        must be preserved, else a later step-up cannot union the granted scopes."""
+        store_file = tmp_path / "tokens.json"
+        monkeypatch.setattr("mcp_stdio.token_store._STORE_DIR", tmp_path)
+        monkeypatch.setattr("mcp_stdio.token_store._STORE_FILE", store_file)
+
+        from mcp_stdio.token_store import load_token, save_token
+
+        save_token(
+            "https://api.example.com/mcp",
+            TokenData(
+                access_token="old_at",
+                refresh_token="rt123",
+                expires_at=time.time() - 10,
+                scope="read write admin",
+                client_id="cid",
+                token_endpoint="https://auth.example.com/token",
+                authorization_endpoint="https://auth.example.com/authorize",
+            ),
+        )
+        # Refresh response omits "scope" entirely.
+        httpx_mock.add_response(
+            url="https://auth.example.com/token",
+            json={"access_token": "new_at", "expires_in": 3600},
+        )
+        client = httpx.Client()
+        data = refresh_cached_token("https://api.example.com/mcp", client)
+        assert data is not None and data.scope == "read write admin"
+        assert load_token("https://api.example.com/mcp").scope == "read write admin"
+
     def test_returns_none_when_no_cached_token(self, tmp_path, monkeypatch):
         store_file = tmp_path / "tokens.json"
         monkeypatch.setattr("mcp_stdio.token_store._STORE_DIR", tmp_path)
@@ -1235,6 +1292,33 @@ class TestRefreshCachedToken:
 
 
 class TestTokenResponseToData:
+    META = OAuthMetadata(
+        authorization_endpoint="https://ex.com/auth",
+        token_endpoint="https://ex.com/token",
+    )
+
+    def test_preserves_previous_scope_when_omitted(self):
+        """#1: scope omitted from the response falls back to previous_scope."""
+        raw = {"access_token": "at", "expires_in": 3600}
+        data = _token_response_to_data(
+            raw, self.META, "cid", None, previous_scope="read write"
+        )
+        assert data.scope == "read write"
+
+    def test_response_scope_overrides_previous_scope(self):
+        """A scope present in the response wins over the previous one."""
+        raw = {"access_token": "at", "scope": "read"}
+        data = _token_response_to_data(
+            raw, self.META, "cid", None, previous_scope="read write"
+        )
+        assert data.scope == "read"
+
+    def test_missing_access_token_raises(self):
+        """#15: a token response without access_token (RFC 6749 §5.1 REQUIRED)
+        must fail loudly, not build a credential-less TokenData."""
+        with pytest.raises(RuntimeError, match="access_token"):
+            _token_response_to_data({"token_type": "Bearer"}, self.META, "cid", None)
+
     def test_full_response(self):
         raw = {
             "access_token": "at",
@@ -3020,6 +3104,35 @@ class TestAuthorizationFlowFailurePaths:
                 client_id_override="cid",
                 timeout=0.3,
             )
+
+    def test_authorize_url_log_redacts_state(self, monkeypatch, capsys):
+        """#4: the authorize URL logged to stderr must REDACT the single-use
+        CSRF state nonce (stderr persists to shareable host logs), while the
+        browser still receives the full URL with the real state."""
+        from urllib.parse import parse_qs, urlparse
+
+        opened: dict[str, str] = {}
+
+        def fake_open(url: str) -> bool:
+            opened["url"] = url
+            return True
+
+        monkeypatch.setattr("mcp_stdio.oauth.webbrowser.open", fake_open)
+        client = httpx.Client()
+        with pytest.raises(TimeoutError):
+            _run_authorization_flow(
+                "https://ex.com/mcp",
+                client,
+                metadata=self.META,
+                cached=None,
+                client_id_override="cid",
+                timeout=0.3,
+            )
+        err = capsys.readouterr().err
+        real_state = parse_qs(urlparse(opened["url"]).query)["state"][0]
+        # Browser got the real nonce; stderr log got a redacted placeholder.
+        assert "state=%3Credacted%3E" in err
+        assert real_state not in err
 
     def test_callback_error_raises_runtime_error(self, monkeypatch):
         """A callback carrying ?error=... → RuntimeError, no code exchange."""


### PR DESCRIPTION
## Overview

From the Opus 4.8 review (round 9): one MEDIUM scope-preservation bug plus five LOW/NIT hardening fixes, all in `oauth.py`.

## 1. Refresh wiped granted scope — #1 (MEDIUM)

`_token_response_to_data` set `scope=raw.get("scope")` with **no** fallback, unlike the adjacent `refresh_token=raw.get("refresh_token") or previous_refresh_token`. RFC 6749 §5.1 lets a refresh response **omit** `scope` (refreshes routinely do), so `cached.scope` became `None`. `step_up_authorize` then read `cached.scope` to compute the union of granted + challenge scopes — with it wiped, step-up requested only the challenge scopes, producing a narrower token than intended.

**Fix:** add `previous_scope` (mirrors `previous_refresh_token`); `refresh_cached_token` passes `previous_scope=cached.scope`.

## 2. RFC 9207 `iss` check dark on default-path fallback — #3 (LOW)

The Phase-3 discovery fallback built `OAuthMetadata` with no `issuer`, so the `iss` mix-up compare no-op'd — on the *least*-trustworthy outcome (no metadata validated at all). **Fix:** pin `issuer` to the base the default endpoints derive from.

## 3. State nonce in authorize-URL stderr log — #4 (LOW)

The full authorize URL (with the single-use CSRF `state`) was logged to stderr, which MCP hosts persist to shareable log files. **Fix:** log a `state`-redacted URL; the browser still receives the full URL.

## 4. `client_secret_expires_at: "0"` misread — #5 (LOW)

RFC 7591 §3.2.1: `0` means *never expires*. A non-conformant AS sending the **string** `"0"` was truthy → `float("0")==0.0` → read as already-expired, forcing a needless re-DCR on every refresh/step-up. **Fix:** coerce defensively, treat `0` as never regardless of JSON type.

## 5. Missing `access_token` — #15 (NIT)

A token response without `access_token` (RFC 6749 §5.1 REQUIRED) now raises a clear error instead of constructing a credential-less `TokenData` that fails opaquely later.

## 6. Asserts under `-O` — #16 (NIT)

`assert cid is not None` / `assert code is not None` replaced with explicit `raise` so the invariants survive `python -O`.

## Tests

Scope preservation (refresh end-to-end + `_token_response_to_data`), response-scope-overrides-previous, string-`"0"` never-expires, default-path issuer pinned, missing-`access_token` raises, and `state` redacted in the authorize-URL log (browser still gets the real nonce). 600 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)