### PR TITLE
fix(token_store): guard the migration copy-through write against load_token crash

### DIFF
--- a/src/mcp_stdio/token_store.py
+++ b/src/mcp_stdio/token_store.py
@@ -202,11 +202,21 @@ def _migrate_legacy_store() -> None:
                         data = None
                 # Never write an empty/failed read over the target.
                 if isinstance(data, dict) and data:
-                    _write_store(data)
+                    written = False
                     try:
-                        _LEGACY_STORE_FILE.unlink()
+                        _write_store(data)
+                        written = True
                     except OSError:
+                        # This copy-through runs UNLOCKED from load_token. A
+                        # failed write (disk full, read-only FS, permission) must
+                        # NOT propagate out and crash the read — leave the legacy
+                        # file intact for a later run to retry the migration.
                         pass
+                    if written:
+                        try:
+                            _LEGACY_STORE_FILE.unlink()
+                        except OSError:
+                            pass
         else:
             # rename() succeeded — re-assert 0o600 on the moved inode as a
             # belt-and-suspenders step (the line-143 pre-tighten already set

--- a/tests/test_token_store.py
+++ b/tests/test_token_store.py
@@ -617,6 +617,40 @@ class TestLegacyMigration:
         # The corrupt legacy content was NOT copied through to the new path.
         assert not new_file.exists()
 
+    def test_copy_through_write_failure_does_not_crash_load(
+        self, tmp_path, monkeypatch
+    ):
+        """#11(round15): if the EXDEV copy-through _write_store raises (disk
+        full / read-only FS), load_token (unlocked) must NOT propagate it — it
+        degrades to None and leaves the legacy file intact for a later retry."""
+        legacy_dir = tmp_path / "legacy"
+        legacy_file = legacy_dir / "tokens.json"
+        new_dir = tmp_path / "new"
+        new_file = new_dir / "tokens.json"
+        legacy_dir.mkdir()
+        legacy_file.write_text('{"https://example.com/mcp": {"access_token": "old"}}')
+
+        monkeypatch.setattr("mcp_stdio.token_store._STORE_DIR", new_dir)
+        monkeypatch.setattr("mcp_stdio.token_store._STORE_FILE", new_file)
+        monkeypatch.setattr("mcp_stdio.token_store._LEGACY_STORE_DIR", legacy_dir)
+        monkeypatch.setattr("mcp_stdio.token_store._LEGACY_STORE_FILE", legacy_file)
+
+        def exdev_rename(self, target, *a, **k):
+            raise OSError(18, "Invalid cross-device link")  # force copy-through
+
+        def failing_write(_data):
+            raise OSError(28, "No space left on device")
+
+        monkeypatch.setattr("pathlib.Path.rename", exdev_rename)
+        monkeypatch.setattr("mcp_stdio.token_store._write_store", failing_write)
+
+        loaded = load_token("https://example.com/mcp")  # must not raise
+
+        assert loaded is None
+        # The legacy tokens survive — not unlinked when the write failed.
+        assert legacy_file.exists()
+        assert "old" in legacy_file.read_text()
+
     def test_concurrent_migration_race_does_not_clobber_store(
         self, tmp_path, monkeypatch
     ):


### PR DESCRIPTION
## Overview

A NIT robustness fix from the Opus 4.8 review (round 15, #11; also tempers #5).

## The bug

The EXDEV/ENOENT copy-through branch of `_migrate_legacy_store` called `_write_store(data)` with **no guard**. `_write_store` re-raises `OSError` on a full / read-only disk, and this branch runs **UNLOCKED** from `load_token` — a documented read-only path whose only enclosing `try` has no `except` — so a copy-through write failure propagated out and **crashed the read**.

**Fix:** wrap the write in `try/except OSError`. On failure, leave the legacy file intact (do **not** unlink when the data was not persisted) and degrade to `{}` so `load_token` returns `None` instead of raising. This also tempers #5: a failed clobbering write can no longer surface as an exception.

## Test

A copy-through whose `_write_store` raises `OSError` does not crash `load_token` and preserves the legacy file.

47 token_store tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)