### PR TITLE
perf(cli): skip building relay recovery callbacks on the --check probe

### DIFF
--- a/src/mcp_stdio/cli.py
+++ b/src/mcp_stdio/cli.py
@@ -291,7 +291,8 @@ def main() -> None:
         help=(
             "Disable TCP keepalive on the HTTP socket. TCP keepalive is "
             "on by default (60s idle + 4 probes × 15s ≈ 120s half-open "
-            "detection on Linux/macOS/BSD; SO_KEEPALIVE-only on Windows). "
+            "detection on Linux/macOS/FreeBSD/NetBSD; SO_KEEPALIVE-only on "
+            "Windows and other platforms). "
             "Opt out for proxy/NAT paths that strip keepalive packets. "
             "See #9."
         ),

--- a/src/mcp_stdio/cli.py
+++ b/src/mcp_stdio/cli.py
@@ -465,12 +465,16 @@ def main() -> None:
             for existing in overridden:
                 del headers[existing]
             headers["Authorization"] = f"Bearer {token_data.access_token}"
-            token_refresher = _build_token_refresher(
-                args.url, headers, args.timeout_connect, args.timeout_read
-            )
-            scope_upgrader = _build_scope_upgrader(
-                args.url, headers, args.timeout_connect, args.timeout_read
-            )
+            # The relay-loop 401/403 recovery callbacks are unused by the
+            # one-shot --check / --test probe (check_connection never refreshes
+            # or steps up), so only build them on the real relay path. See #15.
+            if not (args.check or args.test):
+                token_refresher = _build_token_refresher(
+                    args.url, headers, args.timeout_connect, args.timeout_read
+                )
+                scope_upgrader = _build_scope_upgrader(
+                    args.url, headers, args.timeout_connect, args.timeout_read
+                )
         except Exception as e:
             print(f"error: OAuth authentication failed: {e}", file=sys.stderr)
             sys.exit(1)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -484,6 +484,25 @@ class TestMain:
             main()
         assert "ignored without --oauth" not in capsys.readouterr().err
 
+    def test_check_with_oauth_skips_relay_callbacks(self, monkeypatch):
+        """#15(round13): on the one-shot --check probe the relay 401/403
+        recovery callbacks are not built (check_connection never uses them)."""
+        with (
+            patch(
+                "sys.argv",
+                ["mcp-stdio", "--oauth", "--check", "https://example.com/mcp"],
+            ),
+            patch("mcp_stdio.oauth.ensure_token") as mock_ensure,
+            patch("mcp_stdio.cli.check_connection", return_value=True),
+            patch("mcp_stdio.cli._build_token_refresher") as mock_refresher,
+            patch("mcp_stdio.cli._build_scope_upgrader") as mock_upgrader,
+        ):
+            mock_ensure.return_value.access_token = "tok"
+            with pytest.raises(SystemExit):
+                main()
+        assert not mock_refresher.called
+        assert not mock_upgrader.called
+
     def test_explicit_client_id_without_oauth_warns(self, monkeypatch, capsys):
         monkeypatch.delenv("MCP_OAUTH_CLIENT_ID", raising=False)
         with (


### PR DESCRIPTION
## Overview

A NIT efficiency fix from the Opus 4.8 review (round 13, #15).

`token_refresher` / `scope_upgrader` were built inside the OAuth flow even on the `--check` / `--test` path, then immediately discarded — `check_connection` never refreshes or steps up. Only build them on the real relay path.

`#14` (the `--check` probe using a non-keepalive httpx client) is left as-is: a one-shot `initialize` POST completes in a single round-trip and gains nothing from TCP keepalive, which targets long-lived connections.

## Test

`--oauth --check` does not call `_build_token_refresher` / `_build_scope_upgrader`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)