### PR TITLE
docs(claude): correct build backend name to hatchling

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,7 +25,7 @@ pytest tests/test_relay.py::TestSendRequest -v
 pip install build && python -m build
 ```
 
-Uses **hatch** as the build backend. Version is defined in `src/mcp_stdio/__init__.py` (`__version__`).
+Uses **hatchling** as the build backend (`build-backend = "hatchling.build"` in `pyproject.toml`). Version is defined in `src/mcp_stdio/__init__.py` (`__version__`).
 
 ## Architecture
 


### PR DESCRIPTION
## Overview

A NIT doc-accuracy fix from the Opus 4.8 review (round 13, #16).

`CLAUDE.md` said the build backend is **hatch**, but `pyproject.toml` sets `build-backend = "hatchling.build"` (`requires = ["hatchling"]`). hatch is the project manager; hatchling is the actual PEP 517 build backend.

Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)