### PR TITLE
fix(oauth): sanitize AS-supplied error strings; cover explicit-client-id device flow

### DIFF
--- a/src/mcp_stdio/oauth.py
+++ b/src/mcp_stdio/oauth.py
@@ -49,6 +49,24 @@ def _safe_int(value: Any, default: int) -> int:
         return default
 
 
+# RFC 6749 §4.1.2.1 / §5.2 error / error_description grammar: printable ASCII
+# excluding double-quote (0x22) and backslash (0x5C). Anything outside it is
+# stripped from an AS-supplied error before it reaches a log / exception, so a
+# hostile AS cannot inject control characters or megabytes of text into the
+# operator's logs. See #12.
+_OAUTH_ERROR_DISALLOWED_RE = re.compile(r"[^\x20\x21\x23-\x5B\x5D-\x7E]")
+
+
+def _sanitize_oauth_error(value: Any, *, max_len: int = 200) -> str:
+    """Sanitise an AS-supplied error/description to the RFC 6749 grammar.
+
+    Strips out-of-grammar characters and bounds the length so the value is safe
+    to embed in an exception message or log line.
+    """
+    cleaned = _OAUTH_ERROR_DISALLOWED_RE.sub("", str(value))[:max_len]
+    return cleaned or "<unspecified>"
+
+
 @dataclass
 class OAuthMetadata:
     """Authorization server metadata (RFC 8414)."""
@@ -769,7 +787,7 @@ def _raise_for_body_error(result: dict[str, Any]) -> None:
     """
     if "error" in result and "access_token" not in result:
         desc = result.get("error_description", result["error"])
-        raise RuntimeError(f"OAuth token error: {desc}")
+        raise RuntimeError(f"OAuth token error: {_sanitize_oauth_error(desc)}")
 
 
 def _parse_token_response(resp: httpx.Response) -> dict[str, Any]:
@@ -1148,7 +1166,7 @@ def _run_authorization_flow(
         callback_server.server_close()
 
     if cb_result.error:
-        raise RuntimeError(f"OAuth error: {cb_result.error}")
+        raise RuntimeError(f"OAuth error: {_sanitize_oauth_error(cb_result.error)}")
 
     # Use a constant-time comparison so the rejection path does not leak the
     # common-prefix length of the two state tokens via timing. Over a

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -23,6 +23,7 @@ from mcp_stdio.oauth import (
     _probe_www_authenticate,
     _run_authorization_flow,
     _run_device_authorization_flow,
+    _sanitize_oauth_error,
     _token_response_to_data,
     _validate_auth_server_url,
     _validate_endpoint_url,
@@ -103,6 +104,30 @@ class TestAuthorizationBaseUrl:
         producing a malformed '://...' base that flows into default endpoints."""
         with pytest.raises(ValueError, match="absolute http"):
             _authorization_base_url(bad)
+
+
+class TestSanitizeOAuthError:
+    """#12(round14): AS-supplied error strings are sanitised to the RFC 6749
+    grammar and length-bounded before reaching logs / exceptions."""
+
+    def test_plain_error_code_passes(self):
+        assert _sanitize_oauth_error("invalid_scope") == "invalid_scope"
+
+    def test_control_characters_stripped(self):
+        assert _sanitize_oauth_error("bad\r\n\tinjected\x00x") == "badinjectedx"
+
+    def test_quote_and_backslash_stripped(self):
+        # 0x22 (") and 0x5C (\\) are outside the RFC 6749 error grammar.
+        assert _sanitize_oauth_error('a"b\\c') == "abc"
+
+    def test_length_bounded(self):
+        assert len(_sanitize_oauth_error("x" * 5000)) == 200
+
+    def test_empty_after_strip_is_placeholder(self):
+        assert _sanitize_oauth_error("\x00\x01\x02") == "<unspecified>"
+
+    def test_non_string_coerced(self):
+        assert _sanitize_oauth_error(12345) == "12345"
 
 
 # --- PKCE ---
@@ -3827,6 +3852,31 @@ class TestDeviceAuthorizationFlow:
         assert data.access_token == "acc"
         assert data.refresh_token == "ref"
         assert data.client_id == "cid"
+
+    def test_explicit_client_id_skips_dcr(self, httpx_mock, tmp_path, monkeypatch):
+        """#7(round14): with an explicit --client-id (client_id_override) the
+        device flow uses it directly — no DCR /register POST — and the
+        device-authorization POST carries that client_id."""
+        self._patch_store(tmp_path, monkeypatch)
+        httpx_mock.add_response(url=DEVICE_AUTH_URL, json=_da_response())
+        httpx_mock.add_response(
+            url=TOKEN_URL, json={"access_token": "acc", "token_type": "Bearer"}
+        )
+
+        client = httpx.Client()
+        data = _run_device_authorization_flow(
+            MCP_URL,
+            client,
+            metadata=_device_meta(reg=False),  # no registration_endpoint
+            cached=None,
+            client_id_override="cid-from-flag",
+        )
+        assert data.access_token == "acc"
+        assert data.client_id == "cid-from-flag"
+        reqs = httpx_mock.get_requests()
+        assert not any(str(r.url) == REG_URL for r in reqs)  # no DCR
+        da = next(r for r in reqs if str(r.url) == DEVICE_AUTH_URL)
+        assert b"client_id=cid-from-flag" in da.read()
 
     def test_expires_in_clamped_to_max_lifetime(
         self, httpx_mock, tmp_path, monkeypatch, capsys


### PR DESCRIPTION
## Overview

A NIT security-hygiene fix and a coverage gap from the Opus 4.8 review (round 14, #12/#7).

## 1. Unbounded AS error strings — #12

AS-supplied `error` / `error_description` strings were embedded into exception messages **verbatim** (the in-body token error and the authorization-callback error). A hostile AS could stuff control characters or megabytes of text into the operator's logs. Added `_sanitize_oauth_error`, which strips anything outside the RFC 6749 §4.1.2.1 / §5.2 error grammar (printable ASCII minus `"` and `\`) and bounds the length to 200 chars; applied at both surfacing sites. (The device-flow error message uses a known constant, so it needs no sanitising.)

## 2. Explicit-client-id device flow untested — #7

Covered the device flow with an explicit `--client-id` (`client_id_override`): asserts no DCR `/register` POST is made and the device-authorization POST carries the supplied `client_id`.

## Tests

`_sanitize_oauth_error` strips control/quote/backslash, bounds length, placeholders an all-stripped value, coerces non-strings; the explicit-client-id device flow skips DCR.

669 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)