### PR TITLE
docs(claude): update Release section for release-please flow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,4 +46,4 @@ Entry point: `mcp-stdio` command → `mcp_stdio.cli:main`.
 
 ## Release
 
-Tagging `v*` triggers the GitHub Actions release pipeline: test → build → TestPyPI → PyPI → MCP Registry → GitHub Release → Homebrew tap update. The `server.json` version is patched from the git tag at publish time.
+Releases are driven by **release-please** (Conventional Commits) — do not tag `v*` by hand. Pushing commits to `main` updates a standing "release PR" that bumps `__version__` (`src/mcp_stdio/__init__.py`) and `CHANGELOG.md`. Merging that PR creates the `v*` tag and a GitHub Release (via a PAT so downstream workflows fire). The `release: published` event then runs the publish pipeline: test → build → TestPyPI → PyPI → MCP Registry → GitHub Release assets → Homebrew tap update. The `server.json` version is patched from the git tag at publish time.


### PR DESCRIPTION
## Overview

`CLAUDE.md`'s Release section said *"Tagging `v*` triggers the GitHub Actions release pipeline"*, implying manual tagging. The project has since adopted **release-please**, so that is stale (round 9, #11).

## Actual flow (verified against `.github/workflows/release-please.yml`, `release.yml`, and `release-please-config.json`)

1. Conventional-commit pushes to `main` update a standing **release PR** that bumps `__version__` (`src/mcp_stdio/__init__.py` via `extra-files`) and `CHANGELOG.md`.
2. Merging that PR makes release-please create the `v*` tag and a GitHub Release **via a PAT** (so downstream workflows fire — `GITHUB_TOKEN`-created tags can't).
3. The `release: published` event runs the publish pipeline: test → build → TestPyPI → PyPI → MCP Registry → GitHub Release assets → Homebrew tap.

Updated the section to describe this and to note that `v*` tags must not be created by hand. Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)