### PR TITLE
fix(oauth): single-shot callback capture; don't abandon discovery on a useless PRM

### DIFF
--- a/src/mcp_stdio/oauth.py
+++ b/src/mcp_stdio/oauth.py
@@ -463,6 +463,7 @@ def discover_oauth_metadata(
                 f"expected {server_url!r}, got {prm_resource!r}"
             )
         auth_servers = prm_data.get("authorization_servers")
+        found = False
         if auth_servers and isinstance(auth_servers, list):
             # Walk the list and pick the first entry that passes validation.
             # A malicious or misconfigured MCP server might otherwise send
@@ -474,8 +475,13 @@ def discover_oauth_metadata(
                 ):
                     auth_server_url = candidate
                     log(f"discovered authorization server: {auth_server_url}")
+                    found = True
                     break
-        break
+        if found:
+            break
+        # A 200 PRM doc that yielded no usable authorization_servers (missing /
+        # empty / all entries rejected) must NOT end discovery — fall through to
+        # the next candidate (e.g. the host-root PRM) instead of giving up here.
 
     # Phase 2: RFC 8414 Authorization Server Metadata
     meta = _fetch_authorization_server_metadata(auth_server_url, client)
@@ -686,6 +692,19 @@ def _make_callback_handler(
                 return
 
             params = parse_qs(parsed.query)
+
+            # Single-shot capture: once the first authorization response is
+            # recorded, ignore any subsequent /callback hit (browser refresh,
+            # link prefetch, double-submit) so it cannot overwrite the captured
+            # code/error in the race window before the main loop consumes it.
+            if result.auth_code is not None or result.error is not None:
+                self.send_response(200)
+                self.send_header("Content-Type", "text/html")
+                self.end_headers()
+                self.wfile.write(
+                    b"<h1>Already received</h1><p>You can close this tab.</p>"
+                )
+                return
 
             if "error" in params:
                 result.error = params["error"][0]

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -189,6 +189,36 @@ class TestDiscoverMetadata:
         assert meta.token_endpoint == "https://as.example.com/token"
         assert "//authorize" not in meta.authorization_endpoint
 
+    def test_path_prm_without_as_falls_through_to_host_root(self, httpx_mock):
+        """#7(round11): a path-aware PRM that returns 200 but yields no usable
+        authorization_servers must NOT end discovery — fall through to the
+        host-root PRM candidate instead of giving up."""
+        server_url = "https://api.example.com/mcp"
+        # Path-aware PRM: 200 but empty authorization_servers (nothing usable).
+        httpx_mock.add_response(
+            url="https://api.example.com/.well-known/oauth-protected-resource/mcp",
+            json={"resource": server_url, "authorization_servers": []},
+        )
+        # Host-root PRM: 200 with a valid AS.
+        httpx_mock.add_response(
+            url="https://api.example.com/.well-known/oauth-protected-resource",
+            json={
+                "resource": server_url,
+                "authorization_servers": ["https://as.example.com"],
+            },
+        )
+        httpx_mock.add_response(
+            url="https://as.example.com/.well-known/oauth-authorization-server",
+            json={
+                "authorization_endpoint": "https://as.example.com/auth",
+                "token_endpoint": "https://as.example.com/tok",
+            },
+        )
+        client = httpx.Client()
+        meta = discover_oauth_metadata(server_url, client)
+        assert meta.authorization_endpoint == "https://as.example.com/auth"
+        assert meta.token_endpoint == "https://as.example.com/tok"
+
     def test_fallback_on_404(self, httpx_mock):
         self._mock_no_prm(httpx_mock)
         httpx_mock.add_response(
@@ -1616,6 +1646,39 @@ class TestCallbackServer:
 
         assert cb_result.error == "access_denied"
         assert cb_result.auth_code is None
+
+    def test_callback_is_single_shot(self):
+        """#6(round11): once the first authorization response is captured, a
+        second /callback hit (refresh / prefetch / double-submit) must NOT
+        overwrite it."""
+        cb_result = CallbackResult()
+        handler_cls = _make_callback_handler(cb_result)
+
+        from http.server import HTTPServer
+
+        server = HTTPServer(("127.0.0.1", 0), handler_cls)
+        port = server.server_address[1]
+        done = threading.Event()
+
+        def serve():
+            while not done.is_set():
+                server.handle_request()
+
+        t = threading.Thread(target=serve, daemon=True)
+        t.start()
+        time.sleep(0.3)
+
+        r1 = httpx.get(f"http://127.0.0.1:{port}/callback?code=FIRST&state=s1")
+        r2 = httpx.get(f"http://127.0.0.1:{port}/callback?code=SECOND&state=s2")
+
+        done.set()
+        server.server_close()
+
+        assert "Authorization successful" in r1.text
+        assert "Already received" in r2.text  # second hit ignored
+        # The first capture stands; the second did not overwrite it.
+        assert cb_result.auth_code == "FIRST"
+        assert cb_result.state == "s1"
 
     def test_non_callback_path_returns_404_and_does_not_capture(self):
         """#15: favicon / prefetch / stray tabs must not deliver a code.

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -2952,6 +2952,13 @@ class TestValidateAuthServerUrl:
                 "authorization_servers": ["http://evil.example.net/authorize"],
             },
         )
+        # The path-aware PRM yielded no USABLE auth server (the only entry was a
+        # rejected plaintext URL), so discovery now falls through to the
+        # host-root PRM candidate before the base AS-metadata fetch. See #7.
+        httpx_mock.add_response(
+            url="https://mcp.example.com/.well-known/oauth-protected-resource",
+            status_code=404,
+        )
         httpx_mock.add_response(
             url="https://mcp.example.com/.well-known/oauth-authorization-server",
             json={


### PR DESCRIPTION
## Overview

Two `oauth.py` robustness fixes from the Opus 4.8 review (round 11, #6/#7 — both LOW).

## 1. Callback capture was not single-shot — #6

The localhost callback handler wrote into `cb_result` on **every** `/callback` request. A second hit (browser refresh, link prefetch, double-submit) could **overwrite** the first captured `code`/`error` in the window before the main loop consumed it. Now capture is single-shot: once `auth_code` or `error` is set, a further `/callback` returns an "Already received" page **without touching** `cb_result`.

## 2. Discovery abandoned on a useless PRM — #7

`discover_oauth_metadata` broke out of the PRM-candidate loop after the **first** candidate that merely returned 200 — even when that document carried no usable `authorization_servers` (missing / empty / all entries rejected as plaintext/cross-origin). A path-aware PRM with no usable AS therefore skipped the **host-root** PRM candidate and discovery fell through to default endpoints needlessly. Now the loop only breaks once a valid AS is accepted; otherwise it continues to the next candidate.

## Tests

- A second callback hit keeps the first code (`Already received` on the duplicate).
- A path-aware PRM with empty `authorization_servers` now discovers the AS from the host-root PRM.
- The existing plaintext-AS-skip test gained a host-root PRM 404 mock to reflect the new fall-through.

637+ tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)