### PR TITLE
fix(oauth): reject userinfo in PRM hint; close callback server on any auth-flow failure

### DIFF
--- a/src/mcp_stdio/oauth.py
+++ b/src/mcp_stdio/oauth.py
@@ -250,6 +250,17 @@ def _validate_prm_hint_url(hint_url: str, server_url: str) -> bool:
         log(f"warning: unsupported scheme in resource_metadata hint {hint_url!r}, ignoring")
         return False
 
+    if parsed.username is not None or parsed.password is not None:
+        # Parity with the sibling #13 validators (_validate_auth_server_url,
+        # _validate_endpoint_url): refuse embedded userinfo so this attacker-
+        # influenced hint cannot send HTTP Basic credentials to a userinfo
+        # authority on the discovery GET.
+        log(
+            f"warning: resource_metadata hint {hint_url!r} embeds userinfo "
+            f"(user:pass@); refusing. See #13."
+        )
+        return False
+
     if parsed.scheme == "http" and not _is_loopback(parsed.hostname or ""):
         log(
             f"warning: refusing resource_metadata hint {hint_url!r} "
@@ -1070,57 +1081,63 @@ def _run_authorization_flow(
     if cid is None:  # -O-safe invariant (every branch above sets cid)
         raise RuntimeError("no client_id available for authorization")
 
-    code_verifier, code_challenge = generate_pkce()
-
-    # Authorization URL params; RFC 8707 resource indicator included by default
-    state = secrets.token_urlsafe(32)
-    params: dict[str, str] = {
-        "client_id": cid,
-        "response_type": "code",
-        "redirect_uri": redirect_uri,
-        "state": state,
-        "code_challenge": code_challenge,
-        "code_challenge_method": "S256",
-    }
-    if resource_indicator:
-        params["resource"] = server_url
-    if scope:
-        params["scope"] = scope
-
-    auth_url = f"{metadata.authorization_endpoint}?{urlencode(params)}"
-    # Log a STATE-REDACTED URL. The user still needs a clickable URL when the
-    # browser does not auto-open, but the single-use CSRF ``state`` nonce does
-    # not need to land in stderr — MCP host logs (Claude Desktop/Code) persist
-    # to files that may be shared in bug reports. The browser receives the full
-    # URL below; the PKCE secret (``code_verifier``) is never in the URL and the
-    # S256 ``code_challenge`` is public, so only ``state`` is worth redacting.
-    log_url = f"{metadata.authorization_endpoint}?{urlencode({**params, 'state': '<redacted>'})}"
-    log(f"authorize URL (open in browser if not auto-opened):\n{log_url}")
-
-    webbrowser.open(auth_url)
-
+    # From here the callback server is listening. Any failure between now and
+    # the close below (generate_pkce, webbrowser.open, thread.start, timeout)
+    # must still close it, or the loopback listening socket leaks for the
+    # process lifetime — so the whole window is guarded and closed on any exit.
     done = threading.Event()
+    try:
+        code_verifier, code_challenge = generate_pkce()
 
-    def serve() -> None:
-        while not done.is_set():
-            callback_server.handle_request()
+        # Authorization URL params; RFC 8707 resource indicator on by default
+        state = secrets.token_urlsafe(32)
+        params: dict[str, str] = {
+            "client_id": cid,
+            "response_type": "code",
+            "redirect_uri": redirect_uri,
+            "state": state,
+            "code_challenge": code_challenge,
+            "code_challenge_method": "S256",
+        }
+        if resource_indicator:
+            params["resource"] = server_url
+        if scope:
+            params["scope"] = scope
 
-    thread = threading.Thread(target=serve, daemon=True)
-    thread.start()
+        auth_url = f"{metadata.authorization_endpoint}?{urlencode(params)}"
+        # Log a STATE-REDACTED URL. The user still needs a clickable URL when the
+        # browser does not auto-open, but the single-use CSRF ``state`` nonce
+        # does not need to land in stderr — MCP host logs (Claude Desktop/Code)
+        # persist to files that may be shared in bug reports. The browser
+        # receives the full URL below; the PKCE secret (``code_verifier``) is
+        # never in the URL and the S256 ``code_challenge`` is public, so only
+        # ``state`` is worth redacting.
+        log_url = (
+            f"{metadata.authorization_endpoint}"
+            f"?{urlencode({**params, 'state': '<redacted>'})}"
+        )
+        log(f"authorize URL (open in browser if not auto-opened):\n{log_url}")
 
-    deadline = time.monotonic() + timeout
-    while not (cb_result.auth_code or cb_result.error):
-        if time.monotonic() > deadline:
-            done.set()
-            callback_server.server_close()
-            raise TimeoutError(
-                "OAuth callback not received within timeout. "
-                "Please restart and try again."
-            )
-        time.sleep(0.2)
+        webbrowser.open(auth_url)
 
-    done.set()
-    callback_server.server_close()
+        def serve() -> None:
+            while not done.is_set():
+                callback_server.handle_request()
+
+        thread = threading.Thread(target=serve, daemon=True)
+        thread.start()
+
+        deadline = time.monotonic() + timeout
+        while not (cb_result.auth_code or cb_result.error):
+            if time.monotonic() > deadline:
+                raise TimeoutError(
+                    "OAuth callback not received within timeout. "
+                    "Please restart and try again."
+                )
+            time.sleep(0.2)
+    finally:
+        done.set()
+        callback_server.server_close()
 
     if cb_result.error:
         raise RuntimeError(f"OAuth error: {cb_result.error}")

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -3297,6 +3297,38 @@ class TestAuthorizationFlowFailurePaths:
             )
         assert closed, "callback server was not closed on the DCR error path"
 
+    def test_webbrowser_open_failure_closes_callback_server(self, monkeypatch):
+        """#4(round13): a failure AFTER the callback server is bound but before
+        the success-path close (here webbrowser.open raising) must still close
+        the server — the try/finally covers the whole listening window, not just
+        DCR."""
+        import mcp_stdio.oauth as oauth_mod
+
+        closed: list[bool] = []
+        real_server_close = oauth_mod.HTTPServer.server_close
+
+        def spying_close(self) -> None:
+            closed.append(True)
+            real_server_close(self)
+
+        monkeypatch.setattr(oauth_mod.HTTPServer, "server_close", spying_close)
+
+        def boom(_url):
+            raise RuntimeError("no browser available")
+
+        monkeypatch.setattr("mcp_stdio.oauth.webbrowser.open", boom)
+        client = httpx.Client()
+        with pytest.raises(RuntimeError, match="no browser available"):
+            _run_authorization_flow(
+                "https://ex.com/mcp",
+                client,
+                metadata=self.META,
+                cached=None,
+                client_id_override="cid",  # skip DCR; reach the webbrowser step
+                timeout=5,
+            )
+        assert closed, "callback server was not closed on the webbrowser failure"
+
 
 class TestRfc9207IssValidation:
     """RFC 9207: validate the authorization-response `iss` parameter against the
@@ -3494,6 +3526,17 @@ class TestValidatePrmHintUrl:
 
     def test_malformed_url_rejected(self):
         assert _validate_prm_hint_url("not a url !!!", self.SERVER) is False
+
+    def test_userinfo_rejected(self, capsys):
+        """#3(round13): an embedded userinfo hint is refused, parity with the
+        sibling #13 validators (so HTTP Basic creds aren't sent on the GET)."""
+        assert (
+            _validate_prm_hint_url(
+                "https://attacker:secret@api.example.com/prm", self.SERVER
+            )
+            is False
+        )
+        assert "userinfo" in capsys.readouterr().err
 
 
 # --- discover_oauth_metadata with www_authenticate hint ---


### PR DESCRIPTION
## Overview

Two LOW hardening fixes from the Opus 4.8 review (round 13, #3/#4).

## 1. Userinfo not rejected in `_validate_prm_hint_url` — #3

Unlike its two sibling `#13` validators (`_validate_auth_server_url`, `_validate_endpoint_url`), `_validate_prm_hint_url` never inspected `username`/`password`. A WWW-Authenticate `resource_metadata` hint like `https://attacker:secret@evil/.well-known/...` would cause httpx to send HTTP Basic credentials to the userinfo authority on the discovery GET. **Fix:** reject userinfo for parity across all three validators. (Impact was limited — only the PRM doc is fetched on that GET, and any `authorization_servers` it returns are re-validated — but the project's `#13` policy says userinfo should be refused uniformly.)

## 2. Callback socket leak outside the DCR window — #4

`_run_authorization_flow` closed the localhost callback server only on the DCR-failure, timeout, and success paths. A failure in the window between PKCE generation and the poll loop — notably `webbrowser.open` raising on a headless/misconfigured host, or `thread.start` under resource exhaustion — propagated with the loopback listening socket still bound, leaking it for the process lifetime. **Fix:** wrap that whole window in `try/finally` so the server is closed on every exit.

## Tests

- a userinfo PRM hint is refused;
- a `webbrowser.open` failure still closes the callback server (parity with the existing DCR-leak test).

## Deferred

Round-13 #5 (auth-code DCR doesn't request `offline_access`, so some ASes never issue refresh tokens) is a behavioral interop change best validated against real ASes (Entra/Okta/Google) and risks `invalid_scope` on strict servers — deferred rather than auto-appending the scope here.

652 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)