### PR TITLE
fix(relay): catch DecodingError so a malformed response body can't crash the gateway

### DIFF
--- a/src/mcp_stdio/relay.py
+++ b/src/mcp_stdio/relay.py
@@ -794,13 +794,17 @@ def _post_and_stream(
                     # Notifications (has_id False) stay silent.
                     _write_line(_error_response("empty response from server", req_id))
                 return _StreamResult(session, 200, protocol_version=pv)
-        except httpx.TransportError as e:
-            # TransportError is the supertype of every transient network/timeout/
-            # protocol failure: ConnectError/ReadError/Write*, ConnectTimeout/
-            # ReadTimeout/PoolTimeout, and RemoteProtocolError (mid-response
-            # server disconnect — common during half-open recovery). Catching
-            # the narrow leaf list missed several of these and let them crash the
-            # whole gateway. Non-transport (programming) errors still propagate.
+        except httpx.HTTPError as e:
+            # httpx.HTTPError is the broadest request-level supertype: every
+            # transient transport failure (TransportError — ConnectError/
+            # ReadError/Write*/timeouts/RemoteProtocolError) AND DecodingError,
+            # which is a SIBLING of TransportError (not a subclass) raised when a
+            # response body's Content-Encoding/charset is malformed or truncated.
+            # A buggy/hostile server (e.g. ``Content-Encoding: gzip`` on a
+            # non-gzip body) would otherwise propagate DecodingError out of the
+            # for-line loop and crash the whole gateway mid-session, violating
+            # the #11 "never crash the stdio connection" contract. Non-HTTP
+            # (programming) errors still propagate.
             last_error = e
             log(f"attempt {attempt}/{MAX_RETRIES} failed: {e}")
             if emitted:
@@ -908,13 +912,14 @@ def _post_parsed(
                 return json.loads(text), _StreamResult(session, 200)
             except json.JSONDecodeError:
                 return None, _StreamResult(session, 200)
-        except httpx.TransportError as e:
-            # TransportError is the supertype of every transient network/timeout/
-            # protocol failure: ConnectError/ReadError/Write*, ConnectTimeout/
-            # ReadTimeout/PoolTimeout, and RemoteProtocolError (mid-response
-            # server disconnect — common during half-open recovery). Catching
-            # the narrow leaf list missed several of these and let them crash the
-            # whole gateway. Non-transport (programming) errors still propagate.
+        except httpx.HTTPError as e:
+            # Broadest request-level supertype: covers every transient transport
+            # failure AND DecodingError (a SIBLING of TransportError, not a
+            # subclass) raised on a malformed/truncated Content-Encoding or
+            # charset. Catching only TransportError let a DecodingError propagate
+            # out of the run() loop and crash the gateway mid-session — see the
+            # matching note in _post_and_stream and #11. Non-HTTP errors still
+            # propagate.
             last_error = e
             log(f"attempt {attempt}/{MAX_RETRIES} failed: {e}")
             if attempt < MAX_RETRIES:

--- a/tests/test_relay.py
+++ b/tests/test_relay.py
@@ -401,6 +401,38 @@ class TestPostAndStream:
         emitted = json.loads(stdout.getvalue().strip())
         assert emitted["result"] == {"ok": True}
 
+    def test_decoding_error_is_caught_not_crashed(self, httpx_mock):
+        """#1(round15) HIGH: a 200 whose body fails to decode (bad
+        Content-Encoding) raises httpx.DecodingError — a SIBLING of
+        TransportError, not a subclass. It must be caught (now via HTTPError) and
+        retried/surfaced, never propagate out and crash the gateway."""
+        import httpx as _httpx
+
+        # Sanity: DecodingError is an HTTPError but NOT a TransportError.
+        assert issubclass(_httpx.DecodingError, _httpx.HTTPError)
+        assert not issubclass(_httpx.DecodingError, _httpx.TransportError)
+
+        for _ in range(MAX_RETRIES):
+            httpx_mock.add_response(
+                status_code=200,
+                headers={
+                    "content-type": "application/json",
+                    "content-encoding": "gzip",  # body is NOT gzip → DecodingError
+                },
+                content=b"this is not valid gzip",
+            )
+        client = httpx.Client()
+        stdout = StringIO()
+        with patch("sys.stdout", stdout), patch("mcp_stdio.relay.time.sleep"):
+            result = _post_and_stream(
+                client, "https://example.com/mcp", '{"id":1}', {}, 1, has_id=True
+            )
+        # Retried to exhaustion (not crashed) and a JSON-RPC error was synthesized.
+        assert result is None
+        assert len(httpx_mock.get_requests()) == MAX_RETRIES
+        err = json.loads(stdout.getvalue().strip())
+        assert err["id"] == 1 and "error" in err
+
     def test_notification_retry_exhaustion_emits_no_error(self, httpx_mock):
         """has_id=False (a notification): retry exhaustion must NOT synthesize an
         id:null error — a notification can never receive a response."""
@@ -1113,6 +1145,38 @@ class TestRun:
             ['{"jsonrpc":"2.0","method":"notifications/progress","params":{}}'],
         )
         assert output.strip() == ""
+
+    def test_decoding_error_does_not_crash_loop(self, httpx_mock):
+        """#1(round15) HIGH end-to-end: a request whose body fails to decode
+        (bad Content-Encoding) must NOT crash run() — the client gets an error
+        and the loop survives to process the next stdin line."""
+        for _ in range(MAX_RETRIES):  # bad-gzip request 1 → DecodingError ×3
+            httpx_mock.add_response(
+                status_code=200,
+                headers={
+                    "content-type": "application/json",
+                    "content-encoding": "gzip",
+                },
+                content=b"not gzip",
+            )
+        # request 2 succeeds — proves the loop kept going after the crash-y line.
+        httpx_mock.add_response(
+            text='{"jsonrpc":"2.0","result":{"ok":true},"id":2}',
+            headers={"content-type": "application/json"},
+        )
+        with patch("mcp_stdio.relay.time.sleep"):
+            output = self._run_with_stdin(
+                httpx_mock,
+                [
+                    '{"jsonrpc":"2.0","method":"tools/call","id":1}',
+                    '{"jsonrpc":"2.0","method":"tools/call","id":2}',
+                ],
+            )
+        lines = [json.loads(x) for x in output.strip().splitlines() if x]
+        ids = {m.get("id") for m in lines}
+        assert 1 in ids and 2 in ids  # both answered; id=1 an error, id=2 a result
+        assert any(m.get("id") == 1 and "error" in m for m in lines)
+        assert any(m.get("id") == 2 and "result" in m for m in lines)
 
     def test_notification_404_reinit_failure_gets_no_response(self, httpx_mock):
         """#5(round14): a notification whose POST 404s (with a prior session) and


### PR DESCRIPTION
## Overview

A **HIGH** robustness fix from the Opus 4.8 review (round 15, #1) — empirically verified against httpx 0.28.1.

## The bug

Both POST cores (`_post_and_stream`, `_post_parsed`) caught only `httpx.TransportError`. But `httpx.DecodingError` is a **sibling** of `TransportError` (not a subclass) — both descend from `RequestError`/`HTTPError`:

```
issubclass(httpx.DecodingError, httpx.TransportError) == False
```

`DecodingError` is raised when httpx decodes a response body whose `Content-Encoding` (gzip/brotli/deflate) or charset is malformed/truncated. A buggy or hostile server — e.g. `Content-Encoding: gzip` on a **non-gzip** 200 body — therefore propagated `DecodingError` out of `_dispatch`, out of `run()`'s per-line loop (whose only enclosing `try` is `finally: client.close()`, no `except`), **crashing the gateway mid-session** and losing every subsequent stdin line. This violated the #11 "never crash the stdio connection" contract that the rest of the module (`_reinitialize`, `check_connection`) already upheld.

## The fix

Widen the handler in both cores from `httpx.TransportError` to the broader `httpx.HTTPError` (covers `DecodingError` and any other non-transport `RequestError`). The existing `if emitted:` no-replay guard stays inside `_post_and_stream`, so a `DecodingError` after partial SSE delivery surfaces a stream-interrupted error rather than re-POSTing a non-idempotent request.

## Tests

- a 200 with a non-gzip body under `Content-Encoding: gzip` is caught and retried/surfaced (`_post_and_stream` unit);
- `run()` survives it and answers the next stdin line (end-to-end);
- explicit asserts that `DecodingError` is an `HTTPError` but not a `TransportError`.

676 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)