### PR TITLE
fix(relay): gate MCP-Protocol-Version strip on a parse-authoritative initialize check

### DIFF
--- a/src/mcp_stdio/relay.py
+++ b/src/mcp_stdio/relay.py
@@ -249,8 +249,35 @@ def _looks_like_initialize(line: str) -> bool:
     A cheap pre-filter so the relay only attempts to capture the negotiated
     protocol version from initialize responses. The trailing quote in the
     pattern means ``notifications/initialized`` does not match.
+
+    Pre-filter ONLY: this is a substring regex, so a ``tools/call`` whose nested
+    ``arguments`` merely contains a ``"method":"initialize"`` key also matches.
+    That is fine for the response-capture use (over-triggering it is harmless —
+    a non-initialize response carries no ``result.protocolVersion``), but a
+    request-header MUTATION must NOT key off this; use ``_is_initialize_request``.
     """
     return bool(_INITIALIZE_METHOD_RE.search(line))
+
+
+def _is_initialize_request(line: str) -> bool:
+    """Authoritatively confirm ``line`` is a JSON-RPC ``initialize`` REQUEST.
+
+    Parses the line and checks the TOP-LEVEL ``method``, mirroring
+    ``_normalize_null_arguments`` / ``_detect_paginated_list``. Unlike the
+    ``_looks_like_initialize`` regex pre-filter, a ``tools/call`` whose nested
+    ``arguments`` contains a ``"method":"initialize"`` substring does NOT
+    false-positive here — so this is safe to gate the request-header strip on,
+    where a false positive would wrongly drop MCP-Protocol-Version from a real
+    tool call and break it against a strict 2025-06-18 server. The cheap regex
+    still short-circuits the parse for the common non-matching line.
+    """
+    if not _INITIALIZE_METHOD_RE.search(line):
+        return False
+    try:
+        msg = json.loads(line)
+    except (json.JSONDecodeError, TypeError):
+        return False
+    return isinstance(msg, dict) and msg.get("method") == "initialize"
 
 
 def _extract_protocol_version(payload: str) -> str | None:
@@ -1645,7 +1672,9 @@ def run(
                     # header is sent rather than guessing — a server that both
                     # omits it and enforces the header would be self-contradictory.
                     capture_init = _looks_like_initialize(content)
-                    if capture_init and protocol_version is not None:
+                    if protocol_version is not None and _is_initialize_request(
+                        content
+                    ):
                         # An initialize request IS the (re)negotiation and predates a
                         # known version, so it must not advertise the prior one
                         # (2025-06-18: the header carries the negotiated version and
@@ -1654,7 +1683,10 @@ def run(
                         # on ``protocol_version is not None`` means we only drop the
                         # relay's OWN injected header — on a cold-start initialize
                         # (no version yet) a user-pinned ``-H MCP-Protocol-Version``
-                        # is left intact. Mcp-Session-Id is untouched.
+                        # is left intact. Mcp-Session-Id is untouched. The strip is
+                        # gated on the PARSE-authoritative check (not the regex
+                        # capture_init) so a tools/call whose arguments contains a
+                        # "method":"initialize" key keeps its header. See #3 (round18).
                         h = {
                             k: v
                             for k, v in h.items()

--- a/tests/test_relay.py
+++ b/tests/test_relay.py
@@ -1690,6 +1690,35 @@ class TestProtocolVersionHeader:
         # (b) the next request carries the relay-injected negotiated version
         assert reqs[1].headers["mcp-protocol-version"] == "2025-06-18"
 
+    def test_tools_call_with_nested_method_initialize_keeps_header(self, httpx_mock):
+        """#3(round18): a tools/call whose nested ``arguments`` contains a
+        ``"method":"initialize"`` key must NOT be misread as an initialize
+        request — the substring matches the cheap regex, but the header strip is
+        gated on a parse-authoritative top-level method check, so the negotiated
+        MCP-Protocol-Version is PRESERVED on the tool call (a regression would
+        strip it and break the call against a strict 2025-06-18 server)."""
+        httpx_mock.add_response(
+            text='{"jsonrpc":"2.0","result":{"protocolVersion":"2025-06-18"},"id":1}',
+            headers={"content-type": "application/json"},
+        )
+        httpx_mock.add_response(
+            text='{"jsonrpc":"2.0","result":{},"id":2}',
+            headers={"content-type": "application/json"},
+        )
+        # The tool call's arguments legitimately carry a "method" key whose value
+        # is "initialize" (e.g. an HTTP/API-wrapper tool) — top-level method is
+        # tools/call, so the header must survive.
+        self._run_with_stdin(
+            [
+                '{"jsonrpc":"2.0","method":"initialize","id":1}',
+                '{"jsonrpc":"2.0","method":"tools/call","id":2,"params":'
+                '{"name":"http","arguments":{"method":"initialize","url":"https://x"}}}',
+            ]
+        )
+        reqs = httpx_mock.get_requests()
+        # The tools/call is a post-init request → carries the negotiated header.
+        assert reqs[1].headers["mcp-protocol-version"] == "2025-06-18"
+
     def test_initialized_notification_carries_header(self, httpx_mock):
         """notifications/initialized is the first subsequent request — must carry it."""
         httpx_mock.add_response(


### PR DESCRIPTION
## Overview

A MEDIUM correctness fix from the Opus 4.8 review (round 18, #3).

## The bug

The post-initialize **header strip** was driven solely by `_looks_like_initialize` — a bare substring regex `"method"\s*:\s*"initialize"` — with **no authoritative parse**, unlike `_normalize_null_arguments` (`msg.get("method") != "tools/call"`) and `_detect_paginated_list` (`method not in PAGINATED_LIST_METHODS`), which both verify the **top-level** method.

A perfectly valid `tools/call` whose nested `arguments` carries a key named `method` with value `initialize` (e.g. an HTTP/API-wrapper tool with a `method` parameter) serializes the raw substring `"method": "initialize"` at the **top level** of the JSON line (arguments are nested objects, not string-escaped). So the regex matched and — once a protocol version had been negotiated (steady state) — the relay **wrongly stripped `MCP-Protocol-Version`** from that tool call's request headers. Against a strict 2025-06-18 Streamable HTTP server that returns 400 when the negotiated header is absent on a post-init request, the compliant client's tool call then **fails with 400**.

(The response-side `capture_init` effect is harmless: `_extract_protocol_version` only adopts a *string* `result.protocolVersion`, which a tools/call response lacks. Only the request-header strip needed a backstop.)

## The fix

Add `_is_initialize_request()` — parses the line and confirms the **top-level** `method == "initialize"` (the cheap regex still short-circuits the parse for the common non-matching line). Gate the header strip on it instead of the regex. `capture_init` keeps the cheap regex for the harmless response-capture path.

## Test

A `tools/call` whose `arguments` contains `"method":"initialize"` now **preserves** the negotiated `MCP-Protocol-Version` header rather than having it stripped.

**329 relay tests pass** (3 skipped). No raw U+2028/U+2029/U+0085/U+FEFF bytes in source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)