### PR TITLE
fix(token_store): never clobber an unreadable store on save/delete

### DIFF
--- a/src/mcp_stdio/token_store.py
+++ b/src/mcp_stdio/token_store.py
@@ -202,8 +202,27 @@ def _migrate_legacy_store() -> None:
         pass  # Not empty or already gone
 
 
-def _read_store() -> dict[str, Any]:
-    """Read the token store file."""
+class _StoreUnreadable(Exception):
+    """The store file exists but could not be READ (permission / symlink /
+    I/O error) — distinct from 'absent' (→ {}) and 'corrupt JSON' (which is
+    overwrite-safe). A writer must ABORT on this rather than clobber a store
+    whose real contents it never saw, which would destroy every other
+    server's tokens.
+    """
+
+
+def _read_store(*, for_write: bool = False) -> dict[str, Any]:
+    """Read the token store file.
+
+    Returns ``{}`` when the store is absent / genuinely empty. On the READ
+    path any failure also degrades to ``{}`` (load_token tolerates that). On the
+    WRITE path (``for_write=True``) a read failure raises ``_StoreUnreadable``
+    so the caller aborts instead of overwriting a store it could not read — a
+    transient EACCES, an ELOOP from a swapped-in symlink, or a backup-restore
+    race would otherwise let the next save persist ONLY its one key and wipe
+    every other server's cached token. A corrupt-JSON store stays overwrite-safe
+    (``{}``), preserving the intentional corrupt-store-replacement behaviour.
+    """
     _migrate_legacy_store()
     if not _STORE_FILE.exists():
         return {}
@@ -221,9 +240,13 @@ def _read_store() -> dict[str, Any]:
     # NTFS ACLs govern access anyway.
     try:
         fd = os.open(_STORE_FILE, os.O_RDONLY | _O_NOFOLLOW)
-    except OSError:
-        # ELOOP (a symlink was swapped in — refused), ENOENT (race), or a
-        # permission error: treat as no readable store.
+    except OSError as e:
+        # The file EXISTS but we could not open it: ELOOP (a symlink swapped
+        # in — refused), EACCES, or a transient I/O error. On the write path
+        # this must NOT degrade to {} (which a save would then clobber over the
+        # unread store); raise so the caller aborts.
+        if for_write:
+            raise _StoreUnreadable(str(e)) from e
         return {}
     try:
         _fchmod = getattr(os, "fchmod", None)
@@ -233,9 +256,19 @@ def _read_store() -> dict[str, Any]:
             except OSError:
                 pass  # best-effort tighten
         with os.fdopen(fd, "r", encoding="utf-8") as f:
-            return json.loads(f.read())
-    except (json.JSONDecodeError, OSError):
+            text = f.read()
+    except OSError as e:
+        # Opened but the read itself failed — same trust problem as open failure.
+        if for_write:
+            raise _StoreUnreadable(str(e)) from e
         return {}
+    try:
+        data = json.loads(text)
+    except json.JSONDecodeError:
+        # Genuinely corrupt JSON is overwrite-safe (the contents are unusable);
+        # both read and write paths treat it as an empty store.
+        return {}
+    return data if isinstance(data, dict) else {}
 
 
 def _write_store(data: dict[str, Any]) -> None:
@@ -366,7 +399,19 @@ def load_token(server_url: str) -> TokenData | None:
 def save_token(server_url: str, data: TokenData) -> None:
     """Save token data for a server URL."""
     with _store_lock():
-        store = _read_store()
+        try:
+            store = _read_store(for_write=True)
+        except _StoreUnreadable as e:
+            # The store exists but we could not read it — writing now would
+            # persist only this one key and destroy every other server's token.
+            # Skip the save (the token is simply not cached; the caller re-auths
+            # next time) rather than corrupt the store.
+            print(
+                f"warning: token store exists but could not be read ({e}); "
+                f"not saving to avoid overwriting other servers' tokens",
+                file=sys.stderr,
+            )
+            return
         key = _normalize_key(server_url)
         # Drop any stale entry stored under the un-normalised key by an older
         # version so the two spellings don't both linger.
@@ -379,7 +424,18 @@ def save_token(server_url: str, data: TokenData) -> None:
 def delete_token(server_url: str) -> None:
     """Delete token data for a server URL."""
     with _store_lock():
-        store = _read_store()
+        try:
+            store = _read_store(for_write=True)
+        except _StoreUnreadable as e:
+            # Same reasoning as save_token: never write over a store we could
+            # not read. The targeted entry stays (a stale token at worst), the
+            # other servers' tokens are preserved.
+            print(
+                f"warning: token store exists but could not be read ({e}); "
+                f"not deleting to avoid overwriting other servers' tokens",
+                file=sys.stderr,
+            )
+            return
         removed = False
         for key in {_normalize_key(server_url), server_url}:
             if key in store:

--- a/tests/test_token_store.py
+++ b/tests/test_token_store.py
@@ -188,6 +188,88 @@ class TestLoadSaveDelete:
         loaded = load_token("https://example.com/mcp")
         assert loaded is not None and loaded.access_token == "fresh"
 
+    def test_save_aborts_when_store_unreadable(self, tmp_path, monkeypatch, capsys):
+        """#3: if the store EXISTS but cannot be read (e.g. transient EACCES),
+        a save must ABORT rather than clobber it with a single-key payload that
+        destroys every other server's token."""
+        store_file = tmp_path / "tokens.json"
+        monkeypatch.setattr("mcp_stdio.token_store._STORE_DIR", tmp_path)
+        monkeypatch.setattr("mcp_stdio.token_store._STORE_FILE", store_file)
+
+        save_token("https://a.com/mcp", TokenData(access_token="tok-a"))
+        save_token("https://b.com/mcp", TokenData(access_token="tok-b"))
+
+        real_open = os.open
+
+        def fail_store_read(path, flags, *a, **k):
+            # Fail only the read-open of the store file; allow lock + temp writes.
+            is_read = flags & (os.O_WRONLY | os.O_RDWR) == 0
+            if is_read and os.fspath(path) == os.fspath(store_file):
+                raise PermissionError(13, "store momentarily locked")
+            return real_open(path, flags, *a, **k)
+
+        monkeypatch.setattr("mcp_stdio.token_store.os.open", fail_store_read)
+        save_token("https://c.com/mcp", TokenData(access_token="tok-c"))  # must abort
+        monkeypatch.setattr("mcp_stdio.token_store.os.open", real_open)
+
+        # The pre-existing tokens survive; the unreadable-time save was skipped.
+        assert load_token("https://a.com/mcp").access_token == "tok-a"
+        assert load_token("https://b.com/mcp").access_token == "tok-b"
+        assert load_token("https://c.com/mcp") is None
+        assert "could not be read" in capsys.readouterr().err
+
+    def test_delete_aborts_when_store_unreadable(
+        self, tmp_path, monkeypatch, capsys
+    ):
+        """#3: delete must likewise abort on an unreadable store rather than
+        overwrite it and lose the other servers' tokens."""
+        store_file = tmp_path / "tokens.json"
+        monkeypatch.setattr("mcp_stdio.token_store._STORE_DIR", tmp_path)
+        monkeypatch.setattr("mcp_stdio.token_store._STORE_FILE", store_file)
+
+        save_token("https://a.com/mcp", TokenData(access_token="tok-a"))
+        save_token("https://b.com/mcp", TokenData(access_token="tok-b"))
+
+        real_open = os.open
+
+        def fail_store_read(path, flags, *a, **k):
+            is_read = flags & (os.O_WRONLY | os.O_RDWR) == 0
+            if is_read and os.fspath(path) == os.fspath(store_file):
+                raise PermissionError(13, "store momentarily locked")
+            return real_open(path, flags, *a, **k)
+
+        monkeypatch.setattr("mcp_stdio.token_store.os.open", fail_store_read)
+        delete_token("https://a.com/mcp")  # must abort
+        monkeypatch.setattr("mcp_stdio.token_store.os.open", real_open)
+
+        # Nothing deleted (and nothing else lost).
+        assert load_token("https://a.com/mcp").access_token == "tok-a"
+        assert load_token("https://b.com/mcp").access_token == "tok-b"
+        assert "could not be read" in capsys.readouterr().err
+
+    def test_save_degrades_to_unlocked_when_lock_open_fails(
+        self, tmp_path, monkeypatch
+    ):
+        """#8: if the advisory lock file cannot be opened, the save must still
+        proceed (unsynchronised) — lock trouble never blocks a write."""
+        store_file = tmp_path / "tokens.json"
+        lock_path = tmp_path / "tokens.json.lock"
+        monkeypatch.setattr("mcp_stdio.token_store._STORE_DIR", tmp_path)
+        monkeypatch.setattr("mcp_stdio.token_store._STORE_FILE", store_file)
+
+        real_open = os.open
+
+        def fail_lock_open(path, flags, *a, **k):
+            if os.fspath(path) == os.fspath(lock_path):
+                raise PermissionError(13, "cannot create lock file")
+            return real_open(path, flags, *a, **k)
+
+        monkeypatch.setattr("mcp_stdio.token_store.os.open", fail_lock_open)
+        save_token("https://example.com/mcp", TokenData(access_token="t"))
+        monkeypatch.setattr("mcp_stdio.token_store.os.open", real_open)
+
+        assert load_token("https://example.com/mcp").access_token == "t"
+
     @pytest.mark.skipif(
         sys.platform == "win32",
         reason="POSIX mode bits don't model NTFS ACLs",


### PR DESCRIPTION
## Overview

A MEDIUM data-loss fix from the Opus 4.8 review (round 10, #3), plus a coverage gap (#8).

## The bug

`_read_store` returned `{}` on **every** failure path — O_NOFOLLOW/ELOOP symlink refusal, a transient `EACCES`, any read `OSError` — indistinguishable from a genuinely-empty store. `save_token` / `delete_token` then read-modify-write on that `{}` and `os.replace` it over the real store, **destroying every other server's cached token** (refresh tokens and DCR `client_secret`s included). A `tokens.json` momentarily held by an indexer/AV, restored from backup, or hit by a symlink swap routes straight through this. The O_NOFOLLOW read added last round widened the set of inputs reaching it.

## The fix

Distinguish *absent/empty* from *present-but-unreadable*:

- `_read_store(for_write=...)` — on an `OSError` (open or read) it raises `_StoreUnreadable` when `for_write=True`; the read path (`load_token`) still degrades to `{}`.
- `save_token` / `delete_token` catch `_StoreUnreadable` and **abort** (warn to stderr, leave the store untouched) instead of overwriting a store they could not read. The token simply isn't cached; the caller re-auths next time.
- A genuinely **corrupt-JSON** store stays overwrite-safe (`{}`), preserving the intentional corrupt-store-replacement behaviour (`test_save_over_corrupt_store_succeeds` still passes).

## Tests

- `save`/`delete` both abort and preserve the other servers' tokens when the store read fails with `EACCES`.
- A lock-open failure still lets the save proceed unsynchronised (#8 — the documented best-effort fallback was untested).

612 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)