### PR TITLE
fix(relay): strip a leading U+FEFF BOM in the SSE decoder (WHATWG)

### DIFF
--- a/src/mcp_stdio/relay.py
+++ b/src/mcp_stdio/relay.py
@@ -627,7 +627,19 @@ def _iter_sse_events(lines: Iterable[str]) -> Iterator[tuple[str, str]]:
     """
     event_type = "message"
     data_lines: list[str] = []
+    first = True
     for line in lines:
+        if first:
+            first = False
+            # WHATWG SSE stream-decode mandates removing ONE leading U+FEFF BOM
+            # before line decoding. httpx does not strip it, so a BOM-prefixed
+            # stream would otherwise parse the first field as a BOM-prefixed field
+            # name (e.g. a U+FEFF before ``event``) — an unrecognised field —
+            # silently misclassifying the critical first event (the legacy SSE
+            # ``endpoint`` bootstrap) as a default ``message`` and breaking
+            # startup. (Escape used, not a raw BOM, to keep the source ASCII.)
+            if line[:1] == "\ufeff":
+                line = line[1:]
         if line == "":
             if data_lines:
                 yield event_type, "\n".join(data_lines)
@@ -1244,6 +1256,14 @@ def _check_connection_sse(
     # thread. On a POST failure the helper closes the stream so the probe fails
     # fast instead of hanging until the read timeout for a response that will
     # never arrive.
+    #
+    # ``holder`` is shared between the two threads WITHOUT a lock, relying on
+    # CPython dict item get/set being atomic under the GIL (the same convention
+    # _SseState documents). ``resp`` is published before the POST thread spawns,
+    # so its read is ordered. ``post_error`` is only used to pick which of two
+    # diagnostic strings to log on a probe failure; a benign read-before-write
+    # race there can mis-pick the message but never affects the bool verdict and
+    # never touches stdout — this is the one-shot --check path, not the relay.
     holder: dict[str, Any] = {"resp": None, "post_error": None}
 
     def do_post(endpoint: str) -> None:

--- a/tests/test_relay.py
+++ b/tests/test_relay.py
@@ -586,6 +586,30 @@ class TestIterSseEvents:
     def test_event_without_data_not_dispatched(self):
         assert list(_iter_sse_events(["event:message", ""])) == []
 
+    def test_leading_bom_stripped(self):
+        """#2(round13): WHATWG SSE stream-decode removes ONE leading U+FEFF BOM.
+        A BOM-prefixed first line must still parse as its real field, so the
+        critical first `endpoint` event is recognised, not misclassified.
+        (BOM written as the "\\ufeff" escape — never a raw byte in source.)"""
+        lines = ["\ufeff" + "event: endpoint", "data: /messages", ""]
+        assert list(_iter_sse_events(lines)) == [("endpoint", "/messages")]
+
+    def test_only_first_line_bom_stripped(self):
+        """Only ONE leading BOM at the very start is removed — a stray U+FEFF on
+        a later line is left as part of that field's content."""
+        lines = ["data: a", "\ufeff" + "data: b", ""]
+        # First line clean; the second line's BOM makes its field unrecognised
+        # (not a `data` field), so only "a" is collected.
+        assert list(_iter_sse_events(lines)) == [("message", "a")]
+
+    def test_bom_via_split_sse_text(self):
+        """End-to-end through _split_sse_text: a BOM-prefixed buffered body still
+        yields the endpoint event."""
+        body = "\ufeff" + "event: endpoint\ndata: /m\n\n"
+        assert list(_iter_sse_events(_split_sse_text(body))) == [
+            ("endpoint", "/m")
+        ]
+
 
 class TestSseLineSplitting:
     """SSE lines split on CR/LF/CRLF only — NOT the wider str.splitlines() set


### PR DESCRIPTION
## Overview

A genuine LOW spec-compliance bug from the Opus 4.8 review (round 13, #2), empirically verified against the pinned httpx 0.28.1.

## The bug

The WHATWG Server-Sent Events **stream-decode** step mandates removing one leading `U+FEFF` BOM before line decoding. httpx does **not** strip it, so a BOM-prefixed SSE stream parsed its first field as a BOM-prefixed (hence unrecognised) field — silently **misclassifying the critical first event**. In the legacy SSE bootstrap that is the `endpoint` event, so `run_sse` never learned the POST URL and startup failed with `SSE reader terminated before endpoint event`. The Streamable HTTP SSE-framed paths (`_post_and_stream` / `_post_parsed` / `check_connection` / `_reinitialize`) were affected too.

## The fix

Strip one leading BOM at the single shared decoder `_iter_sse_events`, so every SSE-decode site is covered at once. Also documented the `_check_connection_sse` `holder` dict's GIL-atomicity convention (#1 — a benign probe-only diagnostic race, never a wire fault).

## Tests

A BOM-prefixed first line still yields the `endpoint` event (direct and via `_split_sse_text`); only one leading BOM is removed; a stray BOM on a later line is left as content. The BOM is written as the `﻿` escape — never a raw byte in source.

653 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)