### PR TITLE
fix(token_store): give each write a unique temp-file name

### DIFF
--- a/src/mcp_stdio/token_store.py
+++ b/src/mcp_stdio/token_store.py
@@ -15,6 +15,7 @@ import json
 import os
 import stat
 import sys
+import threading
 from collections.abc import Iterator
 from dataclasses import asdict, dataclass
 from pathlib import Path
@@ -282,7 +283,13 @@ def _write_store(data: dict[str, Any]) -> None:
     """
     _ensure_store_dir()
     payload = json.dumps(data, indent=2).encode("utf-8")
-    tmp_path = _STORE_FILE.with_suffix(_STORE_FILE.suffix + f".tmp.{os.getpid()}")
+    # Per-write unique temp name. PID alone is not enough: when the advisory
+    # lock degrades to a no-op (lock fs unavailable), two THREADS in one process
+    # share the PID and would otherwise pick the same temp path and clobber each
+    # other's in-flight write. Thread id + random make every temp file distinct,
+    # leaving only the documented os.replace last-writer-wins on the final file.
+    uniq = f"{os.getpid()}.{threading.get_ident()}.{os.urandom(4).hex()}"
+    tmp_path = _STORE_FILE.with_suffix(_STORE_FILE.suffix + f".tmp.{uniq}")
     flags = os.O_WRONLY | os.O_CREAT | os.O_TRUNC | _O_NOFOLLOW
     fd = os.open(tmp_path, flags, stat.S_IRUSR | stat.S_IWUSR)  # 0o600
     try:

--- a/tests/test_token_store.py
+++ b/tests/test_token_store.py
@@ -139,6 +139,30 @@ class TestLoadSaveDelete:
         monkeypatch.setattr("mcp_stdio.token_store.os.open", real_open)
         assert load_token("https://example.com/mcp").access_token == "t"
 
+    def test_temp_file_name_is_unique_per_write(self, tmp_path, monkeypatch):
+        """#8: each write uses a distinct temp file name so two writers sharing a
+        PID (the unlocked-lock fallback) cannot collide on the same temp path."""
+        store_file = tmp_path / "tokens.json"
+        monkeypatch.setattr("mcp_stdio.token_store._STORE_DIR", tmp_path)
+        monkeypatch.setattr("mcp_stdio.token_store._STORE_FILE", store_file)
+
+        temp_names: list[str] = []
+        real_open = os.open
+
+        def spy_open(path, flags, *a, **k):
+            p = os.fspath(path)
+            if ".tmp." in p:
+                temp_names.append(p)
+            return real_open(path, flags, *a, **k)
+
+        monkeypatch.setattr("mcp_stdio.token_store.os.open", spy_open)
+        save_token("https://a.com/mcp", TokenData(access_token="a"))
+        save_token("https://b.com/mcp", TokenData(access_token="b"))
+        monkeypatch.setattr("mcp_stdio.token_store.os.open", real_open)
+
+        assert len(temp_names) == 2
+        assert temp_names[0] != temp_names[1]  # distinct temp path per write
+
     def test_load_unknown_future_field_returns_none(self, tmp_path, monkeypatch):
         """Forward-compat: an entry written by a newer version carrying a field
         this version doesn't know must degrade to None, not raise."""


### PR DESCRIPTION
## Overview

A LOW concurrency fix from the Opus 4.8 review (round 11, #8).

The atomic-write temp file was named only with the PID (`tokens.json.tmp.<pid>`). When the advisory lock degrades to a no-op (lock filesystem unavailable), two threads in one process share the PID and would pick the **same** temp path — so one writer's in-flight temp could clobber the other's before either renamed it into place.

**Fix:** add a per-write uniquifier (`thread id` + `os.urandom`) so every temp file is distinct, leaving only the documented `os.replace` last-writer-wins on the final file.

Test asserts two saves use distinct temp paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)