### PR TITLE
fix(token_store): warn on userinfo key collision; sort output; ENOENT is absent

### DIFF
--- a/src/mcp_stdio/token_store.py
+++ b/src/mcp_stdio/token_store.py
@@ -11,6 +11,7 @@ possible (acquisition failures are non-fatal by design).
 from __future__ import annotations
 
 import contextlib
+import errno
 import json
 import os
 import stat
@@ -38,6 +39,10 @@ _DEFAULT_PORTS = {"https": 443, "http": 80}
 # of secrets to an attacker-chosen target. 0 on platforms without it (Windows),
 # where the parent dir's 0o700 mode is the primary guard anyway.
 _O_NOFOLLOW = getattr(os, "O_NOFOLLOW", 0)
+
+# Set once if a server URL carrying embedded userinfo is normalized into a key,
+# so the credential-sharing warning is emitted only once per process.
+_warned_userinfo_key = False
 
 
 def _normalize_key(server_url: str) -> str:
@@ -70,6 +75,21 @@ def _normalize_key(server_url: str) -> str:
         port = parsed.port
     except ValueError:
         return server_url
+    # #7 (round17): userinfo is dropped from the key, so two URLs differing ONLY
+    # in embedded credentials (user:pass@) fold to the same slot and silently
+    # share / overwrite one cached token. MCP endpoints normally carry no
+    # userinfo, so this stays a deliberate fold — but warn ONCE so an operator
+    # using embedded credentials is not surprised by the token sharing.
+    if parsed.username or parsed.password:
+        global _warned_userinfo_key
+        if not _warned_userinfo_key:
+            print(
+                "mcp-stdio: warning: server URL contains embedded userinfo "
+                "(user:pass@host); it is dropped from the token-store key, so "
+                "URLs differing only in credentials share one cached token slot.",
+                file=sys.stderr,
+            )
+            _warned_userinfo_key = True
     # ``hostname`` strips the brackets from an IPv6 literal; re-add them so the
     # rebuilt netloc is a valid, re-parsable URL and ``[::1]:8443`` cannot
     # collide with another address whose final hextet equals a port.
@@ -340,7 +360,14 @@ def _read_store(*, for_write: bool = False) -> dict[str, Any]:
         # in — refused), EACCES, or a transient I/O error. On the write path
         # this must NOT degrade to {} (which a save would then clobber over the
         # unread store); raise so the caller aborts.
-        if for_write:
+        #
+        # ENOENT is the exception (#9 round17): the file vanished in the TOCTOU
+        # window between the exists() check above and this open (a concurrent
+        # migration unlink, or an external tool). A vanished file is semantically
+        # ABSENT, not unreadable — return {} so the write proceeds from a clean
+        # slate, instead of aborting the save with a misleading "could not be
+        # read" warning. There is nothing to clobber.
+        if for_write and e.errno != errno.ENOENT:
             raise _StoreUnreadable(str(e)) from e
         return {}
     try:
@@ -376,7 +403,10 @@ def _write_store(data: dict[str, Any]) -> None:
     loss (the file data fsync alone does not guarantee the rename survives).
     """
     _ensure_store_dir()
-    payload = json.dumps(data, indent=2).encode("utf-8")
+    # sort_keys for stable, diff-friendly on-disk output (#8 round17): without it
+    # the per-server key order follows dict-insertion order and churns across the
+    # read-modify-write saves, complicating inspection/diffing for no benefit.
+    payload = json.dumps(data, indent=2, sort_keys=True).encode("utf-8")
     # Per-write unique temp name. PID alone is not enough: when the advisory
     # lock degrades to a no-op (lock fs unavailable), two THREADS in one process
     # share the PID and would otherwise pick the same temp path and clobber each

--- a/tests/test_token_store.py
+++ b/tests/test_token_store.py
@@ -1,5 +1,6 @@
 """Tests for mcp_stdio.token_store module."""
 
+import errno
 import json
 import os
 import stat
@@ -489,6 +490,27 @@ class TestNormalizeKey:
         # Default port still folds out, brackets retained.
         assert _normalize_key("https://[::1]:443/mcp") == "https://[::1]/mcp"
 
+    def test_userinfo_dropped_and_warned_once(self, monkeypatch, capsys):
+        """#7(round17): embedded userinfo is dropped from the key (two URLs
+        differing only in credentials fold to one slot), and a one-time stderr
+        warning surfaces the silent token-sharing — emitted only once."""
+        monkeypatch.setattr("mcp_stdio.token_store._warned_userinfo_key", False)
+        k1 = _normalize_key("https://userA:passA@example.com/mcp")
+        k2 = _normalize_key("https://userB:passB@example.com/mcp")
+        # userinfo dropped → both fold to the same credential-free key
+        assert k1 == k2 == "https://example.com/mcp"
+        err = capsys.readouterr().err
+        assert err.count("embedded userinfo") == 1  # warned exactly once
+        # A second normalize with userinfo does not warn again.
+        _normalize_key("https://userC:passC@example.com/mcp")
+        assert "embedded userinfo" not in capsys.readouterr().err
+
+    def test_no_userinfo_no_warning(self, monkeypatch, capsys):
+        """A normal URL (no userinfo) must not emit the warning."""
+        monkeypatch.setattr("mcp_stdio.token_store._warned_userinfo_key", False)
+        _normalize_key("https://example.com/mcp")
+        assert capsys.readouterr().err == ""
+
 
 class TestKeyNormalizationInStore:
     def _patch(self, tmp_path, monkeypatch):
@@ -523,6 +545,43 @@ class TestKeyNormalizationInStore:
         delete_token("https://x.com/mcp/")
         assert load_token("https://x.com/mcp") is None
         assert load_token("https://x.com/mcp/") is None
+
+    def test_write_store_output_is_key_sorted(self, tmp_path, monkeypatch):
+        """#8(round17): on-disk tokens.json keys are sorted for stable,
+        diff-friendly output regardless of save order."""
+        store_file = self._patch(tmp_path, monkeypatch)
+        save_token("https://zebra.com/mcp", TokenData(access_token="z"))
+        save_token("https://alpha.com/mcp", TokenData(access_token="a"))
+        save_token("https://middle.com/mcp", TokenData(access_token="m"))
+        keys = list(json.loads(store_file.read_text()).keys())
+        assert keys == sorted(keys)
+
+    def test_write_path_enoent_treated_as_absent_not_unreadable(
+        self, tmp_path, monkeypatch, capsys
+    ):
+        """#9(round17): if the store vanishes in the TOCTOU window between
+        exists() and os.open on the WRITE path, treat it as absent (the save
+        proceeds from {}) rather than _StoreUnreadable (which would abort the
+        save with a misleading 'could not be read' warning)."""
+        store_file = self._patch(tmp_path, monkeypatch)
+        save_token("https://a.com/mcp", TokenData(access_token="a"))  # store exists
+
+        real_open = os.open
+
+        def vanishing_read_open(path, flags, *a, **k):
+            # Simulate ENOENT only on the read-open of the store file (no O_CREAT);
+            # the temp-file write-open (O_CREAT) and dir fsync proceed normally.
+            if os.fspath(path) == str(store_file) and not (flags & os.O_CREAT):
+                raise OSError(errno.ENOENT, "No such file or directory")
+            return real_open(path, flags, *a, **k)
+
+        monkeypatch.setattr("mcp_stdio.token_store.os.open", vanishing_read_open)
+        save_token("https://b.com/mcp", TokenData(access_token="b"))  # must NOT abort
+        monkeypatch.setattr("mcp_stdio.token_store.os.open", real_open)
+
+        # The save proceeded (treated the vanished store as absent), so b persisted.
+        assert load_token("https://b.com/mcp").access_token == "b"
+        assert "could not be read" not in capsys.readouterr().err
 
 
 class TestLegacyMigration:


### PR DESCRIPTION
## Overview

round-17 findings: one LOW (silent credential sharing) + two NITs (diff churn, spurious warning). All from the Opus 4.8 review.

## #7 — userinfo dropped from store key (LOW)

`_normalize_key` drops URL userinfo (via `.hostname`), so `https://userA:passA@example.com/mcp` and `https://userB:passB@example.com/mcp` fold to the **same** key `https://example.com/mcp`. Two operators/configs pointing at the same host+path with different embedded credentials would share one cached token slot — a save under one credential overwrites the other, and `load_token` could serve operator B the token minted for operator A.

MCP endpoints normally carry no userinfo, so the fold stays a deliberate tradeoff — but it now emits a **one-time stderr warning** (mirroring the `_warned_loose_store_dir` pattern) so an operator using embedded credentials is not silently surprised by the token sharing.

## #8 — nondeterministic store output (NIT)

`_write_store` serialized with `json.dumps(data, indent=2)` and no `sort_keys`, so per-server key order followed dict-insertion order and churned across the read-modify-write saves. Now `sort_keys=True` → stable, diff-friendly output. No functional impact.

## #9 — transient ENOENT aborts the save (NIT)

A transient ENOENT in the TOCTOU window between `_STORE_FILE.exists()` and `os.open` on the **write** path (a concurrent migration unlink, an external tool) was mapped to `_StoreUnreadable`, aborting the save with a misleading "could not be read" warning. A vanished file is semantically **absent**, not unreadable (there is nothing to clobber), so on the write path ENOENT now returns `{}` and the save proceeds from a clean slate. Every other `OSError` (ELOOP / EACCES / I-O) still raises, so a genuinely unread store is never overwritten.

## Tests

- userinfo dropped + warned exactly once (and silent without userinfo)
- on-disk `tokens.json` keys are sorted
- a simulated write-path ENOENT lets the save proceed instead of aborting

55 token_store tests pass. No raw U+2028/U+2029/U+0085/U+FEFF bytes in source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)