### PR TITLE
fix(oauth): phase-3 defaults target the discovered AS origin; precise RFC 8414 citation

### DIFF
--- a/src/mcp_stdio/oauth.py
+++ b/src/mcp_stdio/oauth.py
@@ -516,8 +516,9 @@ def discover_oauth_metadata(
 
     # Path-scoped issuers (Keycloak realm URLs, AWS Cognito user pools, etc.)
     # publish metadata at /.well-known/oauth-authorization-server/<path> per
-    # RFC 8414 §3 path-insertion. Try the original server_url when it has a
-    # path component that neither the PRM-discovered AS nor the base URL tried.
+    # RFC 8414 §3.1 (the well-known string is inserted between the host and the
+    # issuer's path component). Try the original server_url when it has a path
+    # component that neither the PRM-discovered AS nor the base URL tried.
     if server_url not in (auth_server_url, base):
         meta = _fetch_authorization_server_metadata(server_url, client)
         if meta:
@@ -525,16 +526,23 @@ def discover_oauth_metadata(
 
     # Phase 3: Default paths
     log("OAuth metadata not found, using default endpoints")
+    # Derive the default endpoints from the DISCOVERED authorization server when
+    # PRM advertised one (auth_server_url differs from the MCP-host base). A
+    # cross-origin AS that published no reachable RFC 8414 metadata would
+    # otherwise have its credential/code exchange POSTed to the MCP host — the
+    # wrong origin entirely. When no PRM AS was found, auth_server_url == base,
+    # so this reduces to the previous MCP-host defaults.
+    as_base = auth_server_url.rstrip("/")
     return OAuthMetadata(
-        authorization_endpoint=f"{base}/authorize",
-        token_endpoint=f"{base}/token",
-        registration_endpoint=f"{base}/register",
+        authorization_endpoint=f"{as_base}/authorize",
+        token_endpoint=f"{as_base}/token",
+        registration_endpoint=f"{as_base}/register",
         # No metadata was validated on this fallback, so it is the LEAST
         # trustworthy discovery outcome — keep the RFC 9207 iss mix-up check
         # active by pinning the issuer to the base the endpoints derive from.
         # Otherwise an AS returning `iss` would be compared against None and
         # the defence would silently no-op precisely here.
-        issuer=base,
+        issuer=as_base,
     )
 
 

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -228,6 +228,36 @@ class TestDiscoverMetadata:
         assert meta.authorization_endpoint == "https://as.example.com/auth"
         assert meta.token_endpoint == "https://as.example.com/tok"
 
+    def test_phase3_defaults_target_discovered_as_origin(self, httpx_mock):
+        """#3(round14): when a cross-origin AS is discovered via PRM but ALL its
+        RFC 8414 metadata fetches 404, the phase-3 default endpoints must target
+        the DISCOVERED AS origin — not the MCP host (which would POST the
+        credential exchange to the wrong origin)."""
+        server_url = "https://mcp.example.com/mcp"
+        # Path-aware PRM advertises a cross-origin AS (found → loop breaks).
+        httpx_mock.add_response(
+            url="https://mcp.example.com/.well-known/oauth-protected-resource/mcp",
+            json={
+                "resource": server_url,
+                "authorization_servers": ["https://as.example.com"],
+            },
+        )
+        # Every RFC 8414 metadata fetch 404s: the discovered AS, the host base,
+        # and the path-scoped server URL.
+        for url in (
+            "https://as.example.com/.well-known/oauth-authorization-server",
+            "https://mcp.example.com/.well-known/oauth-authorization-server",
+            "https://mcp.example.com/.well-known/oauth-authorization-server/mcp",
+        ):
+            httpx_mock.add_response(url=url, status_code=404)
+
+        client = httpx.Client()
+        meta = discover_oauth_metadata(server_url, client)
+        # Defaults point at the AS origin, not the MCP host.
+        assert meta.authorization_endpoint == "https://as.example.com/authorize"
+        assert meta.token_endpoint == "https://as.example.com/token"
+        assert meta.issuer == "https://as.example.com"
+
     def test_fallback_on_404(self, httpx_mock):
         self._mock_no_prm(httpx_mock)
         httpx_mock.add_response(


### PR DESCRIPTION
## Overview

A LOW credential-origin fix and a NIT citation fix from the Opus 4.8 review (round 14, #3/#13).

## 1. Phase-3 defaults pinned to the MCP host — #3 (LOW)

`discover_oauth_metadata`'s phase-3 fallback synthesised default `/authorize`, `/token`, `/register` against the **MCP-host base** even when a **cross-origin** authorization server had been discovered via PRM. In the narrow case where that AS published **no** reachable RFC 8414 metadata (and neither the host base nor the path-scoped URL did), the credential/code exchange would be POSTed to the **MCP host — the wrong origin**.

**Fix:** derive the defaults from the discovered `auth_server_url` (and pin `issuer` to it). When no PRM AS was found, `auth_server_url == base`, so this reduces to the previous behaviour.

## 2. RFC 8414 citation — #13 (NIT)

Corrected `RFC 8414 §3` → `§3.1` (the section specifying insertion of the well-known string between the host and the issuer's path component).

## Test

A cross-origin AS discovered via PRM whose RFC 8414 fetches all 404 yields defaults targeting the **AS origin**, not the MCP host.

659 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)