### PR TITLE
docs(readme): show --check with --transport sse

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -134,6 +134,10 @@ mcp-stdio --transport sse https://your-server.example.com:8080/sse
 
 ```bash
 mcp-stdio --check https://your-server.example.com:8080/mcp
+
+# SSE サーバーの場合は --transport sse を渡すと、--check は Streamable HTTP の
+# プローブではなくレガシーの GET/endpoint/POST ハンドシェイクで確認する：
+mcp-stdio --check --transport sse https://your-server.example.com:8080/sse
 ```
 
 ## Claude Desktop の設定

--- a/README.md
+++ b/README.md
@@ -136,6 +136,10 @@ Check connectivity before use:
 
 ```bash
 mcp-stdio --check https://your-server.example.com:8080/mcp
+
+# For an SSE server, pass --transport sse so --check runs the legacy
+# GET/endpoint/POST handshake instead of a Streamable HTTP probe:
+mcp-stdio --check --transport sse https://your-server.example.com:8080/sse
 ```
 
 ## Claude Desktop Configuration


### PR DESCRIPTION
## Overview

A NIT doc gap from the Opus 4.8 review (round 11, #16): the `--check` example block showed only the default Streamable HTTP probe. Added an SSE variant so users of legacy SSE servers know to pass `--transport sse` (which runs the GET/endpoint/POST handshake added in #111). Mirrored in `README.ja.md`.

Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)