### PR TITLE
fix(cli): reject zero --timeout-connect / --timeout-read

### DIFF
--- a/src/mcp_stdio/cli.py
+++ b/src/mcp_stdio/cli.py
@@ -24,6 +24,21 @@ def _non_negative_float(value: str) -> float:
     return f
 
 
+def _positive_float(value: str) -> float:
+    """argparse type for strictly-positive floats.
+
+    For ``--timeout-connect`` / ``--timeout-read`` a value of 0 is meaningless:
+    httpx treats it as an immediate timeout, so every connect/read would fail at
+    once. Reject 0 at parse time. (``--sse-read-timeout`` keeps 0 = disable and
+    ``--oauth-refresh-leeway`` keeps 0 = no proactive refresh, so those stay on
+    ``_non_negative_float``.) See #9.
+    """
+    f = _non_negative_float(value)  # reuse non-numeric / negative handling
+    if f == 0:
+        raise argparse.ArgumentTypeError("value must be > 0")
+    return f
+
+
 # RFC 7230 §3.2.6 field-name = token = 1*tchar. tchar covers
 # "!#$%&'*+-.^_`|~" plus DIGIT and ALPHA. Used to reject header names
 # that could be misinterpreted by downstream HTTP parsers.
@@ -248,15 +263,15 @@ def main() -> None:
     )
     parser.add_argument(
         "--timeout-connect",
-        type=_non_negative_float,
+        type=_positive_float,
         default=10,
-        help="Connection timeout in seconds (default: 10)",
+        help="Connection timeout in seconds, > 0 (default: 10)",
     )
     parser.add_argument(
         "--timeout-read",
-        type=_non_negative_float,
+        type=_positive_float,
         default=120,
-        help="Read timeout in seconds (default: 120)",
+        help="Read timeout in seconds, > 0 (default: 120)",
     )
     parser.add_argument(
         "--sse-read-timeout",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -231,6 +231,17 @@ class TestMain:
             assert exc_info.value.code == 2
         assert "must be >= 0" in capsys.readouterr().err
 
+    @pytest.mark.parametrize("flag", ["--timeout-connect", "--timeout-read"])
+    def test_zero_connect_read_timeout_rejected(self, flag, capsys):
+        """#9: --timeout-connect 0 / --timeout-read 0 are rejected at parse time
+        (httpx would treat 0 as an immediate timeout that always fails). Unlike
+        --sse-read-timeout, where 0 means 'disable'."""
+        with patch("sys.argv", ["mcp-stdio", flag, "0", "https://example.com/mcp"]):
+            with pytest.raises(SystemExit) as exc_info:
+                main()
+            assert exc_info.value.code == 2
+        assert "must be > 0" in capsys.readouterr().err
+
     def test_sse_read_timeout_zero_still_accepted(self):
         """--sse-read-timeout 0 (disable) must remain valid — 0 is allowed."""
         with (


### PR DESCRIPTION
## Overview

A LOW input-validation fix from the Opus 4.8 review (round 11, #9).

`--timeout-connect 0` / `--timeout-read 0` were accepted and passed straight to `httpx.Timeout`, where `0` means an **immediate** timeout — every connect/read fails at once, which is never what the user wants. Add a strictly-positive argparse type (`_positive_float`) for those two flags so `0` is rejected at parse time.

`--sse-read-timeout` (0 = disable) and `--oauth-refresh-leeway` (0 = no proactive refresh) keep `_non_negative_float`, since `0` is meaningful there.

## Test

`--timeout-connect 0` / `--timeout-read 0` exit 2 with `must be > 0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)