### PR TITLE
fix(token_store): reconcile empty XDG placeholder; harden legacy dir perms

### DIFF
--- a/src/mcp_stdio/token_store.py
+++ b/src/mcp_stdio/token_store.py
@@ -110,6 +110,11 @@ class TokenData:
     no_resource_indicator: bool = False
 
 
+# Set once if we ever fail to tighten the store dir to 0o700 and detect it is
+# still group/other-accessible, so the operator warning is emitted only once.
+_warned_loose_store_dir = False
+
+
 def _ensure_store_dir() -> None:
     """Create the store directory with secure permissions.
 
@@ -117,11 +122,49 @@ def _ensure_store_dir() -> None:
     the directory pre-existed with looser permissions (created earlier by
     another tool, or under a permissive umask).
     """
+    global _warned_loose_store_dir
     _STORE_DIR.mkdir(mode=0o700, parents=True, exist_ok=True)
     try:
         os.chmod(_STORE_DIR, stat.S_IRWXU)  # 0o700
     except OSError:
-        pass
+        # #10 (round16): the chmod can genuinely fail (a dir owned by another
+        # uid after a botched restore, some network mounts). The token file is
+        # still written 0o600 so the secret bytes stay protected, but a loose
+        # store DIR widens the listing/symlink-swap surface. Fail closed but
+        # surface it ONCE so an operator on a problem filesystem is not blind to
+        # it — silence here previously hid a persistently world-readable dir.
+        if not _warned_loose_store_dir:
+            try:
+                mode = stat.S_IMODE(os.stat(_STORE_DIR).st_mode)
+                if mode & (stat.S_IRWXG | stat.S_IRWXO):
+                    print(
+                        f"mcp-stdio: warning: could not tighten {_STORE_DIR} to "
+                        f"0o700 (current mode {mode:#o}); cached tokens' directory "
+                        f"is group/other-accessible.",
+                        file=sys.stderr,
+                    )
+                    _warned_loose_store_dir = True
+            except OSError:
+                pass
+
+
+def _read_legacy_data() -> dict[str, Any] | None:
+    """Read the legacy token file via ``O_NOFOLLOW``.
+
+    Returns the parsed dict, or ``None`` if the file is absent, unreadable,
+    not valid JSON, or not a JSON object — so callers never write garbage (or
+    an attacker-redirected symlink target) over the XDG store.
+    """
+    try:
+        fd = os.open(_LEGACY_STORE_FILE, os.O_RDONLY | _O_NOFOLLOW)
+    except OSError:
+        return None
+    try:
+        with os.fdopen(fd, "r", encoding="utf-8") as f:
+            data = json.loads(f.read())
+    except (json.JSONDecodeError, OSError):
+        return None
+    return data if isinstance(data, dict) else None
 
 
 def _migrate_legacy_store() -> None:
@@ -159,10 +202,40 @@ def _migrate_legacy_store() -> None:
                 _LEGACY_STORE_FILE.unlink()
             except OSError:
                 pass
-        # else: leave the legacy file intact; a later run with a valid XDG
-        # store (or after the bogus placeholder is removed) reconciles it.
+        else:
+            # #8 (round16): the XDG store is an EMPTY placeholder (a stray
+            # `touch`, an interrupted external write, a backup restore) that
+            # otherwise shadows still-valid legacy tokens forever — _read_store
+            # would read {} and load_token would force a needless re-auth. Copy
+            # the legacy data through into the placeholder instead of stranding
+            # it. Re-stat under the same call so a placeholder that CONCURRENTLY
+            # gained real data (a locked save_token) is never clobbered; the
+            # residual TOCTOU is the documented one-time migration race above.
+            data = _read_legacy_data()
+            if data:
+                try:
+                    if _STORE_FILE.stat().st_size == 0:
+                        _write_store(data)
+                        try:
+                            _LEGACY_STORE_FILE.unlink()
+                        except OSError:
+                            pass
+                except OSError:
+                    # Unlocked read path: a failed stat/write must never crash
+                    # the read — leave the legacy file for a later run to retry.
+                    pass
     else:
         _ensure_store_dir()
+        # #9 (round16): re-assert 0o700 on the legacy DIR before exposing the
+        # secrets to a rename/copy-through, mirroring _ensure_store_dir's
+        # defensive re-chmod of the XDG dir. An older version (or permissive
+        # umask) may have created ~/.mcp-stdio/ group/other-readable; if the
+        # migration then fails partway the legacy tokens.json keeps living in a
+        # loose-mode dir. Best-effort — the 0o600 file mode is the primary guard.
+        try:
+            os.chmod(_LEGACY_STORE_DIR, stat.S_IRWXU)  # 0o700
+        except OSError:
+            pass
         # Tighten the legacy file's mode BEFORE moving it, so the secrets never
         # sit at the new XDG path with a looser (pre-0o600) mode, even briefly:
         # rename() preserves the source inode's permission bits.
@@ -186,22 +259,12 @@ def _migrate_legacy_store() -> None:
             if _STORE_FILE.exists() or not _LEGACY_STORE_FILE.exists():
                 pass  # another process won the migration race — leave it intact
             else:
-                # Read the legacy file via O_NOFOLLOW like every other read in
-                # this module, so a symlink swapped in at the legacy path cannot
-                # redirect the copy-through to read an attacker-chosen file.
-                data = None
-                try:
-                    fd = os.open(_LEGACY_STORE_FILE, os.O_RDONLY | _O_NOFOLLOW)
-                except OSError:
-                    fd = None
-                if fd is not None:
-                    try:
-                        with os.fdopen(fd, "r", encoding="utf-8") as f:
-                            data = json.loads(f.read())
-                    except (json.JSONDecodeError, OSError):
-                        data = None
+                # Read the legacy file via O_NOFOLLOW (see _read_legacy_data) so
+                # a symlink swapped in at the legacy path cannot redirect the
+                # copy-through to read an attacker-chosen file.
+                data = _read_legacy_data()
                 # Never write an empty/failed read over the target.
-                if isinstance(data, dict) and data:
+                if data:
                     written = False
                     try:
                         _write_store(data)

--- a/tests/test_token_store.py
+++ b/tests/test_token_store.py
@@ -734,10 +734,13 @@ class TestLegacyMigration:
         assert loaded.access_token == "new"
         assert not legacy_file.exists()
 
-    def test_empty_xdg_store_does_not_delete_legacy(self, tmp_path, monkeypatch):
-        """#4(round14): if the XDG store exists but is EMPTY (e.g. a 0-byte
-        placeholder from an interrupted write / backup restore), the legacy file
-        must NOT be unlinked — that would silently lose still-real tokens."""
+    def test_empty_xdg_store_copies_legacy_through(self, tmp_path, monkeypatch):
+        """#8(round16): if the XDG store exists but is EMPTY (a 0-byte
+        placeholder from an interrupted write / backup restore), the legacy
+        tokens must not be stranded behind it — they are copied through into the
+        placeholder (and load_token returns them), then the now-redundant legacy
+        file is removed. Earlier behaviour merely preserved the legacy file,
+        leaving the tokens permanently unreachable on the read path."""
         legacy_dir = tmp_path / "legacy"
         legacy_file = legacy_dir / "tokens.json"
         new_dir = tmp_path / "new"
@@ -753,10 +756,113 @@ class TestLegacyMigration:
         monkeypatch.setattr("mcp_stdio.token_store._LEGACY_STORE_DIR", legacy_dir)
         monkeypatch.setattr("mcp_stdio.token_store._LEGACY_STORE_FILE", legacy_file)
 
-        load_token("https://example.com/mcp")
-        # The legacy tokens survive (not deleted by the bogus empty XDG store).
-        assert legacy_file.exists()
+        loaded = load_token("https://example.com/mcp")
+        # The legacy token is now reachable (copied through into the placeholder).
+        assert loaded is not None and loaded.access_token == "old"
+        assert "old" in new_file.read_text()
+        # The legacy file is unlinked only because its data was safely migrated.
+        assert not legacy_file.exists()
+
+    def test_empty_xdg_copy_through_write_failure_preserves_legacy(
+        self, tmp_path, monkeypatch
+    ):
+        """#8(round16): if the empty-placeholder copy-through write FAILS (disk
+        full / read-only FS), load_token must not crash and the legacy file must
+        be preserved (not unlinked) for a later run to retry."""
+        legacy_dir = tmp_path / "legacy"
+        legacy_file = legacy_dir / "tokens.json"
+        new_dir = tmp_path / "new"
+        new_file = new_dir / "tokens.json"
+
+        legacy_dir.mkdir()
+        legacy_file.write_text('{"https://example.com/mcp": {"access_token": "old"}}')
+        new_dir.mkdir()
+        new_file.write_text("")
+
+        monkeypatch.setattr("mcp_stdio.token_store._STORE_DIR", new_dir)
+        monkeypatch.setattr("mcp_stdio.token_store._STORE_FILE", new_file)
+        monkeypatch.setattr("mcp_stdio.token_store._LEGACY_STORE_DIR", legacy_dir)
+        monkeypatch.setattr("mcp_stdio.token_store._LEGACY_STORE_FILE", legacy_file)
+
+        def failing_write(_data):
+            raise OSError(28, "No space left on device")
+
+        monkeypatch.setattr("mcp_stdio.token_store._write_store", failing_write)
+
+        loaded = load_token("https://example.com/mcp")  # must not raise
+        assert loaded is None  # placeholder still empty → no token
+        assert legacy_file.exists()  # legacy preserved for a later retry
         assert "old" in legacy_file.read_text()
+
+    @pytest.mark.skipif(
+        sys.platform == "win32",
+        reason="POSIX mode bits don't model the NTFS ACL Windows uses",
+    )
+    def test_migration_tightens_legacy_dir_permissions(self, tmp_path, monkeypatch):
+        """#9(round16): the legacy DIR is re-chmod'd to 0o700 before its secrets
+        are exposed to a rename/copy-through, mirroring _ensure_store_dir's
+        defensive re-chmod of the XDG dir."""
+        legacy_dir = tmp_path / "legacy"
+        legacy_file = legacy_dir / "tokens.json"
+        new_dir = tmp_path / "new"
+        new_file = new_dir / "tokens.json"
+
+        legacy_dir.mkdir(mode=0o755)
+        legacy_file.write_text('{"https://example.com/mcp": {"access_token": "old"}}')
+        # new_dir absent → migration takes the rename branch (chmods dir first)
+
+        monkeypatch.setattr("mcp_stdio.token_store._STORE_DIR", new_dir)
+        monkeypatch.setattr("mcp_stdio.token_store._STORE_FILE", new_file)
+        monkeypatch.setattr("mcp_stdio.token_store._LEGACY_STORE_DIR", legacy_dir)
+        monkeypatch.setattr("mcp_stdio.token_store._LEGACY_STORE_FILE", legacy_file)
+
+        chmodded: list[tuple[str, int]] = []
+        real_chmod = os.chmod
+
+        def spy_chmod(path, mode, *a, **k):
+            chmodded.append((os.fspath(path), mode))
+            return real_chmod(path, mode, *a, **k)
+
+        monkeypatch.setattr("mcp_stdio.token_store.os.chmod", spy_chmod)
+        load_token("https://example.com/mcp")
+
+        assert any(
+            p == str(legacy_dir) and m == stat.S_IRWXU for p, m in chmodded
+        ), f"legacy dir was not tightened to 0o700; chmod calls: {chmodded!r}"
+
+    @pytest.mark.skipif(
+        sys.platform == "win32",
+        reason="POSIX mode bits don't model the NTFS ACL Windows uses",
+    )
+    def test_ensure_store_dir_warns_once_on_unfixable_loose_perms(
+        self, tmp_path, monkeypatch, capsys
+    ):
+        """#10(round16): if the store dir cannot be tightened and stays group/
+        other-accessible, emit a single operator warning instead of failing
+        silently — and only once, not on every call."""
+        from mcp_stdio.token_store import _ensure_store_dir
+
+        store_dir = tmp_path / "store"
+        store_file = store_dir / "tokens.json"
+        store_dir.mkdir()
+        real_chmod = os.chmod
+        real_chmod(store_dir, 0o755)  # genuinely loose before we block chmod
+
+        monkeypatch.setattr("mcp_stdio.token_store._STORE_DIR", store_dir)
+        monkeypatch.setattr("mcp_stdio.token_store._STORE_FILE", store_file)
+        monkeypatch.setattr("mcp_stdio.token_store._warned_loose_store_dir", False)
+
+        def refuse_dir_chmod(path, mode, *a, **k):
+            if os.path.isdir(path):
+                raise OSError("cannot tighten dir on this filesystem")
+            return real_chmod(path, mode, *a, **k)
+
+        monkeypatch.setattr("mcp_stdio.token_store.os.chmod", refuse_dir_chmod)
+
+        _ensure_store_dir()
+        _ensure_store_dir()  # second call must NOT warn again
+        err = capsys.readouterr().err
+        assert err.count("group/other-accessible") == 1, err
 
     def test_legacy_unlink_failure_when_new_exists_does_not_crash(
         self, tmp_path, monkeypatch


### PR DESCRIPTION
## Overview

Three robustness fixes from the Opus 4.8 review (round 16): one LOW availability gap + two NIT security/observability hardenings.

## #8 — empty XDG placeholder strands legacy tokens (LOW)

When the XDG store exists but is an **empty 0-byte placeholder** (a stray `touch`, an interrupted external write, a backup restore that left a placeholder), `_migrate_legacy_store` preserved the legacy file but **never copied it through**. `_read_store` then kept reading `{}` and `load_token` returned `None` — forcing a needless re-auth while the real tokens sat permanently shadowed behind the placeholder in `~/.mcp-stdio/tokens.json`.

**Fix:** copy the legacy data through into the placeholder (re-`stat`'d immediately before the write so a concurrently-filled store is never clobbered), then remove the now-redundant legacy file. The O_NOFOLLOW copy-through read is factored into a shared `_read_legacy_data` helper reused by the existing EXDEV branch.

## #9 — legacy directory permissions never re-asserted (NIT)

`_ensure_store_dir` defensively re-chmods the XDG dir to 0o700, and the legacy *file* is tightened to 0o600 before the rename — but the legacy *directory* `~/.mcp-stdio/` was never re-asserted. An older version under a permissive umask could have created it group/other-readable; if the migration then fails partway, the legacy `tokens.json` keeps living in a loose-mode dir (the 0o600 file mode protects the bytes, but the listing/symlink-swap surface is wider).

**Fix:** best-effort `chmod(_LEGACY_STORE_DIR, 0o700)` before the rename/copy-through, mirroring the XDG dir's defensive re-chmod.

## #10 — silent chmod failure (NIT)

`_ensure_store_dir` swallowed a `chmod` `OSError` with a bare `pass`, hiding a persistently group/other-accessible store dir on a problem filesystem (a dir owned by another uid after a botched restore, some network mounts).

**Fix:** emit a single stderr warning when the dir is detectably still group/other-accessible after a failed tighten. Stays non-fatal; the 0o600 file mode remains the primary guard.

## Tests

- empty-placeholder copy-through: `load_token` returns the migrated token, legacy file unlinked
- copy-through write-failure preserves the legacy file and does not crash the unlocked read
- migration tightens the legacy dir to 0o700 (chmod spy)
- loose-dir warning emitted exactly once across two calls

51 token_store tests pass. No raw U+2028/U+2029/U+0085/U+FEFF bytes in source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)