### PR TITLE
fix(token_store): don't delete legacy tokens when the XDG store is empty/unreadable

### DIFF
--- a/src/mcp_stdio/token_store.py
+++ b/src/mcp_stdio/token_store.py
@@ -140,16 +140,27 @@ def _migrate_legacy_store() -> None:
     if not _LEGACY_STORE_FILE.exists():
         return
     if _STORE_FILE.exists():
-        # New file already exists — best-effort removal of the now-redundant
-        # legacy file. This runs UNLOCKED from load_token, so the unlink can
-        # lose a TOCTOU race against a concurrent migration (ENOENT) or hit a
-        # read-only / permission-locked legacy FS. Neither must be allowed to
-        # crash a read of the already-migrated store, so guard it like every
-        # other filesystem op in this function.
+        # The XDG store exists — but only discard the legacy copy once it is
+        # confirmed to hold usable data. A 0-byte / unreadable _STORE_FILE (an
+        # interrupted external write, a stray `touch`, a backup restore that
+        # left an empty placeholder) is NOT proof the migration completed;
+        # unlinking the legacy file then would silently lose still-real tokens.
         try:
-            _LEGACY_STORE_FILE.unlink()
+            xdg_has_data = _STORE_FILE.stat().st_size > 0
         except OSError:
-            pass
+            xdg_has_data = False
+        if xdg_has_data:
+            # Best-effort removal of the now-redundant legacy file. This runs
+            # UNLOCKED from load_token, so the unlink can lose a TOCTOU race
+            # against a concurrent migration (ENOENT) or hit a read-only /
+            # permission-locked legacy FS. Neither must crash a read of the
+            # already-migrated store, so guard it like every other fs op here.
+            try:
+                _LEGACY_STORE_FILE.unlink()
+            except OSError:
+                pass
+        # else: leave the legacy file intact; a later run with a valid XDG
+        # store (or after the bogus placeholder is removed) reconciles it.
     else:
         _ensure_store_dir()
         # Tighten the legacy file's mode BEFORE moving it, so the secrets never
@@ -323,7 +334,7 @@ def _write_store(data: dict[str, Any]) -> None:
     # directory fsync, and opening a directory fails on Windows — neither should
     # fail the write.
     try:
-        dir_fd = os.open(str(_STORE_DIR), os.O_RDONLY)
+        dir_fd = os.open(str(_STORE_DIR), os.O_RDONLY | _O_NOFOLLOW)
         try:
             os.fsync(dir_fd)
         finally:

--- a/tests/test_token_store.py
+++ b/tests/test_token_store.py
@@ -667,6 +667,30 @@ class TestLegacyMigration:
         assert loaded.access_token == "new"
         assert not legacy_file.exists()
 
+    def test_empty_xdg_store_does_not_delete_legacy(self, tmp_path, monkeypatch):
+        """#4(round14): if the XDG store exists but is EMPTY (e.g. a 0-byte
+        placeholder from an interrupted write / backup restore), the legacy file
+        must NOT be unlinked — that would silently lose still-real tokens."""
+        legacy_dir = tmp_path / "legacy"
+        legacy_file = legacy_dir / "tokens.json"
+        new_dir = tmp_path / "new"
+        new_file = new_dir / "tokens.json"
+
+        legacy_dir.mkdir()
+        legacy_file.write_text('{"https://example.com/mcp": {"access_token": "old"}}')
+        new_dir.mkdir()
+        new_file.write_text("")  # 0-byte placeholder, NOT a completed migration
+
+        monkeypatch.setattr("mcp_stdio.token_store._STORE_DIR", new_dir)
+        monkeypatch.setattr("mcp_stdio.token_store._STORE_FILE", new_file)
+        monkeypatch.setattr("mcp_stdio.token_store._LEGACY_STORE_DIR", legacy_dir)
+        monkeypatch.setattr("mcp_stdio.token_store._LEGACY_STORE_FILE", legacy_file)
+
+        load_token("https://example.com/mcp")
+        # The legacy tokens survive (not deleted by the bogus empty XDG store).
+        assert legacy_file.exists()
+        assert "old" in legacy_file.read_text()
+
     def test_legacy_unlink_failure_when_new_exists_does_not_crash(
         self, tmp_path, monkeypatch
     ):


### PR DESCRIPTION
## Overview

A LOW data-loss fix from the Opus 4.8 review (round 14, #4), plus a NIT (#14).

## The bug

`_migrate_legacy_store` treated the mere **existence** of `~/.config/mcp-stdio/tokens.json` as proof the migration completed, then unconditionally unlinked the legacy `~/.mcp-stdio/` file. If the XDG file was a 0-byte / unreadable placeholder (an interrupted external write, a stray `touch`, a backup restore that left an empty file) while the legacy file still held **real tokens**, those tokens were permanently deleted and `load_token` returned `{}`.

**Fix:** gate the unlink on the XDG store actually having data (`st_size > 0`); otherwise leave the legacy file intact for a later run to reconcile. (Trigger requires external interference — the module never writes a 0-byte store itself — and impact is bounded to re-authentication, hence LOW.)

## NIT — #14

The directory-fsync `os.open(_STORE_DIR)` now includes `_O_NOFOLLOW`, matching every other `os.open` in the module.

## Test

A 0-byte XDG store does not delete the legacy file.

659 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)