### PR TITLE
fix(relay): don't dispatch an empty-data SSE event (WHATWG)

### DIFF
--- a/src/mcp_stdio/relay.py
+++ b/src/mcp_stdio/relay.py
@@ -641,8 +641,13 @@ def _iter_sse_events(lines: Iterable[str]) -> Iterator[tuple[str, str]]:
             if line[:1] == "\ufeff":
                 line = line[1:]
         if line == "":
-            if data_lines:
-                yield event_type, "\n".join(data_lines)
+            # WHATWG "dispatch the event": if the data buffer is the empty
+            # string the event is NOT dispatched. Gate on the joined buffer, not
+            # list non-emptiness — a bare ``data:`` appends "" yet must not
+            # produce a ('message', '') event a strict decoder never would.
+            data = "\n".join(data_lines)
+            if data:
+                yield event_type, data
             event_type = "message"
             data_lines = []
             continue
@@ -655,8 +660,9 @@ def _iter_sse_events(lines: Iterable[str]) -> Iterator[tuple[str, str]]:
             event_type = value
         elif field == "data":
             data_lines.append(value)
-    if data_lines:
-        yield event_type, "\n".join(data_lines)
+    data = "\n".join(data_lines)
+    if data:
+        yield event_type, data
 
 
 def _post_and_stream(

--- a/tests/test_relay.py
+++ b/tests/test_relay.py
@@ -586,6 +586,19 @@ class TestIterSseEvents:
     def test_event_without_data_not_dispatched(self):
         assert list(_iter_sse_events(["event:message", ""])) == []
 
+    def test_empty_data_value_not_dispatched(self):
+        """#2(round14): WHATWG suppresses dispatch when the data buffer is the
+        empty string — a bare `data:` must not yield a ('message', '') event."""
+        assert list(_iter_sse_events(["data:", ""])) == []
+        # event type set but only an empty data line → still suppressed.
+        assert list(_iter_sse_events(["event: endpoint", "data:", ""])) == []
+        # A trailing unterminated empty-data event is likewise not dispatched.
+        assert list(_iter_sse_events(["data:"])) == []
+
+    def test_nonempty_after_empty_data_lines_dispatched(self):
+        """Mixed empty + non-empty data lines still dispatch (buffer non-empty)."""
+        assert list(_iter_sse_events(["data:", "data:x", ""])) == [("message", "\nx")]
+
     def test_leading_bom_stripped(self):
         """#2(round13): WHATWG SSE stream-decode removes ONE leading U+FEFF BOM.
         A BOM-prefixed first line must still parse as its real field, so the


### PR DESCRIPTION
## Overview

A LOW WHATWG-compliance fix from the Opus 4.8 review (round 14, #2).

The shared SSE decoder (`_iter_sse_events`) dispatched an event whenever `data_lines` was non-empty, so a bare `data:` (empty value) — which appends `""` to the buffer — produced a `('message', '')` / `('endpoint', '')` event that the WHATWG "dispatch the event" step would **never** emit (it suppresses dispatch when the data buffer is the empty string after the trailing-LF strip).

**Fix:** gate dispatch on the **joined buffer** being non-empty instead of list non-emptiness. Benign for MCP (every consumer already skips empty payloads via `json.loads('')`), but removes the divergence from the algorithm the decoder documents itself as implementing.

## Tests

A bare `data:` (with/without an event type, terminated or not) yields no event; mixed empty + non-empty data lines still dispatch.

660 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)