### PR TITLE
fix(relay): pagination ignores interleaved SSE messages; strip protocol header on re-init

### DIFF
--- a/src/mcp_stdio/relay.py
+++ b/src/mcp_stdio/relay.py
@@ -266,11 +266,13 @@ class _CancelTracker:
     exactly once — a later request that legitimately *reuses* the same id
     (permitted by JSON-RPC once the prior call is done) is then forwarded
     normally instead of being dropped for the whole TTL window. Entries
-    expire after ``ttl`` seconds (monotonic clock — immune to NTP jumps),
-    and the internal map is opportunistically garbage-collected when it
-    grows past ``_CANCEL_GC_THRESHOLD`` entries so an adversarial peer cannot
-    leak memory. Both transports share one instance; the SSE reader thread
-    in ``run_sse`` reads concurrently with the main loop, hence the lock.
+    expire after ``ttl`` seconds (monotonic clock — immune to NTP jumps), and
+    once the map grows past ``_CANCEL_GC_THRESHOLD`` every ``add`` sweeps out
+    the TTL-aged entries. The GC reclaims only entries older than ``ttl``, so
+    it is not a hard size cap: the bound against an adversarial peer is "one
+    TTL window of distinct-cancel throughput", which then self-expires — never
+    an unbounded leak. Both transports share one instance; the SSE reader
+    thread in ``run_sse`` reads concurrently with the main loop, hence the lock.
     """
 
     __slots__ = ("_seen", "_lock", "_ttl", "_now")
@@ -804,13 +806,24 @@ def _post_parsed(
 
             content_type = resp.headers.get("content-type", "")
             if "text/event-stream" in content_type:
+                # A spec-compliant server MAY interleave server-initiated
+                # requests and notifications on the POST's SSE stream BEFORE the
+                # actual JSON-RPC response. Return only the response object (one
+                # carrying ``result``/``error``); a bare notification has
+                # neither, and returning it would make the pagination merge treat
+                # it as the page result and drop the real list. Mirrors the
+                # keep-reading gate in _check_connection_sse.
                 for event_type, payload in _iter_sse_events(_split_sse_text(resp.text)):
                     if event_type != "message":
                         continue
                     try:
-                        return json.loads(payload), _StreamResult(session, 200)
+                        parsed = json.loads(payload)
                     except json.JSONDecodeError:
                         continue
+                    if isinstance(parsed, dict) and (
+                        "result" in parsed or "error" in parsed
+                    ):
+                        return parsed, _StreamResult(session, 200)
                 return None, _StreamResult(session, 200)
 
             text = resp.text.strip()
@@ -1508,6 +1521,18 @@ def run(
                 # header is sent rather than guessing — a server that both
                 # omits it and enforces the header would be self-contradictory.
                 capture_init = _looks_like_initialize(content)
+                if capture_init:
+                    # An initialize request IS the (re)negotiation and predates a
+                    # known version, so it must not advertise the prior one
+                    # (2025-06-18: the header carries the negotiated version and
+                    # applies to requests AFTER initialization). Strip it from
+                    # this POST, matching _reinitialize which omits it on its own
+                    # initialize POST. Mcp-Session-Id is left untouched.
+                    h = {
+                        k: v
+                        for k, v in h.items()
+                        if k.lower() != "mcp-protocol-version"
+                    }
                 result = _post_and_stream(
                     client, url, content, h, req_id, tracker,
                     capture_init=capture_init, has_id=req_has_id,

--- a/tests/test_relay.py
+++ b/tests/test_relay.py
@@ -1001,6 +1001,41 @@ class TestRun:
         parsed = json.loads(output.strip())
         assert parsed["id"] == 5 and "error" in parsed
 
+    def test_request_with_falsy_id_zero_gets_error(self, httpx_mock):
+        """#6: id 0 is a valid JSON-RPC id (not absent). A 4xx must produce an
+        error carrying id:0 — id=0 must not be mis-treated as a notification by
+        a falsy check."""
+        httpx_mock.add_response(
+            status_code=400, text="", headers={"content-type": "application/json"}
+        )
+        output = self._run_with_stdin(
+            httpx_mock, ['{"jsonrpc":"2.0","method":"tools/call","id":0}']
+        )
+        parsed = json.loads(output.strip())
+        assert parsed["id"] == 0 and "error" in parsed
+
+    def test_batch_request_passes_through(self, httpx_mock):
+        """#11: a JSON-RPC batch array is forwarded verbatim and its batch
+        response relayed end-to-end through run()."""
+        batch_resp = (
+            '[{"jsonrpc":"2.0","result":{},"id":1},'
+            '{"jsonrpc":"2.0","result":{},"id":2}]'
+        )
+        httpx_mock.add_response(
+            text=batch_resp, headers={"content-type": "application/json"}
+        )
+        output = self._run_with_stdin(
+            httpx_mock,
+            [
+                '[{"jsonrpc":"2.0","method":"a","id":1},'
+                '{"jsonrpc":"2.0","method":"b","id":2}]'
+            ],
+        )
+        assert json.loads(output.strip()) == json.loads(batch_resp)
+        # The request reached the wire as a batch array, unchanged.
+        sent = json.loads(httpx_mock.get_requests()[0].read())
+        assert isinstance(sent, list) and len(sent) == 2
+
     def test_notification_transport_failure_gets_no_synthesized_response(
         self, httpx_mock
     ):
@@ -1467,11 +1502,13 @@ class TestProtocolVersionHeader:
             ]
         )
         reqs = httpx_mock.get_requests()
-        # req[0] first initialize: no header yet (it IS the negotiation).
+        # req[0] first initialize: no header (it IS the negotiation).
         assert "mcp-protocol-version" not in reqs[0].headers
-        # req[1] second initialize carries the first-negotiated version.
-        assert reqs[1].headers["mcp-protocol-version"] == "2025-03-26"
-        # req[2] carries the RE-negotiated version — proof of re-capture.
+        # req[1] second initialize ALSO carries no header — an initialize is the
+        # (re)negotiation and must not advertise the prior version (#4).
+        assert "mcp-protocol-version" not in reqs[1].headers
+        # req[2] (a normal request) carries the RE-negotiated version — proof
+        # the second initialize's response was re-captured.
         assert reqs[2].headers["mcp-protocol-version"] == "2025-06-18"
 
     def test_reinitialize_recaptures_version_from_sse_framed_response(self, httpx_mock):
@@ -2289,6 +2326,30 @@ class TestPagination:
         assert [t["name"] for t in merged["result"]["tools"]] == ["a", "b"]
         assert merged["result"]["_meta"] == {"total": 2}  # late field kept
         assert "nextCursor" not in merged["result"]
+
+    def test_page_sse_skips_interleaved_notification(self, httpx_mock):
+        """#1: a server may interleave a notification on the POST's SSE stream
+        BEFORE the list result. _post_parsed must skip it and return the real
+        response, not mistake the notification for the page result."""
+        notif = '{"jsonrpc":"2.0","method":"notifications/message","params":{}}'
+        result = '{"jsonrpc":"2.0","id":1,"result":{"tools":[{"name":"a"}]}}'
+        body = (
+            f"event: message\ndata: {notif}\n\n"
+            f"event: message\ndata: {result}\n\n"
+        )
+        httpx_mock.add_response(
+            url=self.URL,
+            text=body,
+            headers={"content-type": "text/event-stream"},
+        )
+        output = self._run_with_stdin(
+            httpx_mock,
+            [json.dumps({"jsonrpc": "2.0", "id": 1, "method": "tools/list"})],
+        )
+        merged = json.loads(output.strip())
+        assert [t["name"] for t in merged["result"]["tools"]] == ["a"]
+        # The interleaved notification must not have been forwarded as the result.
+        assert "notifications/message" not in output
 
 
 # --- check_connection ---
@@ -3176,6 +3237,25 @@ class TestRunSse:
                 {},
                 sse_read_timeout=300,
             )
+
+    def test_sse_startup_timeout_exits(self, monkeypatch):
+        """#7: if the SSE reader never signals ready within timeout_connect,
+        run_sse must exit(1) rather than block on stdin forever."""
+
+        def blocking_reader(
+            client, url, headers, state, tracker=None, headers_lock=None
+        ):
+            # Never set state.ready; just park until told to stop.
+            state.stop.wait(timeout=2)
+
+        monkeypatch.setattr("mcp_stdio.relay._sse_reader_loop", blocking_reader)
+        with (
+            patch("sys.stdin", StringIO("")),
+            patch("sys.stdout", StringIO()),
+            pytest.raises(SystemExit) as exc,
+        ):
+            run_sse(self.URL, {}, timeout_connect=0.05)
+        assert exc.value.code == 1
 
     def test_post_during_reconnect_window_emits_error(self, monkeypatch):
         """A stdin line arriving while the reader is mid-reconnect (endpoint


### PR DESCRIPTION
## Overview

From the Opus 4.8 review (round 10): one MEDIUM SSE-framing bug, one LOW header deviation, a docstring fix, and four coverage gaps — all in `relay.py`.

## 1. Pagination picked the wrong SSE message — #1 (MEDIUM)

`_post_parsed` (used only by the auto-pagination path) returned the **first** parseable SSE `message` event, with no check that it was the JSON-RPC response. The Streamable HTTP spec permits a server to interleave server-initiated requests / notifications on the POST's SSE stream **before** the response. `_post_parsed` would return that interleaved notification; `_paginate_and_stream` then forwards it verbatim as the page-1 result (`page_result` is not a dict → flush branch) and the real list is never delivered — the client's `tools/list` hangs.

**Fix:** skip non-response messages and return only one carrying `result`/`error`, mirroring the existing `_check_connection_sse` keep-reading gate. The sibling `_post_and_stream` is unaffected (it emits every message verbatim, so the response is always among them).

## 2. Stale `MCP-Protocol-Version` on client-driven re-initialize — #4 (LOW)

`_prepare_headers` stamps the header whenever a version is known, so a **second** client `initialize` advertised the prior version. An initialize **is** the (re)negotiation and predates a known version (2025-06-18: the header applies to requests *after* initialization). **Fix:** strip the header from the initialize POST, matching `_reinitialize`. `Mcp-Session-Id` is untouched.

## 3. `_CancelTracker` GC docstring — #9 (NIT)

Softened: the bound against an adversarial peer is *one TTL window of distinct-cancel throughput* (self-expiring), not the hard 256-entry cap the old wording implied.

## Coverage added

- pagination skips an interleaved notification (#1);
- a request with falsy **id 0** still gets an error, not treated as a notification (#6);
- a JSON-RPC **batch** passes through `run()` end-to-end (#11);
- `run_sse` **exits(1)** on a startup-ready timeout (#7).
- The client-driven re-initialize test now asserts the initialize POST carries **no** protocol-version header (#4).

613 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)