### PR TITLE
fix(oauth): preserve scope on step-up; strip/reject userinfo in discovery

### DIFF
--- a/src/mcp_stdio/oauth.py
+++ b/src/mcp_stdio/oauth.py
@@ -162,6 +162,19 @@ def _validate_auth_server_url(auth_server_url: str, mcp_server_url: str) -> bool
         )
         return False
 
+    if parsed.username is not None or parsed.password is not None:
+        # Mirror _validate_endpoint_url: an authorization_server carrying
+        # userinfo would survive into the synthesized default token endpoint
+        # (which is NOT re-validated), routing the credential exchange — code +
+        # client_secret + PKCE verifier — through a userinfo authority. Refuse
+        # it. See #13.
+        log(
+            f"warning: authorization_server URL {auth_server_url!r} embeds "
+            f"userinfo (user:pass@); refusing as a credential-exfiltration / "
+            f"parser-confusion vector. See #13."
+        )
+        return False
+
     if parsed.scheme == "http" and not _is_loopback(parsed.hostname or ""):
         log(
             f"warning: refusing to follow non-loopback HTTP "
@@ -311,7 +324,21 @@ def _build_well_known_url(
     path = parsed.path.rstrip("/")
     well_known_path = f"/.well-known/{suffix}{path}"
     query = parsed.query if keep_query else ""
-    return urlunsplit((parsed.scheme, parsed.netloc, well_known_path, query, ""))
+    # Drop any embedded userinfo so credentials in a ``user:pass@host`` server
+    # URL are not sent as HTTP Basic auth on the discovery GET — consistent with
+    # the userinfo stripping in _authorization_base_url and the #13 validators.
+    host = parsed.hostname or ""
+    if host:
+        if ":" in host:
+            host = f"[{host}]"  # re-bracket an IPv6 literal
+        try:
+            port = parsed.port
+        except ValueError:
+            port = None
+        netloc = f"{host}:{port}" if port is not None else host
+    else:
+        netloc = parsed.netloc  # no parseable host — preserve verbatim
+    return urlunsplit((parsed.scheme, netloc, well_known_path, query, ""))
 
 
 def _fetch_authorization_server_metadata(
@@ -1116,6 +1143,12 @@ def _run_authorization_flow(
         metadata,
         cid,
         csecret,
+        # RFC 6749 §5.1 lets the AS omit `scope` when it equals the requested
+        # scope — exactly what a step-up does (requested == merged union). Fall
+        # back to the requested `scope` so the stored TokenData.scope is not
+        # wiped to None, which would shrink the union on the NEXT step-up. On
+        # initial auth `scope` is None, which is the correct fallback there too.
+        previous_scope=scope,
         client_secret_expires_at=cse_at,
         auth_method=auth_method,
         no_resource_indicator=not resource_indicator,

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -538,6 +538,27 @@ class TestDiscoverMetadata:
             == "https://auth.example.com/.well-known/oauth-authorization-server/a/b/c"
         )
 
+    def test_build_well_known_url_strips_userinfo(self):
+        """#5: embedded userinfo must NOT be carried into the discovery GET URL
+        (it would be sent as HTTP Basic auth)."""
+        url = _build_well_known_url(
+            "https://user:pass@api.example.com/mcp", "oauth-authorization-server"
+        )
+        assert "user:pass@" not in url
+        assert url == (
+            "https://api.example.com/.well-known/oauth-authorization-server/mcp"
+        )
+
+    def test_build_well_known_url_strips_userinfo_keeps_port(self):
+        url = _build_well_known_url(
+            "https://u:p@api.example.com:8443/mcp",
+            "oauth-protected-resource",
+            keep_query=False,
+        )
+        assert url == (
+            "https://api.example.com:8443/.well-known/oauth-protected-resource/mcp"
+        )
+
     def test_rfc8414_issuer_mismatch_warns_but_continues(self, httpx_mock, caplog):
         """RFC 8414 §3: issuer in metadata mismatches discovery URL — warn, don't fail."""
         import logging
@@ -2793,15 +2814,18 @@ class TestValidateAuthServerUrl:
         )
         assert "cross-origin" not in capsys.readouterr().err
 
-    def test_userinfo_is_not_cross_origin(self, capsys):
-        """Per RFC 6454 §4, userinfo is not part of the origin."""
+    def test_userinfo_is_rejected(self, capsys):
+        """#10: an authorization_server URL embedding userinfo is refused —
+        it would survive into the (non-revalidated) synthesized token endpoint
+        and route the credential exchange through a userinfo authority. Mirrors
+        _validate_endpoint_url's userinfo rejection."""
         assert (
             _validate_auth_server_url(
                 "https://user:pass@mcp.example.com/authorize", self.SERVER_URL
             )
-            is True
+            is False
         )
-        assert "cross-origin" not in capsys.readouterr().err
+        assert "userinfo" in capsys.readouterr().err
 
     def test_different_port_is_cross_origin(self, capsys):
         """Different explicit ports ARE different origins per RFC 6454."""
@@ -3264,6 +3288,35 @@ class TestRfc9207IssValidation:
             timeout=5,
         )
         assert data.access_token == "at"
+
+    def test_stepup_preserves_requested_scope_when_response_omits_it(
+        self, httpx_mock, tmp_path, monkeypatch
+    ):
+        """#2: a step-up token response that OMITS scope (RFC 6749 §5.1, when it
+        equals the requested scope) must keep the requested/merged union in the
+        stored TokenData — not wipe it to None and shrink the next step-up."""
+        store_file = tmp_path / "tokens.json"
+        monkeypatch.setattr("mcp_stdio.token_store._STORE_DIR", tmp_path)
+        monkeypatch.setattr("mcp_stdio.token_store._STORE_FILE", store_file)
+        # Token response deliberately omits "scope".
+        httpx_mock.add_response(
+            url="https://ex.com/token",
+            json={"access_token": "at", "token_type": "Bearer"},
+        )
+        monkeypatch.setattr(
+            "mcp_stdio.oauth.webbrowser.open", self._driver("iss=https://ex.com")
+        )
+        client = httpx.Client()
+        data = _run_authorization_flow(
+            "https://ex.com/mcp",
+            client,
+            metadata=self.META,
+            cached=None,
+            client_id_override="cid",
+            scope="read write admin",  # the merged union a step-up requests
+            timeout=5,
+        )
+        assert data.scope == "read write admin"
 
     def test_no_iss_skips_validation(self, httpx_mock, tmp_path, monkeypatch):
         store_file = tmp_path / "tokens.json"


### PR DESCRIPTION
## Overview

From the Opus 4.8 review (round 10): one MEDIUM scope-drop on step-up plus two userinfo-handling gaps in discovery. All in `oauth.py`.

## 1. Step-up dropped granted scope — #2 (MEDIUM)

The auth-code path `_run_authorization_flow` called `_token_response_to_data` **without** `previous_scope`. RFC 6749 §5.1 lets the AS omit `scope` when it equals the requested scope — exactly what a step-up does (requested == merged union). So `TokenData.scope` became `None`, and the **next** `step_up_authorize` unioned an empty `cached.scope` with only the new challenge scope, re-requesting a **narrower** set than the user already consented to.

**Fix:** pass `previous_scope=scope` — the merged/requested scope on step-up, `None` on initial auth (the correct fallback in both cases). This completes the symmetry with the round-9 `refresh_cached_token` fix.

## 2. Userinfo leaked into discovery GETs — #5 (LOW)

`_build_well_known_url` copied `netloc` verbatim, so a `user:pass@host` server URL sent those credentials as HTTP Basic auth on the PRM / AS-metadata discovery requests. **Fix:** strip userinfo (rebuild `netloc` from hostname + port), consistent with `_authorization_base_url`.

## 3. Userinfo not rejected in `_validate_auth_server_url` — #10 (NIT)

Unlike its sibling `_validate_endpoint_url`, it never inspected `username`/`password`. A PRM-advertised `authorization_server=https://attacker:secret@evil` would survive into the synthesized (non-revalidated) default token endpoint, routing the `code` + `client_secret` + PKCE `code_verifier` through a userinfo authority. **Fix:** reject userinfo there too.

## Tests

- Step-up with a scope-omitting token response keeps the requested union.
- `_build_well_known_url` strips userinfo (keeping the port).
- A userinfo `authorization_server` is refused with a warning (existing `test_userinfo_is_not_cross_origin` updated to the new reject behaviour).

612 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)