### PR TITLE
fix(cli): empty --bearer-token conflicts with --oauth; warn on overridden -H Authorization

### DIFF
--- a/src/mcp_stdio/cli.py
+++ b/src/mcp_stdio/cli.py
@@ -338,9 +338,12 @@ def main() -> None:
         else os.environ.get("MCP_BEARER_TOKEN", "")
     )
 
-    n_auth = sum(
-        [args.oauth, args.oauth_device, bool(bearer_from_flag and bearer_token)]
-    )
+    # Count an explicit --bearer-token by its PRESENCE, not its truthiness, so
+    # `--bearer-token '' --oauth` errors out the same as a non-empty token
+    # rather than silently slipping past the mutual-exclusion check (an empty
+    # bearer is still an explicit, contradictory auth choice). An ambient
+    # MCP_BEARER_TOKEN (bearer_from_flag False) still does not participate.
+    n_auth = sum([args.oauth, args.oauth_device, bearer_from_flag])
     if n_auth > 1:
         print(
             "error: --oauth, --oauth-device, and --bearer-token are mutually exclusive",
@@ -434,7 +437,17 @@ def main() -> None:
             # Drop any differently-cased 'authorization' header a -H supplied
             # earlier (the -H loop ran before this block), so the OAuth token is
             # the single Authorization sent rather than a duplicate header pair.
-            for existing in [k for k in headers if k.lower() == "authorization"]:
+            overridden = [k for k in headers if k.lower() == "authorization"]
+            if overridden:
+                # The user explicitly supplied -H 'Authorization: ...' AND an
+                # OAuth flow — warn that the OAuth token wins, instead of
+                # silently discarding their header.
+                print(
+                    "warning: explicit -H 'Authorization' header is overridden "
+                    "by the OAuth-acquired token",
+                    file=sys.stderr,
+                )
+            for existing in overridden:
                 del headers[existing]
             headers["Authorization"] = f"Bearer {token_data.access_token}"
             token_refresher = _build_token_refresher(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -330,6 +330,54 @@ class TestMain:
                 main()
             assert exc_info.value.code == 1
 
+    def test_empty_bearer_flag_still_conflicts_with_oauth(self, monkeypatch):
+        """#17: `--bearer-token '' --oauth` must error like a non-empty token —
+        an explicit (even empty) bearer flag is a contradictory auth choice and
+        must not slip past the mutual-exclusion check on a falsiness technicality."""
+        monkeypatch.delenv("MCP_BEARER_TOKEN", raising=False)
+        with patch(
+            "sys.argv",
+            [
+                "mcp-stdio",
+                "https://example.com/mcp",
+                "--oauth",
+                "--bearer-token",
+                "",
+            ],
+        ):
+            with pytest.raises(SystemExit) as exc_info:
+                main()
+            assert exc_info.value.code == 1
+
+    def test_explicit_authorization_header_with_oauth_warns(
+        self, monkeypatch, capsys
+    ):
+        """#18: an explicit -H 'Authorization: ...' overridden by the OAuth token
+        emits a stderr warning instead of silently discarding it."""
+        monkeypatch.delenv("MCP_BEARER_TOKEN", raising=False)
+        with (
+            patch(
+                "sys.argv",
+                [
+                    "mcp-stdio",
+                    "--oauth",
+                    "-H",
+                    "Authorization: Bearer mine",
+                    "https://example.com/mcp",
+                ],
+            ),
+            patch("mcp_stdio.oauth.ensure_token") as mock_ensure,
+            patch("mcp_stdio.cli.run") as mock_run,
+            patch("mcp_stdio.cli._build_token_refresher"),
+            patch("mcp_stdio.cli._build_scope_upgrader"),
+        ):
+            mock_ensure.return_value.access_token = "oauth-tok"
+            main()
+        # The OAuth token wins and the override is announced.
+        headers = mock_run.call_args.kwargs["headers"]
+        assert headers["Authorization"] == "Bearer oauth-tok"
+        assert "overridden by the OAuth-acquired token" in capsys.readouterr().err
+
     def test_dash_h_overrides_bearer_authorization_case_insensitively(self):
         """A -H differing only in case from a built-in header replaces it,
         rather than sending two same-named headers (RFC 7230 §3.2)."""


### PR DESCRIPTION
## Overview

Two small `cli.py` robustness fixes from the Opus 4.8 review (round 9, #17/#18 — both NIT).

## 1. `--bearer-token '' --oauth` bypassed mutual exclusion — #17

The mutual-exclusion check counted the bearer flag by **truthiness** (`bearer_from_flag and bearer_token`), so an explicit but empty `--bearer-token ''` slipped past it while `--bearer-token x` errored. An empty bearer is still an explicit, contradictory auth choice. **Fix:** count it by flag **presence** (`bearer_from_flag`); an ambient `MCP_BEARER_TOKEN` (not the flag) still does not participate.

## 2. Silent discard of -H Authorization under OAuth — #18

When `--oauth` is set and the user also passed `-H 'Authorization: ...'`, the explicit header was silently dropped in favour of the OAuth token. **Fix:** emit a stderr warning (`explicit -H 'Authorization' header is overridden by the OAuth-acquired token`) before overriding, mirroring the existing `ignored without --oauth` warning style. The override behaviour itself is unchanged and correct.

## Tests

- `--bearer-token '' --oauth` exits 1.
- `-H 'Authorization: ...' --oauth` warns on stderr and the OAuth token wins.

596 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)