### PR TITLE
fix(relay): recover SSE reader on unexpected error; error on 202-to-request

### DIFF
--- a/src/mcp_stdio/relay.py
+++ b/src/mcp_stdio/relay.py
@@ -1789,10 +1789,16 @@ def run(
 
             # Fall-through error for any unhandled 4xx/5xx so the MCP client
             # never hangs waiting for a response. 200 bodies were already
-            # streamed by _post_and_stream; 202 is reserved for notifications
-            # and intentionally produces no stdout. A notification (no id) that
-            # draws a 4xx/5xx is logged but gets no synthesized response. See #11.
-            if result.status_code >= 400:
+            # streamed by _post_and_stream. 202 is reserved for the client's own
+            # responses/notifications (MCP Streamable HTTP "Sending Messages"
+            # rule 4); a compliant server answers a REQUEST with 200 + an SSE /
+            # JSON body (rule 5). So a 202 to a request-WITH-id is non-compliant
+            # and would leave the client hanging forever (no body now, no async
+            # reply on Streamable HTTP) — synthesize an error for it too, matching
+            # the empty-200 guard in _post_and_stream. A 202 to a NOTIFICATION
+            # (no id) stays correctly silent. See #11 and #4 (round16).
+            req_202_hang = result.status_code == 202 and req_has_id
+            if result.status_code >= 400 or req_202_hang:
                 log(f"upstream returned HTTP {result.status_code}")
                 if req_has_id:
                     # On a 429/503 whose retries were exhausted / over-cap,
@@ -1804,11 +1810,12 @@ def run(
                         and result.retry_after is not None
                         else None
                     )
-                    _write_line(
-                        _error_response(
-                            f"HTTP {result.status_code}", req_id, data=err_data
-                        )
+                    msg = (
+                        f"HTTP {result.status_code} (no response body for request)"
+                        if req_202_hang
+                        else f"HTTP {result.status_code}"
                     )
+                    _write_line(_error_response(msg, req_id, data=err_data))
     finally:
         client.close()
 
@@ -1944,9 +1951,33 @@ def _sse_reader_loop(
             if state.stop.wait(RETRY_DELAY):
                 return
         except Exception as e:  # noqa: BLE001 — thread safety net
-            log(f"SSE reader unexpected error: {e}")
-            state.ready.set()
-            return
+            if state.stop.is_set():
+                return
+            # An UNEXPECTED (non-HTTPError) exception — e.g. a decode bug in
+            # _iter_sse_events on a single server-controlled malformed event, or
+            # a _write_line failure surfacing through _emit. Split on `established`
+            # exactly like the non-200 path above:
+            if not established:
+                # First connect never succeeded — fail fast: unblock run_sse's
+                # startup wait() (endpoint stays None so run_sse exits) rather than
+                # spin reconnecting on a deterministic startup-time bug.
+                log(f"SSE reader unexpected error before first connect: {e}")
+                state.ready.set()
+                return
+            # Established mid-session: do NOT permanently die. The earlier
+            # unconditional "set ready; return" left endpoint_url non-None, so the
+            # main loop's `endpoint = state.endpoint_url` stayed truthy and it kept
+            # POSTing requests whose async JSON-RPC replies arrive ONLY on this
+            # now-dead GET stream — every later request-with-id then hung forever
+            # (silent, permanent). Mirror the disconnect paths: clear ready + null
+            # endpoint_url so in-flight ids surface "SSE endpoint unavailable"
+            # instead of hanging, then reconnect — a one-off bad event should not be
+            # fatal (cf. the loop's stated intent above). See #1 (round16).
+            log(f"SSE reader unexpected error, reconnecting: {e}")
+            state.ready.clear()
+            state.endpoint_url = None
+            if state.stop.wait(RETRY_DELAY):
+                return
 
 
 def run_sse(
@@ -2148,6 +2179,16 @@ def run_sse(
                     )
                     time.sleep(sleep_secs)
 
+                # NOTE (#3 round16): the re-POST below resends the same JSON-RPC
+                # id after a refresh/step-up. Unlike a non-2xx (which reliably
+                # means "not accepted"), a 401/403 does NOT guarantee the origin
+                # rejected the request — an edge proxy can inject the 401 while
+                # the origin already accepted and enqueued a reply. The re-POST
+                # then makes the server push a SECOND async reply for the same id
+                # on the GET stream, and the reader's _emit writes both (the same
+                # no-shared-de-dup-map window documented at the non-2xx branch
+                # below). Left undeduplicated by design — a shared seen-id set
+                # would be heavier than the project's minimalism warrants.
                 if resp.status_code == 401 and token_refresher:
                     log("received 401, attempting token refresh")
                     new_headers = token_refresher()

--- a/tests/test_relay.py
+++ b/tests/test_relay.py
@@ -1508,6 +1508,24 @@ class TestRun:
         )
         assert output.strip() == ""
 
+    def test_202_to_request_with_id_synthesizes_error(self, httpx_mock):
+        """#4(round16): a non-compliant 202 to a REQUEST (with id) on Streamable
+        HTTP delivers no body and no async reply, so the relay must synthesize a
+        JSON-RPC error instead of leaving the client hanging — unlike the silent
+        202-to-notification case above."""
+        httpx_mock.add_response(
+            status_code=202,
+            text="",
+            headers={"content-type": "application/json"},
+        )
+        output = self._run_with_stdin(
+            httpx_mock,
+            ['{"jsonrpc":"2.0","method":"tools/call","id":7}'],
+        )
+        result = json.loads(output.strip())
+        assert result["id"] == 7
+        assert "202" in result["error"]["message"]
+
     def test_401_without_refresher_emits_error(self, httpx_mock):
         """#11: unhandled non-2xx must never produce a silent stdin hang."""
         httpx_mock.add_response(
@@ -1567,6 +1585,40 @@ class TestProtocolVersionHeader:
         # initialize itself carries no header (version not yet negotiated)
         assert "mcp-protocol-version" not in reqs[0].headers
         # the next request carries the negotiated version
+        assert reqs[1].headers["mcp-protocol-version"] == "2025-06-18"
+
+    def test_user_pinned_header_survives_cold_start_initialize(self, httpx_mock):
+        """#12(round16): on a cold-start initialize (version not yet negotiated)
+        a user-supplied -H MCP-Protocol-Version is deliberately preserved on the
+        initialize POST (relay.py only strips its OWN injected header once a
+        version is captured). The next request then carries the relay-injected
+        NEGOTIATED version, not the pinned one. Guards the `protocol_version is
+        not None` gate against a regression that stripped the cold-start header."""
+        httpx_mock.add_response(
+            text='{"jsonrpc":"2.0","result":{"protocolVersion":"2025-06-18"},"id":1}',
+            headers={"content-type": "application/json"},
+        )
+        httpx_mock.add_response(
+            text='{"jsonrpc":"2.0","result":{},"id":2}',
+            headers={"content-type": "application/json"},
+        )
+        stdin_data = (
+            '{"jsonrpc":"2.0","method":"initialize","id":1}\n'
+            '{"jsonrpc":"2.0","method":"tools/call","id":2}\n'
+        )
+        stdout = StringIO()
+        with patch("sys.stdin", StringIO(stdin_data)), patch("sys.stdout", stdout):
+            run(
+                "https://example.com/mcp",
+                {
+                    "Content-Type": "application/json",
+                    "MCP-Protocol-Version": "2024-11-05",
+                },
+            )
+        reqs = httpx_mock.get_requests()
+        # (a) the cold-start initialize keeps the user's pinned version
+        assert reqs[0].headers["mcp-protocol-version"] == "2024-11-05"
+        # (b) the next request carries the relay-injected negotiated version
         assert reqs[1].headers["mcp-protocol-version"] == "2025-06-18"
 
     def test_initialized_notification_carries_header(self, httpx_mock):
@@ -3267,9 +3319,11 @@ class TestSseReaderLoop:
         assert state.endpoint_url is None
 
     def test_generic_exception_safety_net_sets_ready(self, httpx_mock, monkeypatch):
-        """A non-HTTP exception inside the reader must hit the catch-all that
-        sets ready and returns — so run_sse's startup wait() unblocks instead of
-        hanging to the connect timeout."""
+        """A non-HTTP exception on the FIRST connect (before any endpoint event,
+        so `established` is False) must hit the catch-all's fail-fast branch: set
+        ready and return — so run_sse's startup wait() unblocks instead of hanging
+        to the connect timeout. (The established-mid-session branch reconnects
+        instead; see TestRunSseReaderRecovery. #1 round16.)"""
         httpx_mock.add_response(
             url=self.URL,
             method="GET",
@@ -3599,6 +3653,84 @@ class _BlockingStdin:
             return self._line
         self._release.wait(timeout=5)
         raise StopIteration
+
+
+class TestRunSseReaderRecovery:
+    """#1(round16): an unexpected (non-HTTPError) exception in the SSE reader
+    must not permanently kill it. The reader nulls endpoint_url and reconnects,
+    so async reply delivery recovers instead of every later request-with-id
+    hanging forever on a dead stream."""
+
+    URL = "https://example.com/sse"
+
+    def test_reader_reconnects_after_unexpected_emit_error(
+        self, httpx_mock, monkeypatch
+    ):
+        monkeypatch.setattr("mcp_stdio.relay.RETRY_DELAY", 0.05)
+        import mcp_stdio.relay as relay_mod
+
+        real_emit = relay_mod._emit
+        emit_calls = {"n": 0}
+
+        def flaky_emit(line, tracker):
+            emit_calls["n"] += 1
+            if emit_calls["n"] == 1:
+                # Simulate an unexpected decode/_write_line bug on one event.
+                raise RuntimeError("simulated reader-side bug on a malformed event")
+            real_emit(line, tracker)
+
+        monkeypatch.setattr("mcp_stdio.relay._emit", flaky_emit)
+
+        release_stdin = threading.Event()
+        hold_gen2 = threading.Event()
+
+        def sse_gen_1():
+            yield b"event: endpoint\ndata: /messages?sid=abc\n\n"
+            # This message triggers flaky_emit's first-call raise, which throws
+            # out of the reader's for-loop into the catch-all.
+            yield b'event: message\ndata: {"jsonrpc":"2.0","result":{"first":1},"id":1}\n\n'
+
+        def sse_gen_2():
+            yield b"event: endpoint\ndata: /messages?sid=abc\n\n"
+            yield b'event: message\ndata: {"jsonrpc":"2.0","result":{"recovered":1},"id":2}\n\n'
+            # The recovered reply has been _emit'd to stdout by the time the
+            # reader pulls the next event; let the main loop exit, then hold the
+            # stream so the reader parks here (no third unmocked GET) until stop.
+            release_stdin.set()
+            hold_gen2.wait(timeout=2)
+
+        httpx_mock.add_response(
+            url=self.URL,
+            method="GET",
+            stream=IteratorStream(sse_gen_1()),
+            headers={"content-type": "text/event-stream"},
+        )
+        httpx_mock.add_response(
+            url=self.URL,
+            method="GET",
+            stream=IteratorStream(sse_gen_2()),
+            headers={"content-type": "text/event-stream"},
+        )
+        httpx_mock.add_response(
+            url="https://example.com/messages?sid=abc",
+            method="POST",
+            status_code=202,
+            is_reusable=True,
+        )
+
+        stdin = _BlockingStdin(
+            '{"jsonrpc":"2.0","method":"notifications/initialized"}',
+            release_stdin,
+        )
+        stdout = StringIO()
+        with patch("sys.stdin", stdin), patch("sys.stdout", stdout):
+            run_sse(self.URL, {"Content-Type": "application/json"})
+
+        # The reader survived the unexpected error: it reconnected (>=2 GETs)
+        # and delivered the post-recovery reply — proving it did not die.
+        gets = [r for r in httpx_mock.get_requests() if r.method == "GET"]
+        assert len(gets) >= 2, f"expected a reconnect (>=2 GETs), got {len(gets)}"
+        assert "recovered" in stdout.getvalue()
 
 
 class TestRunSse:


### PR DESCRIPTION
## Overview

Two MEDIUM correctness fixes from the Opus 4.8 review (round 16), plus a doc clarification and coverage.

## #1 — SSE reader liveness (MEDIUM)

The reader's catch-all `except Exception` did `state.ready.set(); return`, permanently killing the reader **without nulling `endpoint_url`**. After a mid-session unexpected error (e.g. a decode bug in `_iter_sse_events` on one server-controlled malformed event, or a `_write_line` failure surfacing through `_emit`), `endpoint_url` stayed non-`None`, so the `run_sse` main loop kept POSTing requests whose async JSON-RPC replies arrive **only** on the now-dead GET stream — every later request-with-id hung **forever, silently and permanently**. No `is_alive()` guard exists anywhere.

**Fix:** split the catch-all on `established`, exactly like the existing non-200 path:
- **first-connect** failure → fail fast (`set ready; return`) so startup unblocks and `run_sse` exits, rather than spin on a deterministic startup bug;
- **established mid-session** → clear ready, null `endpoint_url` (so in-flight ids surface "SSE endpoint unavailable" instead of hanging), then **reconnect** — a one-off bad event is no longer fatal, matching the reader loop's own stated design intent.

## #4 — 202-to-request silent hang (MEDIUM)

On Streamable HTTP a compliant server answers a **request** with 200 + an SSE/JSON body; 202 is reserved for the client's own responses/notifications. A non-compliant 202 to a request-**with-id** delivered no body, was not `>= 400`, and slipped past the fall-through error branch — **no stdout, client hangs forever**. `run()` now synthesizes a JSON-RPC error for a 202 to a request. A 202 to a **notification** stays correctly silent.

## #3 — doc (LOW)

Documented the 401/403-retry re-POST double-delivery window at its site: unlike a non-2xx, a 401/403 does **not** reliably mean "not accepted", so the re-POST can make the server enqueue a second async reply for the same id. Left undeduplicated by design (consistent with the existing non-2xx NOTE and the project's minimalism).

## Tests

- 202-to-request → JSON-RPC error (vs the existing 202-notification-silent test)
- cold-start initialize preserves a user-pinned `MCP-Protocol-Version` header while the next request carries the negotiated one (#12 coverage gap)
- SSE reader **reconnects** after an unexpected mid-session error instead of dying (new `TestRunSseReaderRecovery`); the existing first-connect safety-net test still asserts fail-fast

Full relay suite **323 passed, 3 skipped**. No raw U+2028/U+2029/U+0085/U+FEFF bytes in source.

> Note: round-16 review also flagged 5 NITs + 2 more LOWs across token_store/oauth — handled in separate per-file PRs. #2/#5/#7/#11 accepted as documented design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)