### PR TITLE
fix(token_store): validate value types on load; O_NOFOLLOW read; document migration lock gap

### DIFF
--- a/src/mcp_stdio/token_store.py
+++ b/src/mcp_stdio/token_store.py
@@ -124,7 +124,18 @@ def _ensure_store_dir() -> None:
 
 
 def _migrate_legacy_store() -> None:
-    """Migrate tokens from ~/.mcp-stdio/ to ~/.config/mcp-stdio/ if needed."""
+    """Migrate tokens from ~/.mcp-stdio/ to ~/.config/mcp-stdio/ if needed.
+
+    NOTE: this runs from ``_read_store`` and therefore from ``load_token``,
+    which is UNLOCKED (documented read-only). The EXDEV/ENOENT copy-through
+    branch below performs a real ``_write_store`` *without* ``_store_lock``,
+    so the module's lock-serialised RMW contract has one exception: during the
+    one-time legacy-migration window a load-side copy-through can race a
+    concurrent ``save_token`` and one ``os.replace`` wins (each write is still
+    atomic — no torn file — and the existence guard prevents the empty-dict
+    clobber). After migration completes the legacy file is gone and this path
+    is never taken again.
+    """
     if not _LEGACY_STORE_FILE.exists():
         return
     if _STORE_FILE.exists():
@@ -202,14 +213,27 @@ def _read_store() -> dict[str, Any]:
     # backup that lost mode bits, copied under a permissive umask, or written by
     # a third-party tool) and is only ever read would otherwise keep its mode,
     # leaving the secrets readable.
-    # Don't chmod through a symlink (would alter the link target's mode).
+    #
+    # Open with O_NOFOLLOW first: it refuses a symlink atomically (ELOOP), and
+    # the resulting fd anchors BOTH the chmod (via fchmod) and the read to the
+    # same inode — eliminating the stat-then-chmod-then-read TOCTOU window of a
+    # path-based sequence. _O_NOFOLLOW is 0 where unsupported (Windows), where
+    # NTFS ACLs govern access anyway.
     try:
-        if not _STORE_FILE.is_symlink():
-            os.chmod(_STORE_FILE, stat.S_IRUSR | stat.S_IWUSR)  # 0o600
+        fd = os.open(_STORE_FILE, os.O_RDONLY | _O_NOFOLLOW)
     except OSError:
-        pass
+        # ELOOP (a symlink was swapped in — refused), ENOENT (race), or a
+        # permission error: treat as no readable store.
+        return {}
     try:
-        return json.loads(_STORE_FILE.read_text())
+        _fchmod = getattr(os, "fchmod", None)
+        if _fchmod is not None:
+            try:
+                _fchmod(fd, stat.S_IRUSR | stat.S_IWUSR)  # 0o600, fd-anchored
+            except OSError:
+                pass  # best-effort tighten
+        with os.fdopen(fd, "r", encoding="utf-8") as f:
+            return json.loads(f.read())
     except (json.JSONDecodeError, OSError):
         return {}
 
@@ -317,9 +341,26 @@ def load_token(server_url: str) -> TokenData | None:
     if entry is None:
         return None
     try:
-        return TokenData(**entry)
+        td = TokenData(**entry)
     except TypeError:
+        # Unexpected / missing keyword names (schema-shape drift, e.g. a field
+        # added by a newer version). Degrade to None → re-auth.
         return None
+    # A dataclass __init__ does NO value-type checking, so a corrupted store
+    # (partially overwritten, truncated-then-rewritten by another tool, or a
+    # bad backup restore) can yield a structurally-valid-but-type-broken entry.
+    # The comparison-critical numerics would then crash ensure_token (e.g.
+    # `expires_at > time.time()` on a str). Validate the load-bearing fields and
+    # degrade to None rather than propagate a TypeError up the OAuth path.
+    if not isinstance(td.access_token, str) or not td.access_token:
+        return None
+    if td.expires_at is not None and not isinstance(td.expires_at, (int, float)):
+        return None
+    if td.client_secret_expires_at is not None and not isinstance(
+        td.client_secret_expires_at, (int, float)
+    ):
+        return None
+    return td
 
 
 def save_token(server_url: str, data: TokenData) -> None:

--- a/tests/test_token_store.py
+++ b/tests/test_token_store.py
@@ -152,6 +152,31 @@ class TestLoadSaveDelete:
         )
         assert load_token("https://example.com/mcp") is None
 
+    def test_load_value_type_corruption_returns_none(self, tmp_path, monkeypatch):
+        """#6: a structurally-valid entry with wrong VALUE types (e.g. a string
+        expires_at from a truncated/overwritten store) must degrade to None, not
+        crash ensure_token's `expires_at > time.time()` comparison later."""
+        store_file = tmp_path / "tokens.json"
+        monkeypatch.setattr("mcp_stdio.token_store._STORE_DIR", tmp_path)
+        monkeypatch.setattr("mcp_stdio.token_store._STORE_FILE", store_file)
+
+        store_file.write_text(
+            '{"https://example.com/mcp": '
+            '{"access_token": "t", "expires_at": "soon"}}'
+        )
+        assert load_token("https://example.com/mcp") is None
+
+    def test_load_non_string_access_token_returns_none(self, tmp_path, monkeypatch):
+        """A corrupted access_token (wrong type) must not produce a usable token."""
+        store_file = tmp_path / "tokens.json"
+        monkeypatch.setattr("mcp_stdio.token_store._STORE_DIR", tmp_path)
+        monkeypatch.setattr("mcp_stdio.token_store._STORE_FILE", store_file)
+
+        store_file.write_text(
+            '{"https://example.com/mcp": {"access_token": ["x"]}}'
+        )
+        assert load_token("https://example.com/mcp") is None
+
     def test_save_over_corrupt_store_succeeds(self, tmp_path, monkeypatch):
         """A corrupt store file is replaced (not appended to) on the next save."""
         store_file = tmp_path / "tokens.json"
@@ -204,9 +229,10 @@ class TestLoadSaveDelete:
         sys.platform == "win32",
         reason="POSIX symlink semantics; NTFS differs",
     )
-    def test_read_does_not_chmod_through_a_symlink(self, tmp_path, monkeypatch):
-        """A symlinked tokens.json must NOT have its target's mode altered on
-        read — guards against a symlink-swap chmod of an attacker-chosen file."""
+    def test_read_refuses_symlinked_store(self, tmp_path, monkeypatch):
+        """A symlinked tokens.json is refused on read (O_NOFOLLOW), consistent
+        with the O_NOFOLLOW write path — and crucially its target's mode is NOT
+        altered, so a symlink-swap cannot chmod an attacker-chosen file."""
         target = tmp_path / "real.json"
         target.write_text('{"https://example.com/mcp": {"access_token": "t"}}')
         os.chmod(target, 0o644)
@@ -216,9 +242,10 @@ class TestLoadSaveDelete:
         monkeypatch.setattr("mcp_stdio.token_store._STORE_DIR", tmp_path)
         monkeypatch.setattr("mcp_stdio.token_store._STORE_FILE", link)
 
+        # O_NOFOLLOW refuses to open through the link → loads as absent.
         loaded = load_token("https://example.com/mcp")
-        assert loaded is not None and loaded.access_token == "t"
-        # The symlink target's mode must be untouched (chmod skipped on symlink).
+        assert loaded is None
+        # The symlink target's mode must be untouched (never opened/chmod'd).
         assert os.stat(target).st_mode & stat.S_IRWXO == stat.S_IROTH
 
     def test_concurrent_saves_of_distinct_keys_both_persist(


### PR DESCRIPTION
## Overview

Three `token_store.py` robustness fixes from the Opus 4.8 review (round 9, #6/#7/#8 — all LOW).

## 1. Value-type corruption crashed `ensure_token` — #6

`load_token` did `TokenData(**entry)` guarded by `except TypeError`, which only catches unexpected/missing **keyword names** (schema-shape drift). A dataclass `__init__` does **no value-type checking**, so a corrupted store (partially overwritten, truncated-then-rewritten by another tool, bad backup restore) could load a `TokenData` with e.g. a **string** `expires_at` — which then crashed `ensure_token` at `cached.expires_at > time.time()` (`TypeError: '>' not supported between str and float`) instead of degrading to a fresh OAuth flow.

**Fix:** after construction, validate the comparison-critical fields (`access_token` is a non-empty str; `expires_at` / `client_secret_expires_at` are numeric-or-None) and return `None` on mismatch.

## 2. Read-path chmod TOCTOU — #7

The opportunistic read-path mode-tighten used `stat(is_symlink)` → `chmod` → `read_text`, a check-then-use window. **Fix:** `os.open(O_NOFOLLOW)` + `fchmod` on the fd + read from that fd — the symlink is refused atomically (ELOOP) and both the chmod and read are anchored to one inode. This matches the existing `O_NOFOLLOW` **write** path, so a symlinked store is now consistently refused on read too (its target's mode is never touched). `_O_NOFOLLOW` is `0` where unsupported (Windows, where NTFS ACLs govern access).

## 3. Migration write outside the lock — #8

`_migrate_legacy_store`'s EXDEV/ENOENT copy-through does a real `_write_store` from the **unlocked** `load_token` path. Documented in the docstring as the one bounded exception to the lock-serialised RMW contract (one-time migration window; writes stay atomic; the existence guard prevents the empty-dict clobber).

## Tests

- Value-type-corrupted (`expires_at: "soon"`) and non-string-`access_token` entries both load as `None`.
- The symlink test now asserts **refusal** (load `None`) with the target's mode untouched.

596 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)