### PR TITLE
fix(relay): adopt rotated session id across chained recovery; honour fresh SSE endpoint on retry

### DIFF
--- a/src/mcp_stdio/relay.py
+++ b/src/mcp_stdio/relay.py
@@ -1626,6 +1626,12 @@ def run(
                         # never a 4xx). Keep session_id — see the top-level None
                         # handling: a transient blip must not defeat 404 recovery.
                         continue
+                    # Re-adopt a session id the server rotated alongside this 401
+                    # retry's response, so a chained 403 step-up below rebuilds
+                    # its retry headers from the fresh id, not the stale one
+                    # (mirrors the once-adoption above the recovery branches).
+                    if result.session_id:
+                        session_id = result.session_id
                 else:
                     log("token refresh failed, returning error")
                     if req_has_id:
@@ -1652,6 +1658,11 @@ def run(
                             # is never a 4xx). Keep session_id — see the top-level
                             # None handling.
                             continue
+                        # Re-adopt a session id rotated alongside this step-up
+                        # retry's response so a chained 404 sees the fresh id
+                        # (mirrors the 401-branch re-adoption above).
+                        if result.session_id:
+                            session_id = result.session_id
                     else:
                         log("step-up authorization failed, returning error")
                         if req_has_id:
@@ -2026,6 +2037,12 @@ def run_sse(
                     if new_headers:
                         with headers_lock:
                             headers.update(new_headers)
+                        # Re-read the endpoint: if the reader thread reconnected
+                        # between the first POST and this retry it may have
+                        # published a fresh endpoint; honour it rather than the
+                        # stale capture (fall back to the captured one if the
+                        # reader has it momentarily nulled mid-reconnect).
+                        endpoint = state.endpoint_url or endpoint
                         resp = client.post(
                             endpoint,
                             content=line,
@@ -2056,6 +2073,9 @@ def run_sse(
                         if new_headers:
                             with headers_lock:
                                 headers.update(new_headers)
+                            # Honour a fresh endpoint if the reader reconnected
+                            # since the first POST (see the 401 retry above).
+                            endpoint = state.endpoint_url or endpoint
                             resp = client.post(
                                 endpoint,
                                 content=line,

--- a/tests/test_relay.py
+++ b/tests/test_relay.py
@@ -1231,6 +1231,49 @@ class TestRun:
         # The refreshed retry (req 2) must carry the rotated session id.
         assert reqs[2].headers.get("mcp-session-id") == "sess-2"
 
+    def test_chained_401_then_403_adopts_rotated_session_id(self, httpx_mock):
+        """#1(round12): a 401 whose refreshed retry returns 403 + a ROTATED
+        session id must have the step-up retry carry that rotated id — the
+        session adoption must repeat across chained recovery branches, not only
+        on the original response."""
+        # 1: init -> sess-1
+        httpx_mock.add_response(
+            text='{"jsonrpc":"2.0","result":{},"id":1}',
+            headers={"content-type": "application/json", "mcp-session-id": "sess-1"},
+        )
+        # 2: call -> 401 (triggers refresh)
+        httpx_mock.add_response(
+            status_code=401, text="", headers={"content-type": "application/json"}
+        )
+        # 3: refreshed retry -> 403 insufficient_scope AND rotates to sess-2
+        httpx_mock.add_response(
+            status_code=403,
+            text="",
+            headers={
+                "content-type": "application/json",
+                "mcp-session-id": "sess-2",
+                "www-authenticate": 'Bearer error="insufficient_scope", scope="extra"',
+            },
+        )
+        # 4: step-up retry -> 200
+        httpx_mock.add_response(
+            text='{"jsonrpc":"2.0","result":{"ok":true},"id":2}',
+            headers={"content-type": "application/json"},
+        )
+
+        self._run_with_stdin(
+            httpx_mock,
+            [
+                '{"jsonrpc":"2.0","method":"init","id":1}',
+                '{"jsonrpc":"2.0","method":"call","id":2}',
+            ],
+            token_refresher=lambda: {"Authorization": "Bearer new"},
+            scope_upgrader=lambda _s: {"Authorization": "Bearer broader"},
+        )
+        reqs = httpx_mock.get_requests()
+        # The step-up retry (req 3) must carry the id rotated on the 401 retry.
+        assert reqs[3].headers.get("mcp-session-id") == "sess-2"
+
     def test_401_refresh_failure_returns_error(self, httpx_mock):
         httpx_mock.add_response(
             status_code=401,
@@ -1859,6 +1902,24 @@ class TestNormalizeNullArguments:
 
     def test_malformed_json_passed_through(self):
         line = '{"method":"tools/call","arguments":null'  # truncated
+        assert _normalize_null_arguments(line) == line
+
+    def test_null_params_with_arguments_elsewhere_passed_through(self):
+        """#10(round12): the regex matches an "arguments":null nested elsewhere,
+        but params itself is null (not an object). The non-dict-params branch
+        must leave the line unchanged — only params.arguments is ever rewritten."""
+        line = (
+            '{"jsonrpc":"2.0","method":"tools/call","id":1,'
+            '"params":null,"_meta":{"arguments":null}}'
+        )
+        assert _normalize_null_arguments(line) == line
+
+    def test_array_params_with_arguments_elsewhere_passed_through(self):
+        """params as a positional array (non-dict) likewise passes through."""
+        line = (
+            '{"jsonrpc":"2.0","method":"tools/call","id":1,'
+            '"params":[1,2],"_meta":{"arguments":null}}'
+        )
         assert _normalize_null_arguments(line) == line
 
 
@@ -4482,6 +4543,19 @@ class TestEmit:
         line = '[{"jsonrpc":"2.0","result":{},"id":1}]'
         _emit(line, t)
         assert capsys.readouterr().out.strip() == line
+
+    def test_drops_merged_paginated_result(self, capsys):
+        """#2(round12): a merged paginated list result (the shape
+        _paginate_and_stream flushes via _emit) is dropped when its id was
+        cancelled — closing the cancel-filter × pagination coverage gap."""
+        t = _CancelTracker()
+        t.add(1)
+        merged = (
+            '{"jsonrpc":"2.0","id":1,'
+            '"result":{"tools":[{"name":"a"},{"name":"b"}]}}'
+        )
+        _emit(merged, t)
+        assert capsys.readouterr().out.strip() == ""  # cancelled → dropped
 
 
 class TestRunCancelFilter:


### PR DESCRIPTION
## Overview

From the Opus 4.8 review (round 12): one LOW correctness fix, one NIT robustness fix, and two coverage gaps — all in `relay.py`.

## 1. Chained-recovery session rotation — #1 (LOW)

`run()` adopts a server-rotated `Mcp-Session-Id` from a response **once**, just above the recovery branches. But in a `401` → (refreshed retry returns) `403` chain, the 403 step-up rebuilt its retry headers from the **stale** session id — the id rotated on the 401-retry response was never re-adopted before the 403 branch read it, so the step-up POST carried the wrong session.

**Fix:** re-adopt `session_id` after each recovery-branch retry dispatch (mirroring the once-adoption above the branches), so the latest rotation always wins. (The 404 branch still discards the session and re-handshakes — correct, since 404 means "session not found".)

## 2. SSE retry reused a possibly-stale endpoint — #3 (NIT)

`run_sse` 401/403 retry POSTs reused the `endpoint` captured before the first POST. If the reader reconnected to a fresh endpoint in between, the retry targeted the dead one. **Fix:** re-read `state.endpoint_url` before each retry POST (falling back to the capture if momentarily nulled mid-reconnect).

## Coverage

- a `401`→`403` chain where the 401-retry rotates the session: the step-up retry now carries the rotated id (#1);
- the cancel filter drops a **merged paginated** result via the `_emit` path pagination uses (#2);
- `_normalize_null_arguments` leaves a `tools/call` with **non-dict** params (`null` / array) unchanged when an `"arguments":null` appears elsewhere (#10).

646 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)