### PR TITLE
feat(relay): honour Retry-After on 503 like 429; document SSE refresh timing

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -47,7 +47,7 @@ Bearer token、カスタムヘッダー、OAuth 2.1 認証情報をリモート�
   - [RFC 6750](https://www.rfc-editor.org/rfc/rfc6750) Bearer Token の利用
     - §2.1 `Authorization: Bearer <token>` リクエストヘッダー
 - **バックオフ付きリトライ** — 接続エラー時に最大3回リトライ
-- **HTTP 429 対応** — `Retry-After`（delta-seconds または HTTP-date）を 60 秒上限で尊重し、上限超過時は 429 をクライアントに返して判断を委ねる（cf. modelcontextprotocol/typescript-sdk#1892）
+- **HTTP 429 / 503 対応** — `Retry-After`（delta-seconds または HTTP-date）を 60 秒上限で尊重する。対象は仕様上 `Retry-After` を伴う 429（Too Many Requests）と 503（Service Unavailable）の 2 つ（RFC 9110 §10.2.3）。上限超過時はステータスをクライアントに返して判断を委ねる（cf. modelcontextprotocol/typescript-sdk#1892）
 - **自動ページネーション** — `tools/list` / `resources/list` / `resources/templates/list` / `prompts/list` の `nextCursor` を透過的に追従して 1 つのレスポンスにマージ。先頭以降のページを取りこぼすクライアントでも全件を受け取れる（cf. anthropics/claude-code#39586）
 - **ストリーミング耐性** — SSE レスポンスをリアルタイムで転送、ストリーム切断時に自動再接続
 - **行区切り文字の安全化** — 上流レスポンス中の生の `U+2028` / `U+2029`（JSON では合法だが JavaScript の行終端文字）をエスケープし、これらを改行として扱うクライアントによるフレーム崩れを防止。ロスレス（cf. modelcontextprotocol/typescript-sdk#2155）

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Bearer tokens, custom headers, and OAuth 2.1 credentials are forwarded to the re
   - [RFC 6750](https://www.rfc-editor.org/rfc/rfc6750) Bearer Token usage
     - §2.1 `Authorization: Bearer <token>` request header
 - **Retry with backoff** — retries up to 3 times on connection errors
-- **HTTP 429 handling** — honours `Retry-After` (delta-seconds or HTTP-date) up to a 60-second cap, then surfaces the 429 so the client can decide (cf. modelcontextprotocol/typescript-sdk#1892)
+- **HTTP 429 / 503 handling** — honours `Retry-After` (delta-seconds or HTTP-date) up to a 60-second cap on both 429 (Too Many Requests) and 503 (Service Unavailable) — the two spec-sanctioned Retry-After carriers (RFC 9110 §10.2.3) — then surfaces the status so the client can decide (cf. modelcontextprotocol/typescript-sdk#1892)
 - **Auto-pagination** — transparently follows `nextCursor` for `tools/list` / `resources/list` / `resources/templates/list` / `prompts/list` and merges the pages into one response, so clients that drop pages beyond the first still see the full list (cf. anthropics/claude-code#39586)
 - **Streaming resilience** — streams SSE responses in real time; auto-reconnects on mid-stream disconnect
 - **Line-separator safety** — escapes raw `U+2028` / `U+2029` (legal in JSON, but JavaScript line terminators) in upstream responses so clients that treat them as line breaks cannot mis-frame the output; lossless (cf. modelcontextprotocol/typescript-sdk#2155)

--- a/src/mcp_stdio/relay.py
+++ b/src/mcp_stdio/relay.py
@@ -31,6 +31,16 @@ RETRY_DELAY = 1  # seconds
 # modelcontextprotocol/typescript-sdk#1892.
 _RATE_LIMIT_SLEEP_CAP_SECS = 60.0
 
+# Status codes whose ``Retry-After`` we honour for a backoff-and-retry, and
+# whose final value we surface as ``error.data.retryAfter`` when we give up.
+# Both are spec-sanctioned Retry-After carriers that mean "the request was
+# NOT processed, try again later" — so replaying the non-idempotent POST is
+# safe (no work was done server-side). 429 Too Many Requests (RFC 6585 §4)
+# is rate limiting; 503 Service Unavailable (RFC 9110 §15.6.4) is a
+# transient overload / maintenance window — RFC 9110 §10.2.3 explicitly
+# lists 503 as a Retry-After carrier alongside 429.
+_RETRYABLE_RATE_LIMIT_STATUSES = (429, 503)
+
 # TCP keepalive tuning. Together (60 s idle + 4 × 15 s probes) a silent
 # half-open TCP is surfaced as a socket error within ~120 s — fast enough
 # to matter during a long tool call, slow enough to tolerate transient
@@ -744,21 +754,21 @@ def _post_and_stream(
                 session = resp.headers.get("mcp-session-id")
                 www_auth = resp.headers.get("www-authenticate")
 
-                if resp.status_code == 429:
+                if resp.status_code in _RETRYABLE_RATE_LIMIT_STATUSES:
                     resp.read()
                     sleep_secs = _handle_rate_limit(resp.headers, attempt)
                     if sleep_secs is None:
                         return _StreamResult(
                             session,
-                            429,
+                            resp.status_code,
                             www_auth,
                             retry_after=_parse_retry_after(
                                 resp.headers.get("retry-after")
                             ),
                         )
                     log(
-                        f"attempt {attempt}/{MAX_RETRIES} got HTTP 429, "
-                        f"sleeping {sleep_secs:.1f}s before retry"
+                        f"attempt {attempt}/{MAX_RETRIES} got HTTP "
+                        f"{resp.status_code}, sleeping {sleep_secs:.1f}s before retry"
                     )
                     time.sleep(sleep_secs)
                     continue
@@ -863,20 +873,20 @@ def _post_parsed(
             resp = client.post(url, content=content, headers=headers)
             session = resp.headers.get("mcp-session-id")
             www_auth = resp.headers.get("www-authenticate")
-            if resp.status_code == 429:
+            if resp.status_code in _RETRYABLE_RATE_LIMIT_STATUSES:
                 sleep_secs = _handle_rate_limit(resp.headers, attempt)
                 if sleep_secs is None:
                     return None, _StreamResult(
                         session,
-                        429,
+                        resp.status_code,
                         www_auth,
                         retry_after=_parse_retry_after(
                             resp.headers.get("retry-after")
                         ),
                     )
                 log(
-                    f"attempt {attempt}/{MAX_RETRIES} got HTTP 429, "
-                    f"sleeping {sleep_secs:.1f}s before retry"
+                    f"attempt {attempt}/{MAX_RETRIES} got HTTP "
+                    f"{resp.status_code}, sleeping {sleep_secs:.1f}s before retry"
                 )
                 time.sleep(sleep_secs)
                 continue
@@ -1785,12 +1795,13 @@ def run(
             if result.status_code >= 400:
                 log(f"upstream returned HTTP {result.status_code}")
                 if req_has_id:
-                    # On a 429 whose retries were exhausted / over-cap, surface
-                    # the server's Retry-After (when present) as error.data so a
-                    # client can back off intelligently. See #8.
+                    # On a 429/503 whose retries were exhausted / over-cap,
+                    # surface the server's Retry-After (when present) as
+                    # error.data so a client can back off intelligently. See #8.
                     err_data = (
                         {"retryAfter": result.retry_after}
-                        if result.status_code == 429 and result.retry_after is not None
+                        if result.status_code in _RETRYABLE_RATE_LIMIT_STATUSES
+                        and result.retry_after is not None
                         else None
                     )
                     _write_line(
@@ -1843,6 +1854,17 @@ def _sse_reader_loop(
     401/403 token refresh. ``headers_lock`` (when provided) serialises the
     per-reconnect snapshot taken here against those mutations so the request
     build never iterates a dict that is changing under it.
+
+    Refresh-propagation timing (#3): a token refresh driven by the POST path
+    reaches THIS already-open GET stream only on its NEXT reconnect — the
+    snapshot above is re-taken per connect, so the fresh credential is picked
+    up then, but a refresh does NOT forcibly tear down a healthy live stream.
+    No forced-reconnect signal is wired, by design: a token expiry severe
+    enough to 401 the POST uses the SAME credential as the GET, so the server
+    closes (401s) the long-lived GET too, and the resulting reconnect snapshots
+    the refreshed headers. Adding a cross-thread reconnect kick for the narrow
+    window where a server keeps the GET alive on an expired token would be
+    over-engineering for no observed failure mode.
 
     Reconnects automatically on disconnect.
     """
@@ -2104,9 +2126,9 @@ def run_sse(
                     write=timeout_write,
                     pool=10,
                 )
-                # Honour Retry-After on 429 up to the cap; over-cap or
-                # retries-exhausted falls through with the final 429 and
-                # is surfaced to the caller by the generic 4xx branch
+                # Honour Retry-After on 429/503 up to the cap; over-cap or
+                # retries-exhausted falls through with the final status and
+                # is surfaced to the caller by the generic 4xx/5xx branch
                 # below (typescript-sdk#1892).
                 for attempt in range(1, MAX_RETRIES + 1):
                     resp = client.post(
@@ -2115,14 +2137,14 @@ def run_sse(
                         headers=_snapshot_headers(),
                         timeout=post_timeout,
                     )
-                    if resp.status_code != 429:
+                    if resp.status_code not in _RETRYABLE_RATE_LIMIT_STATUSES:
                         break
                     sleep_secs = _handle_rate_limit(resp.headers, attempt)
                     if sleep_secs is None:
                         break
                     log(
-                        f"attempt {attempt}/{MAX_RETRIES} got HTTP 429, "
-                        f"sleeping {sleep_secs:.1f}s before retry"
+                        f"attempt {attempt}/{MAX_RETRIES} got HTTP "
+                        f"{resp.status_code}, sleeping {sleep_secs:.1f}s before retry"
                     )
                     time.sleep(sleep_secs)
 
@@ -2204,7 +2226,7 @@ def run_sse(
                     # with the cancel filter's narrow scope).
                     if req_has_id:
                         err_data = None
-                        if resp.status_code == 429:
+                        if resp.status_code in _RETRYABLE_RATE_LIMIT_STATUSES:
                             secs = _parse_retry_after(resp.headers.get("retry-after"))
                             if secs is not None:
                                 err_data = {"retryAfter": secs}  # See #8.

--- a/tests/test_relay.py
+++ b/tests/test_relay.py
@@ -1437,7 +1437,9 @@ class TestRun:
         assert result["error"]["message"] == "authentication failed"
         assert result["id"] == 1
 
-    @pytest.mark.parametrize("status_code", [400, 404, 409, 422, 500, 502, 503, 504])
+    # 429 and 503 are excluded: both are Retry-After carriers the relay
+    # retries (see the dedicated 503 tests below), not unrecoverable codes.
+    @pytest.mark.parametrize("status_code", [400, 404, 409, 422, 500, 502, 504])
     def test_unhandled_error_status_surfaces_jsonrpc_error(
         self, httpx_mock, status_code
     ):
@@ -2964,6 +2966,73 @@ class TestCheckConnectionSse:
             check_connection(self.SSE_URL, dict(self.HEADERS), transport="sse")
             is False
         )
+
+    def test_sse_post_non_2xx_reports_post_failure(self, httpx_mock, capsys):
+        """#6(round15): the endpoint POST returning a non-2xx sets post_error,
+        the helper closes the stream, and the probe reports the POST failure
+        (not a generic 'stream ended') and returns False."""
+        post_attempted = threading.Event()
+
+        def sse_gen():
+            yield b"event: endpoint\ndata: /messages?sid=abc\n\n"
+            # Hold the stream open until the POST has been attempted, then give
+            # the helper a beat to record post_error before the stream ends.
+            post_attempted.wait(timeout=3)
+            time.sleep(0.1)
+
+        httpx_mock.add_response(
+            url=self.SSE_URL,
+            method="GET",
+            stream=IteratorStream(sse_gen()),
+            headers={"content-type": "text/event-stream"},
+        )
+
+        def on_post(request: httpx.Request) -> httpx.Response:
+            post_attempted.set()
+            return httpx.Response(status_code=500)
+
+        httpx_mock.add_callback(
+            on_post, url="https://example.com/messages?sid=abc"
+        )
+
+        assert (
+            check_connection(self.SSE_URL, dict(self.HEADERS), transport="sse")
+            is False
+        )
+        err = capsys.readouterr().err
+        assert "POST to SSE endpoint failed" in err
+        assert "HTTP 500" in err
+
+    def test_sse_post_raises_reports_post_failure(self, httpx_mock, capsys):
+        """#6(round15): the endpoint POST raising a transport error is caught in
+        the helper (str(e) → post_error) and surfaced as a POST failure → False."""
+        post_attempted = threading.Event()
+
+        def sse_gen():
+            yield b"event: endpoint\ndata: /messages?sid=abc\n\n"
+            post_attempted.wait(timeout=3)
+            time.sleep(0.1)
+
+        httpx_mock.add_response(
+            url=self.SSE_URL,
+            method="GET",
+            stream=IteratorStream(sse_gen()),
+            headers={"content-type": "text/event-stream"},
+        )
+
+        def on_post(request: httpx.Request) -> httpx.Response:
+            post_attempted.set()
+            raise httpx.ConnectError("connection refused", request=request)
+
+        httpx_mock.add_callback(
+            on_post, url="https://example.com/messages?sid=abc"
+        )
+
+        assert (
+            check_connection(self.SSE_URL, dict(self.HEADERS), transport="sse")
+            is False
+        )
+        assert "POST to SSE endpoint failed" in capsys.readouterr().err
 
     def test_sse_cross_origin_endpoint_refused_with_credentials(
         self, httpx_mock, capsys
@@ -4950,6 +5019,54 @@ class TestRunSseCancelFilter:
 
         assert "kept" in stdout.getvalue()
 
+    def test_sse_reader_escapes_raw_line_separators_end_to_end(self, httpx_mock):
+        """#13(round15): a message event whose JSON payload contains a RAW
+        U+2028/U+2029 must reach stdout in escaped \\uXXXX form. Proves the
+        reader-thread reply path runs through _emit's escape, not just the
+        unit-tested _emit — a client framing on these chars can't mis-split."""
+        # Raw separators sit inside a JSON string value (legal unescaped per
+        # RFC 8259) — the gateway must escape them on the wire regardless.
+        payload = '{"jsonrpc":"2.0","result":{"t":"a\u2028b\u2029c"},"id":31}'
+        post_received = threading.Event()
+        release_stdin = threading.Event()
+
+        def sse_gen():
+            yield b"event: endpoint\ndata: /messages?sessionId=abc\n\n"
+            post_received.wait(timeout=3)
+            yield f"event: message\ndata: {payload}\n\n".encode()
+            time.sleep(0.1)
+            release_stdin.set()
+
+        httpx_mock.add_response(
+            url=self.URL,
+            stream=IteratorStream(sse_gen()),
+            headers={"content-type": "text/event-stream"},
+        )
+
+        def on_post(request: httpx.Request) -> httpx.Response:
+            post_received.set()
+            return httpx.Response(status_code=202)
+
+        httpx_mock.add_callback(
+            on_post,
+            url="https://example.com/messages?sessionId=abc",
+        )
+
+        stdin = _BlockingStdin(
+            '{"jsonrpc":"2.0","method":"tools/call","id":31}',
+            release_stdin,
+        )
+        stdout = StringIO()
+        with patch("sys.stdin", stdin), patch("sys.stdout", stdout):
+            run_sse(self.URL, {"Content-Type": "application/json"})
+
+        out = stdout.getvalue()
+        assert "\u2028" not in out and "\u2029" not in out
+        assert "\\u2028" in out and "\\u2029" in out
+        # Lossless: the escaped line still parses back to the original value.
+        line = next(x for x in out.splitlines() if x and "31" in x)
+        assert json.loads(line)["result"]["t"] == "a\u2028b\u2029c"
+
     def test_sse_id_reuse_supersedes_cancel(self, httpx_mock):
         """#19: a request REUSING a previously-cancelled id supersedes the
         cancel (tracker.discard), so its later SSE response is DELIVERED, not
@@ -5218,6 +5335,81 @@ class TestRun429Retry:
         assert len(httpx_mock.get_requests()) == 3
 
 
+class TestRun503Retry:
+    """503 Service Unavailable is a Retry-After carrier (RFC 9110 §10.2.3 /
+    §15.6.4), so the relay backs-off-and-retries it exactly like 429 — a 503
+    means the request was not processed, so replaying the POST is safe."""
+
+    URL = "https://example.com/mcp"
+
+    def _run_with_stdin(self, httpx_mock, stdin_lines, **kwargs):
+        stdin_data = "\n".join(stdin_lines) + "\n"
+        stdout = StringIO()
+        with patch("sys.stdin", StringIO(stdin_data)), patch("sys.stdout", stdout):
+            run(self.URL, {"Content-Type": "application/json"}, **kwargs)
+        return stdout.getvalue()
+
+    def test_503_with_retry_after_then_200(self, httpx_mock, monkeypatch):
+        """#2(round15): a 503 with Retry-After sleeps that long, then the
+        retried POST's 200 is delivered normally."""
+        slept: list[float] = []
+        monkeypatch.setattr("mcp_stdio.relay.time.sleep", lambda s: slept.append(s))
+
+        httpx_mock.add_response(
+            status_code=503, headers={"retry-after": "2"}, text=""
+        )
+        httpx_mock.add_response(
+            text='{"jsonrpc":"2.0","result":{"ok":true},"id":1}',
+            headers={"content-type": "application/json"},
+        )
+
+        output = self._run_with_stdin(
+            httpx_mock, ['{"jsonrpc":"2.0","method":"tools/call","id":1}']
+        )
+        assert '"ok":true' in output
+        assert 2.0 in slept, f"expected a 2.0-second sleep, got {slept!r}"
+
+    def test_503_without_retry_after_uses_backoff_then_200(
+        self, httpx_mock, monkeypatch
+    ):
+        """A 503 with no Retry-After falls back to the same linear backoff as
+        429 / transient errors, then succeeds on retry."""
+        slept: list[float] = []
+        monkeypatch.setattr("mcp_stdio.relay.time.sleep", lambda s: slept.append(s))
+
+        httpx_mock.add_response(status_code=503, text="")  # no retry-after
+        httpx_mock.add_response(
+            text='{"jsonrpc":"2.0","result":{"ok":true},"id":1}',
+            headers={"content-type": "application/json"},
+        )
+
+        output = self._run_with_stdin(
+            httpx_mock, ['{"jsonrpc":"2.0","method":"tools/call","id":1}']
+        )
+        assert '"ok":true' in output
+        assert 1.0 in slept  # RETRY_DELAY * 1
+
+    def test_503_over_cap_surfaces_retry_after_in_error_data(
+        self, httpx_mock, monkeypatch
+    ):
+        """A 503 whose Retry-After exceeds the cap gives up immediately and
+        surfaces HTTP 503 with error.data.retryAfter — mirroring 429."""
+        slept: list[float] = []
+        monkeypatch.setattr("mcp_stdio.relay.time.sleep", lambda s: slept.append(s))
+
+        httpx_mock.add_response(
+            status_code=503, headers={"retry-after": "120"}, text=""
+        )
+        output = self._run_with_stdin(
+            httpx_mock, ['{"jsonrpc":"2.0","method":"tools/call","id":1}']
+        )
+        err = json.loads(output.strip())
+        assert err["id"] == 1 and "503" in err["error"]["message"]
+        assert err["error"]["data"]["retryAfter"] == 120.0
+        assert slept == [], f"expected no sleep for over-cap, got {slept!r}"
+        assert len(httpx_mock.get_requests()) == 1
+
+
 class TestRunSse429Retry:
     URL = "https://example.com/sse"
 
@@ -5374,6 +5566,104 @@ class TestRunSse429Retry:
         )
 
 
+class TestRunSse503Retry:
+    """The legacy SSE POST path treats 503 like 429 too (#2 round15)."""
+
+    URL = "https://example.com/sse"
+
+    def test_503_with_retry_after_then_202(self, httpx_mock, monkeypatch):
+        slept: list[float] = []
+        monkeypatch.setattr("mcp_stdio.relay.time.sleep", lambda s: slept.append(s))
+
+        release_stdin = threading.Event()
+        post_done = threading.Event()
+
+        def sse_gen():
+            yield b"event: endpoint\ndata: /messages?sessionId=abc\n\n"
+            post_done.wait(timeout=3)
+            release_stdin.set()
+
+        httpx_mock.add_response(
+            url=self.URL,
+            stream=IteratorStream(sse_gen()),
+            headers={"content-type": "text/event-stream"},
+        )
+
+        posts: list[int] = []
+
+        def on_post(request: httpx.Request) -> httpx.Response:
+            posts.append(len(posts) + 1)
+            if len(posts) == 1:
+                return httpx.Response(status_code=503, headers={"retry-after": "3"})
+            post_done.set()
+            return httpx.Response(status_code=202)
+
+        httpx_mock.add_callback(
+            on_post,
+            url="https://example.com/messages?sessionId=abc",
+            is_reusable=True,
+        )
+
+        stdin = _BlockingStdin(
+            '{"jsonrpc":"2.0","method":"notifications/initialized"}',
+            release_stdin,
+        )
+        stdout = StringIO()
+        with patch("sys.stdin", stdin), patch("sys.stdout", stdout):
+            run_sse(self.URL, {"Content-Type": "application/json"})
+
+        assert 3.0 in slept, f"expected a 3.0-second sleep, got {slept!r}"
+        assert len(posts) == 2
+
+    def test_503_over_cap_surfaces_retry_after_in_error_data(
+        self, httpx_mock, monkeypatch
+    ):
+        slept: list[float] = []
+        monkeypatch.setattr("mcp_stdio.relay.time.sleep", lambda s: slept.append(s))
+
+        release_stdin = threading.Event()
+        post_seen = threading.Event()
+
+        def sse_gen():
+            yield b"event: endpoint\ndata: /messages?sessionId=abc\n\n"
+            post_seen.wait(timeout=3)
+            release_stdin.set()
+
+        httpx_mock.add_response(
+            url=self.URL,
+            stream=IteratorStream(sse_gen()),
+            headers={"content-type": "text/event-stream"},
+        )
+
+        posts: list[int] = []
+
+        def on_post(request: httpx.Request) -> httpx.Response:
+            posts.append(len(posts) + 1)
+            post_seen.set()
+            return httpx.Response(status_code=503, headers={"retry-after": "120"})
+
+        httpx_mock.add_callback(
+            on_post,
+            url="https://example.com/messages?sessionId=abc",
+            is_reusable=True,
+        )
+
+        stdin = _BlockingStdin(
+            '{"jsonrpc":"2.0","method":"tools/call","id":9}',
+            release_stdin,
+        )
+        stdout = StringIO()
+        with patch("sys.stdin", stdin), patch("sys.stdout", stdout):
+            run_sse(self.URL, {"Content-Type": "application/json"})
+
+        assert slept == [], f"expected no sleep for over-cap, got {slept!r}"
+        assert len(posts) == 1
+        decoded = [json.loads(x) for x in stdout.getvalue().splitlines() if x]
+        match = [d for d in decoded if d.get("id") == 9 and "error" in d]
+        assert match and "503" in match[0]["error"]["message"]
+        assert match[0]["error"]["data"]["retryAfter"] == 120.0
+
+
 class TestPaginate429Retry:
     """_post_parsed (pagination path) honours Retry-After on 429 too."""
 
@@ -5432,3 +5722,49 @@ class TestPaginate429Retry:
         names = [t["name"] for t in merged["result"]["tools"]]
         assert names == ["t1", "t2"]
         assert "nextCursor" not in merged["result"]
+
+    def test_paginated_list_429_over_cap_surfaces_error_data(
+        self, httpx_mock, monkeypatch
+    ):
+        """#12(round15): a page-1 429 whose Retry-After exceeds the cap gives
+        up in _post_parsed and the pagination caller surfaces one JSON-RPC
+        error carrying error.data.retryAfter (the over-cap give-up branch)."""
+        slept: list[float] = []
+        monkeypatch.setattr("mcp_stdio.relay.time.sleep", lambda s: slept.append(s))
+
+        httpx_mock.add_response(
+            status_code=429, headers={"retry-after": "999999"}, text=""
+        )
+        output = self._run_with_stdin(
+            httpx_mock, ['{"jsonrpc":"2.0","id":1,"method":"tools/list"}']
+        )
+        err = json.loads(output.strip())
+        assert err["id"] == 1 and "429" in err["error"]["message"]
+        assert err["error"]["data"]["retryAfter"] == 999999.0
+        assert slept == [], f"expected no sleep for over-cap, got {slept!r}"
+        assert len(httpx_mock.get_requests()) == 1
+
+    def test_paginated_list_503_then_200(self, httpx_mock, monkeypatch):
+        """The pagination path honours 503 Retry-After too (#2 round15)."""
+        slept: list[float] = []
+        monkeypatch.setattr("mcp_stdio.relay.time.sleep", lambda s: slept.append(s))
+
+        httpx_mock.add_response(
+            status_code=503, headers={"retry-after": "2"}, text=""
+        )
+        httpx_mock.add_response(
+            text=json.dumps(
+                {
+                    "jsonrpc": "2.0",
+                    "id": 1,
+                    "result": {"tools": [{"name": "t1"}]},
+                }
+            ),
+            headers={"content-type": "application/json"},
+        )
+        output = self._run_with_stdin(
+            httpx_mock, ['{"jsonrpc":"2.0","id":1,"method":"tools/list"}']
+        )
+        assert 2.0 in slept, f"expected a 2.0-second sleep, got {slept!r}"
+        merged = json.loads(output.strip())
+        assert [t["name"] for t in merged["result"]["tools"]] == ["t1"]


### PR DESCRIPTION
## Overview

round-15 follow-ups from the Opus 4.8 review: one behavioural change (#2) + one doc clarification (#3) + three coverage gaps (#6, #12, #13).

## #2 — 503 Retry-After (behavioural)

RFC 9110 §10.2.3 explicitly lists **503 Service Unavailable** (§15.6.4) alongside **429 Too Many Requests** (RFC 6585 §4) as a `Retry-After` carrier. Both statuses mean *"the request was not processed, try again later"*, so replaying the non-idempotent POST is safe (no server-side work happened).

A new module constant `_RETRYABLE_RATE_LIMIT_STATUSES = (429, 503)` now drives **all four** POST sites:
- `_post_and_stream` (streaming core)
- `_post_parsed` (pagination core)
- `run()` and `run_sse()` `error.data` surfacing

So a 503 now backs off and retries up to the 60 s cap, and on give-up surfaces its `Retry-After` as `error.data.retryAfter` — **identical to the existing 429 path**. Log lines and the `_StreamResult.status_code` now carry the actual status (429 *or* 503) instead of a hard-coded 429.

## #3 — SSE refresh timing (docs only)

Documented in `_sse_reader_loop` that a POST-path token refresh reaches the already-open GET stream **only on its next reconnect** (the per-reconnect header snapshot picks up the fresh credential). No forced-reconnect signal is wired, by design: a token expiry severe enough to 401 the POST uses the *same* credential as the GET, so the server closes the long-lived GET too, and the resulting reconnect snapshots the refreshed headers. A cross-thread reconnect kick for the narrow keep-alive-on-expired-token window would be over-engineering for no observed failure mode.

## Coverage

- **#6** — `--check` SSE POST-failure branch: a non-2xx endpoint POST **and** a raised transport error both set `post_error`, close the stream, and report `"POST to SSE endpoint failed"` → `False`.
- **#12** — pagination 429 over-cap give-up branch surfaces `error.data.retryAfter`.
- **#13** — end-to-end SSE-reader reply path escapes raw U+2028/U+2029 to `\uXXXX` (proves the reader thread runs through `_emit`'s escape, not just the unit-tested `_emit`).

503 tests added for `run()`, `run_sse()`, and the pagination path. The `test_unhandled_error_status_surfaces_jsonrpc_error` parametrize drops 503 (now retryable, like 429). Both READMEs updated to say 429 / 503.

## Tests

688 passed, 3 skipped (full suite). No raw U+2028/U+2029/U+0085/U+FEFF bytes in source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)