### PR TITLE
fix(oauth): probe WWW-Authenticate on step-up re-discovery

### DIFF
--- a/src/mcp_stdio/oauth.py
+++ b/src/mcp_stdio/oauth.py
@@ -1581,7 +1581,17 @@ def step_up_authorize(
             issuer=cached.issuer,
         )
     else:
-        metadata = discover_oauth_metadata(server_url, client)
+        # Mirror ensure_token's discovery (the _probe_www_authenticate call
+        # above): probe the server's WWW-Authenticate for an RFC 9728
+        # resource_metadata hint FIRST, so a server publishing its PRM at a
+        # non-standard URL is discoverable on this step-up re-discovery path too,
+        # not only on initial auth. Every endpoint is still re-validated by the
+        # discovery validators, so no credential can be routed to an unsafe host.
+        # See #6 (round16).
+        www_authenticate = _probe_www_authenticate(server_url, client)
+        metadata = discover_oauth_metadata(
+            server_url, client, www_authenticate=www_authenticate
+        )
 
     resource_indicator = not (cached.no_resource_indicator if cached else False)
     return _run_authorization_flow(

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -2870,6 +2870,15 @@ class TestStepUpAuthorize:
         monkeypatch.setattr("mcp_stdio.token_store._STORE_FILE", store_file)
         self._drive_callback(monkeypatch)
 
+        # Step-up re-discovery now probes WWW-Authenticate first (#6 round16).
+        # A 401 with no PRM hint makes the probe a no-op so discovery falls
+        # through to the .well-known URLs below — but the request must be mocked
+        # or pytest_httpx's strict assert_all_requests_were_expected fails.
+        httpx_mock.add_response(
+            url=self.SERVER_URL,
+            method="POST",
+            status_code=401,
+        )
         httpx_mock.add_response(
             url="https://example.com/.well-known/oauth-protected-resource/mcp",
             status_code=404,

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -2766,6 +2766,60 @@ class TestStepUpAuthorize:
         # The grant is authorization_code (full flow), not refresh_token
         assert b"grant_type=authorization_code" in token_calls[0].content
 
+    def test_rediscovery_probes_www_authenticate_for_prm_hint(
+        self, tmp_path, monkeypatch
+    ):
+        """#6(round16): when the cached token lacks endpoints, step_up's
+        re-discovery probes WWW-Authenticate for an RFC 9728 PRM hint FIRST and
+        threads it into discovery — mirroring ensure_token — so a server
+        publishing PRM at a non-standard URL is discoverable on this path too,
+        not only on initial auth."""
+        store_file = tmp_path / "tokens.json"
+        monkeypatch.setattr("mcp_stdio.token_store._STORE_DIR", tmp_path)
+        monkeypatch.setattr("mcp_stdio.token_store._STORE_FILE", store_file)
+        from mcp_stdio.token_store import save_token
+
+        # Cached token has NO token/authorization endpoints → forces re-discovery.
+        save_token(
+            self.SERVER_URL,
+            TokenData(access_token="old_at", scope="mcp:connect"),
+        )
+
+        hint = 'Bearer resource_metadata="https://as.example/.well-known/custom"'
+        probe_calls: list[str] = []
+
+        def fake_probe(server_url, client):
+            probe_calls.append(server_url)
+            return hint
+
+        discover_hints: list[str | None] = []
+        sentinel_md = OAuthMetadata(
+            authorization_endpoint="https://as.example/authorize",
+            token_endpoint="https://as.example/token",
+        )
+
+        def fake_discover(server_url, client, www_authenticate=None):
+            discover_hints.append(www_authenticate)
+            return sentinel_md
+
+        flow_md: list[object] = []
+
+        def fake_flow(server_url, client, *, metadata, **kwargs):
+            flow_md.append(metadata)
+            return TokenData(access_token="upgraded_at")
+
+        monkeypatch.setattr("mcp_stdio.oauth._probe_www_authenticate", fake_probe)
+        monkeypatch.setattr("mcp_stdio.oauth.discover_oauth_metadata", fake_discover)
+        monkeypatch.setattr("mcp_stdio.oauth._run_authorization_flow", fake_flow)
+
+        client = httpx.Client()
+        data = step_up_authorize(self.SERVER_URL, client, "hr:read", timeout=5)
+
+        assert data.access_token == "upgraded_at"
+        assert probe_calls == [self.SERVER_URL]  # PRM probe ran
+        assert discover_hints == [hint]  # hint threaded into discovery
+        assert flow_md == [sentinel_md]  # discovered metadata used by the flow
+
     def test_respects_cached_no_resource_indicator(
         self, tmp_path, monkeypatch, httpx_mock
     ):


### PR DESCRIPTION
## Overview

A NIT robustness/consistency fix from the Opus 4.8 review (round 16, #6).

## The gap

When the cached `TokenData` lacks `token_endpoint` / `authorization_endpoint` (rare — the cache was cleared but a step-up was triggered), `step_up_authorize` fell back to `discover_oauth_metadata(server_url, client)` **without first probing** the server's `WWW-Authenticate` for an RFC 9728 `resource_metadata` hint — unlike `ensure_token`, which calls `_probe_www_authenticate` first. A server that publishes its PRM at a **non-standard URL** would therefore fail step-up re-discovery even though initial auth succeeded.

**Fix:** probe `WWW-Authenticate` first and thread the hint into discovery, mirroring `ensure_token`.

This is **not** a security change: every discovered endpoint is still re-validated by the discovery validators, so no credential can be routed to an unsafe host. It only widens what is discoverable on the step-up path to match the initial-auth path.

## Test

Step-up re-discovery (cached token without endpoints) probes `WWW-Authenticate` and passes the hint into `discover_oauth_metadata`.

248 oauth tests pass. No raw U+2028/U+2029/U+0085/U+FEFF bytes in source.

> Round-16 NITs #5 (cross-origin PRM federation — RFC 9728 §2 permits it; credential paths independently validated) and #7 (Basic-auth percent vs form-urlencoded — practically unreachable, fails closed, already documented in-code) were reviewed and accepted as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)