### PR TITLE
fix(oauth): reject schemeless/hostless server URL in _authorization_base_url

### DIFF
--- a/src/mcp_stdio/oauth.py
+++ b/src/mcp_stdio/oauth.py
@@ -81,7 +81,16 @@ def _authorization_base_url(server_url: str) -> str:
     authorization codes to be POSTed to ``https://user:pass@host/token``.
     """
     parsed = urlparse(server_url)
-    host = parsed.hostname or ""
+    if not parsed.scheme or not parsed.hostname:
+        # A schemeless / hostless input (e.g. "example.com/mcp") otherwise
+        # produces a malformed base like "://example.com/mcp" that flows
+        # silently into the synthesized default endpoints. Fail clearly at the
+        # source — OAuth needs an absolute http(s) URL with a host.
+        raise ValueError(
+            f"server URL must be an absolute http(s) URL with a host, "
+            f"got {server_url!r}"
+        )
+    host = parsed.hostname
     # urlparse strips the brackets from an IPv6 literal host — restore them.
     if ":" in host:
         host = f"[{host}]"

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -95,6 +95,15 @@ class TestAuthorizationBaseUrl:
             == "https://[2001:db8::1]:9000"
         )
 
+    @pytest.mark.parametrize(
+        "bad", ["example.com/mcp", "/just/a/path", "ftp:///nohost", ""]
+    )
+    def test_schemeless_or_hostless_raises(self, bad):
+        """#7(round12): a URL missing scheme or host must fail clearly instead of
+        producing a malformed '://...' base that flows into default endpoints."""
+        with pytest.raises(ValueError, match="absolute http"):
+            _authorization_base_url(bad)
+
 
 # --- PKCE ---
 


### PR DESCRIPTION
## Overview

A NIT robustness fix from the Opus 4.8 review (round 12, #7).

`_authorization_base_url` for a schemeless / hostless `server_url` (e.g. `example.com/mcp`, where `urlparse` puts everything in `path`) produced a malformed base like `://example.com/mcp`, which then flowed silently into the synthesized default `/authorize` and `/token` endpoints.

**Fix:** raise a clear `ValueError` when the URL has no scheme or host — the OAuth flow needs an absolute http(s) URL. The failure is now actionable at the source instead of a malformed endpoint failing opaquely later. (Only reachable in OAuth mode, where a schemeless URL is unusable anyway.)

Test: schemeless / hostless / path-only inputs raise `ValueError`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)