### PR TITLE
fix(relay): re-capture protocol version on re-initialize; merge late fields; cover SSE gaps

### DIFF
--- a/src/mcp_stdio/relay.py
+++ b/src/mcp_stdio/relay.py
@@ -972,6 +972,13 @@ def _paginate_and_stream(
 
         if parsed is None:
             if page == 1:
+                # Page-1 body was a 200 that did not parse: fall back to a plain
+                # streamed POST so the client still gets the raw response. This
+                # re-POSTs the request (the first body was buffered by
+                # _post_parsed and discarded), which is only safe because
+                # PAGINATED_LIST_METHODS holds idempotent reads only — keep that
+                # invariant (mirrors the capture-init note in run()'s _dispatch)
+                # if the table ever grows to a non-idempotent method.
                 return _post_and_stream(
                     client, url, line, headers, req_id, tracker, has_id=has_id
                 )
@@ -998,6 +1005,12 @@ def _paginate_and_stream(
             items = page_result.get(result_key)
             if isinstance(items, list):
                 merged_result[result_key].extend(items)
+            # Preserve top-level result fields (e.g. a late ``_meta``) that arrive
+            # only on a later page — last-write-wins. The accumulated list and the
+            # ``nextCursor`` are managed explicitly above, so skip them here.
+            for k, v in page_result.items():
+                if k not in (result_key, "nextCursor"):
+                    merged_result[k] = v
 
         next_cursor = page_result.get("nextCursor")
         if not next_cursor:
@@ -1479,28 +1492,33 @@ def run(
                         client, url, content, h, req_id, detected[1], tracker,
                         has_id=req_has_id,
                     )
-                # Capture-once semantics: we only learn the version from the
-                # first initialize. A later client-driven re-initialize that
-                # renegotiates a different version is not picked up — rare, and
-                # avoids re-parsing every response on the hot path.
+                # Any `initialize` request is a capture point — not just the
+                # first. A client-driven re-initialize that renegotiates a
+                # different version is adopted so the injected
+                # MCP-Protocol-Version header stays equal to the version in
+                # force (the 2025-06-18 spec requires the header to match the
+                # negotiated version). The added per-line cost is one cheap
+                # `_looks_like_initialize` regex; the heavier
+                # `_extract_protocol_version` still runs only inside
+                # `_post_and_stream` for lines that are actually initializes.
                 #
                 # Response-only: the version comes from the server's
                 # InitializeResult, not the client's requested version. If a
                 # (non-compliant) server omits result.protocolVersion, no
                 # header is sent rather than guessing — a server that both
                 # omits it and enforces the header would be self-contradictory.
-                capture_init = protocol_version is None and _looks_like_initialize(content)
+                capture_init = _looks_like_initialize(content)
                 result = _post_and_stream(
                     client, url, content, h, req_id, tracker,
                     capture_init=capture_init, has_id=req_has_id,
                 )
-                if (
-                    result is not None
-                    and result.protocol_version
-                    and protocol_version is None
-                ):
+                if result is not None and result.protocol_version:
+                    if result.protocol_version != protocol_version:
+                        log(
+                            f"negotiated MCP protocol version: "
+                            f"{result.protocol_version}"
+                        )
                     protocol_version = result.protocol_version
-                    log(f"negotiated MCP protocol version: {protocol_version}")
                 return result
 
             result = _dispatch(line, req_headers)
@@ -1526,6 +1544,15 @@ def run(
             # re-recovered and surfaces as a JSON-RPC error (never a hang, #11).
             # The downstream client retries at its own level. This bounded
             # single attempt is deliberate: it avoids unbounded recovery loops.
+            #
+            # Worst case the same line is dispatched up to 4 times in one
+            # iteration (initial + 401-refresh + 403-step-up + 404-reinit, when
+            # each retry returns the next branch's status). That is safe only
+            # because each prior dispatch returned a non-200 with NO body
+            # delivered to stdout — the at-most-once guard in _post_and_stream
+            # covers replay after a partial 200, not these distinct non-200
+            # recovery dispatches, which a server is not expected to have
+            # executed for side effects.
 
             # Token expired (401) — refresh and retry once
             if result.status_code == 401 and token_refresher:

--- a/tests/test_relay.py
+++ b/tests/test_relay.py
@@ -1440,6 +1440,40 @@ class TestProtocolVersionHeader:
         reinit_body = json.loads(reqs[2].read())
         assert reinit_body["params"]["protocolVersion"] == "2025-06-18"
 
+    def test_client_driven_reinitialize_updates_header(self, httpx_mock):
+        """#2: a client that sends a SECOND initialize renegotiating a newer
+        version must have subsequent requests carry the UPDATED
+        MCP-Protocol-Version, not the stale first-negotiated one."""
+        # 1: initialize -> 2025-03-26
+        httpx_mock.add_response(
+            text='{"jsonrpc":"2.0","result":{"protocolVersion":"2025-03-26"},"id":1}',
+            headers={"content-type": "application/json"},
+        )
+        # 2: a second, client-driven initialize -> renegotiates 2025-06-18
+        httpx_mock.add_response(
+            text='{"jsonrpc":"2.0","result":{"protocolVersion":"2025-06-18"},"id":2}',
+            headers={"content-type": "application/json"},
+        )
+        # 3: a later request
+        httpx_mock.add_response(
+            text='{"jsonrpc":"2.0","result":{},"id":3}',
+            headers={"content-type": "application/json"},
+        )
+        self._run_with_stdin(
+            [
+                '{"jsonrpc":"2.0","method":"initialize","id":1}',
+                '{"jsonrpc":"2.0","method":"initialize","id":2}',
+                '{"jsonrpc":"2.0","method":"tools/call","id":3}',
+            ]
+        )
+        reqs = httpx_mock.get_requests()
+        # req[0] first initialize: no header yet (it IS the negotiation).
+        assert "mcp-protocol-version" not in reqs[0].headers
+        # req[1] second initialize carries the first-negotiated version.
+        assert reqs[1].headers["mcp-protocol-version"] == "2025-03-26"
+        # req[2] carries the RE-negotiated version — proof of re-capture.
+        assert reqs[2].headers["mcp-protocol-version"] == "2025-06-18"
+
     def test_reinitialize_recaptures_version_from_sse_framed_response(self, httpx_mock):
         """The 404-recovery re-initialize response may itself be SSE-framed —
         the protocol version must still be re-captured and injected."""
@@ -2227,6 +2261,34 @@ class TestPagination:
         )
         merged = json.loads(output.strip())
         assert [t["name"] for t in merged["result"]["tools"]] == ["a"]
+
+    def test_late_top_level_result_field_preserved(self, httpx_mock):
+        """#14: a top-level result field (e.g. _meta) that appears only on a
+        later page must survive the merge (last-write-wins), not be dropped."""
+        page1 = {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "result": {"tools": [{"name": "a"}], "nextCursor": "p2"},
+        }
+        page2 = {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "result": {"tools": [{"name": "b"}], "_meta": {"total": 2}},
+        }
+        for page in (page1, page2):
+            httpx_mock.add_response(
+                url=self.URL,
+                text=json.dumps(page),
+                headers={"content-type": "application/json"},
+            )
+        output = self._run_with_stdin(
+            httpx_mock,
+            [json.dumps({"jsonrpc": "2.0", "id": 1, "method": "tools/list"})],
+        )
+        merged = json.loads(output.strip())
+        assert [t["name"] for t in merged["result"]["tools"]] == ["a", "b"]
+        assert merged["result"]["_meta"] == {"total": 2}  # late field kept
+        assert "nextCursor" not in merged["result"]
 
 
 # --- check_connection ---
@@ -3195,6 +3257,80 @@ class TestRunSse:
 
         out = stdout.getvalue()
         assert payload in out
+
+    def test_arguments_null_normalized_on_sse_post(self, httpx_mock):
+        """#10: run_sse must rewrite tools/call arguments:null -> {} on the wire
+        before POSTing, symmetric with run() (covered for the streamable path
+        by TestRunNormalizeArguments but previously untested for SSE)."""
+        release_stdin = threading.Event()
+        captured: dict = {}
+
+        def sse_gen():
+            yield b"event: endpoint\ndata: /messages?sessionId=xyz\n\n"
+            release_stdin.wait(timeout=3)
+
+        httpx_mock.add_response(
+            url=self.URL,
+            method="GET",
+            stream=IteratorStream(sse_gen()),
+            headers={"content-type": "text/event-stream"},
+        )
+
+        def post_callback(request):
+            captured["body"] = json.loads(request.read())
+            release_stdin.set()
+            return httpx.Response(status_code=202)
+
+        httpx_mock.add_callback(
+            post_callback,
+            url="https://example.com/messages?sessionId=xyz",
+            method="POST",
+        )
+
+        stdin = _BlockingStdin(
+            '{"jsonrpc":"2.0","method":"tools/call","id":1,'
+            '"params":{"name":"t","arguments":null}}\n',
+            release_stdin,
+        )
+        with patch("sys.stdin", stdin), patch("sys.stdout", StringIO()):
+            run_sse(self.URL, {})
+        assert captured["body"]["params"]["arguments"] == {}
+
+    def test_arguments_null_opt_out_on_sse_post(self, httpx_mock):
+        """--no-normalize-arguments must forward null verbatim on the SSE path."""
+        release_stdin = threading.Event()
+        captured: dict = {}
+
+        def sse_gen():
+            yield b"event: endpoint\ndata: /messages?sessionId=xyz\n\n"
+            release_stdin.wait(timeout=3)
+
+        httpx_mock.add_response(
+            url=self.URL,
+            method="GET",
+            stream=IteratorStream(sse_gen()),
+            headers={"content-type": "text/event-stream"},
+        )
+
+        def post_callback(request):
+            captured["body"] = json.loads(request.read())
+            release_stdin.set()
+            return httpx.Response(status_code=202)
+
+        httpx_mock.add_callback(
+            post_callback,
+            url="https://example.com/messages?sessionId=xyz",
+            method="POST",
+        )
+
+        stdin = _BlockingStdin(
+            '{"jsonrpc":"2.0","method":"tools/call","id":1,'
+            '"params":{"name":"t","arguments":null}}\n',
+            release_stdin,
+        )
+        with patch("sys.stdin", stdin), patch("sys.stdout", StringIO()):
+            run_sse(self.URL, {}, normalize_arguments=False)
+        assert captured["body"]["params"]["arguments"] is None
 
     def test_post_401_triggers_token_refresh(self, httpx_mock):
         """On POST 401, run_sse calls token_refresher and retries."""
@@ -4320,6 +4456,69 @@ class TestRunSseCancelFilter:
         with patch("sys.stdin", stdin), patch("sys.stdout", stdout):
             run_sse(self.URL, {"Content-Type": "application/json"})
 
+        assert "kept" in stdout.getvalue()
+
+    def test_sse_id_reuse_supersedes_cancel(self, httpx_mock):
+        """#19: a request REUSING a previously-cancelled id supersedes the
+        cancel (tracker.discard), so its later SSE response is DELIVERED, not
+        dropped — the SSE analogue of the streamable-path discard."""
+        payload = '{"jsonrpc":"2.0","result":{"kept":true},"id":11}'
+        second_post = threading.Event()
+        release_stdin = threading.Event()
+        post_count = {"n": 0}
+
+        def sse_gen():
+            yield b"event: endpoint\ndata: /messages?sessionId=abc\n\n"
+            # Hold the late response until BOTH the cancel and the reused-id
+            # request have been POSTed — by then discard() has run.
+            second_post.wait(timeout=3)
+            yield f"event: message\ndata: {payload}\n\n".encode()
+            time.sleep(0.1)
+            release_stdin.set()
+
+        httpx_mock.add_response(
+            url=self.URL,
+            stream=IteratorStream(sse_gen()),
+            headers={"content-type": "text/event-stream"},
+        )
+
+        def on_post(request: httpx.Request) -> httpx.Response:
+            post_count["n"] += 1
+            if post_count["n"] >= 2:
+                second_post.set()
+            return httpx.Response(status_code=202)
+
+        httpx_mock.add_callback(
+            on_post,
+            url="https://example.com/messages?sessionId=abc",
+            is_reusable=True,
+        )
+
+        class _TwoLineStdin:
+            def __init__(self) -> None:
+                self._lines = [
+                    '{"jsonrpc":"2.0","method":"notifications/cancelled",'
+                    '"params":{"requestId":11}}\n',
+                    '{"jsonrpc":"2.0","method":"tools/call","id":11}\n',
+                ]
+                self._i = 0
+
+            def __iter__(self):
+                return self
+
+            def __next__(self) -> str:
+                if self._i < len(self._lines):
+                    line = self._lines[self._i]
+                    self._i += 1
+                    return line
+                release_stdin.wait(timeout=5)
+                raise StopIteration
+
+        stdout = StringIO()
+        with patch("sys.stdin", _TwoLineStdin()), patch("sys.stdout", stdout):
+            run_sse(self.URL, {"Content-Type": "application/json"})
+
+        # The reused id superseded the cancel, so the response is delivered.
         assert "kept" in stdout.getvalue()
 
 


### PR DESCRIPTION
## Overview

From the Opus 4.8 review (round 9): one MCP-compliance fix, one pagination-completeness fix, two documented invariants, and four coverage gaps — all in `relay.py`.

## 1. Protocol version captured once, never updated — #2 (LOW)

`_dispatch` captured the negotiated `MCP-Protocol-Version` only while `protocol_version is None`, so a **client-driven re-initialize** that renegotiated a different version (e.g. `2025-03-26` → `2025-06-18`) left the relay injecting the stale value — violating the 2025-06-18 rule that the header equal the negotiated version. **Fix:** treat any `initialize` as a capture point and adopt the renegotiated version. The added per-line cost is one cheap `_looks_like_initialize` regex; the heavier `_extract_protocol_version` still runs only for initialize lines.

## 2. Pagination dropped late top-level result fields — #14 (NIT)

The merge kept only page-1's top-level result fields, so a `_meta` that arrived on a later page was lost. **Fix:** shallow-merge non-list, non-`nextCursor` keys last-write-wins.

## 3. Documented invariants (no behaviour change) — #12, #13 (NIT)

- The page-1 parse-failure fallback re-POSTs the request; safe only because `PAGINATED_LIST_METHODS` holds idempotent reads.
- The sequential recovery branches can dispatch one line up to 4× in a single iteration (initial + 401 + 403 + 404); safe only because each prior dispatch returned a non-200 with no body delivered.

## Coverage added

- `test_client_driven_reinitialize_updates_header` — second initialize's renegotiated version reaches subsequent requests.
- `test_late_top_level_result_field_preserved` — a late `_meta` survives pagination.
- `test_arguments_null_normalized_on_sse_post` / `_opt_out_` — `run_sse` rewrites (and opt-out forwards) `tools/call` `arguments:null` on the wire (#10).
- `test_sse_id_reuse_supersedes_cancel` — a reused id supersedes a cancel on SSE, so its response is delivered (#19).

599 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)