### PR TITLE
fix(cli): float timeout defaults; sync CLAUDE.md OAuth description

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,8 +38,8 @@ Four modules under `src/mcp_stdio/`:
   - `run_sse()` — SSE transport (MCP 2024-11-05 legacy). Spawns a daemon reader thread that maintains a long-lived `GET /sse` connection, parses `endpoint`/`message` events per the WHATWG SSE spec, and resolves the POST endpoint URL (possibly relative). The main thread reads stdin and POSTs to that endpoint. Auto-reconnects on stream disconnect.
   - Both paths enforce the MCP cancellation spec's canceller-side SHOULD via a shared `_CancelTracker` + `_emit` gate: ids seen in `notifications/cancelled` on stdin are tracked with a 60 s TTL, and any late JSON-RPC response for a tracked id is dropped before it reaches stdout. Disable with `--no-cancel-filter`.
   - Signal handlers (`signal.signal`) are set from the main thread only — the SSE reader runs in a daemon thread so pytest tests must drive `run_sse` from the main thread.
-- **`cli.py`** — argparse-based CLI. Builds headers, resolves `MCP_BEARER_TOKEN` / `MCP_OAUTH_CLIENT_ID` env vars, runs OAuth flow before relay if `--oauth` is set, and dispatches to `run()` or `run_sse()` based on `--transport`.
-- **`oauth.py`** — OAuth 2.1 client: RFC 9728/8414 discovery, RFC 7591 dynamic client registration, RFC 7636 PKCE, RFC 8707 resource indicators, authorization code flow with localhost callback server, token exchange and refresh.
+- **`cli.py`** — argparse-based CLI. Builds headers, resolves `MCP_BEARER_TOKEN` / `MCP_OAUTH_CLIENT_ID` env vars, runs the OAuth flow before relay if `--oauth` or `--oauth-device` is set, and dispatches to `run()` or `run_sse()` based on `--transport`.
+- **`oauth.py`** — OAuth 2.1 client: RFC 9728/8414 discovery, RFC 7591 dynamic client registration, RFC 7636 PKCE, RFC 8707 resource indicators, authorization code flow with localhost callback server, RFC 8628 device authorization grant, RFC 9470 step-up authorization, token exchange and refresh.
 - **`token_store.py`** — Token persistence in `~/.config/mcp-stdio/tokens.json` (0o600). Stores per-server-URL tokens with client credentials and endpoint URLs for refresh. Migrates legacy `~/.mcp-stdio/` tokens on first read.
 
 Entry point: `mcp-stdio` command → `mcp_stdio.cli:main`.

--- a/src/mcp_stdio/cli.py
+++ b/src/mcp_stdio/cli.py
@@ -264,13 +264,17 @@ def main() -> None:
     parser.add_argument(
         "--timeout-connect",
         type=_positive_float,
-        default=10,
+        # Float defaults (#6 round18): argparse applies ``type`` only to argv
+        # strings, never to the default object, so an int default would leave
+        # args.timeout_connect an int when the flag is omitted. httpx tolerates
+        # both, but keep the attribute's type consistent with the validator.
+        default=10.0,
         help="Connection timeout in seconds, > 0 (default: 10)",
     )
     parser.add_argument(
         "--timeout-read",
         type=_positive_float,
-        default=120,
+        default=120.0,
         help="Read timeout in seconds, > 0 (default: 120)",
     )
     parser.add_argument(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -141,6 +141,22 @@ class TestMain:
             assert kwargs.kwargs["timeout_connect"] == 5.0
             assert kwargs.kwargs["timeout_read"] == 60.0
 
+    def test_default_timeouts_are_floats(self):
+        """#6(round18): with the timeout flags omitted the defaults must be
+        floats — argparse applies ``type`` only to argv strings, not to the
+        default object, so an int default would leak through. Keep the attribute
+        type consistent with the _positive_float validator."""
+        with (
+            patch("sys.argv", ["mcp-stdio", "https://example.com/mcp"]),
+            patch("mcp_stdio.cli.run") as mock_run,
+        ):
+            main()
+            kwargs = mock_run.call_args
+            assert kwargs.kwargs["timeout_connect"] == 10.0
+            assert isinstance(kwargs.kwargs["timeout_connect"], float)
+            assert kwargs.kwargs["timeout_read"] == 120.0
+            assert isinstance(kwargs.kwargs["timeout_read"], float)
+
     def test_oauth_refresh_leeway_default(self, monkeypatch):
         """#56: --oauth-refresh-leeway defaults to 60 s when env var unset and flag absent."""
         monkeypatch.delenv("MCP_OAUTH_REFRESH_LEEWAY", raising=False)


### PR DESCRIPTION
## Overview

Three NITs from the Opus 4.8 review (round 18): one code consistency fix + two internal-doc accuracy fixes.

## #6 — int timeout defaults bypass the validator (NIT)

`--timeout-connect` (default `10`) and `--timeout-read` (default `120`) declared `type=_positive_float`, but argparse applies `type` only to **argv strings**, never to the default object — so when the flags are omitted `args.timeout_connect` / `args.timeout_read` were **ints**, not floats. Harmless (httpx, `run()`, `run_sse()`, `check_connection()` all accept ints) but a latent inconsistency with the validator and with the deliberate string-default pattern of `--oauth-refresh-leeway`. Defaults are now `10.0` / `120.0`.

## #9 — CLAUDE.md OAuth trigger (NIT, internal doc)

CLAUDE.md said the OAuth flow runs "if `--oauth` is set", but cli.py gates it on `--oauth or --oauth-device`. Reworded to include `--oauth-device`.

## #10 — CLAUDE.md oauth.py summary (NIT, internal doc)

The oauth.py architecture summary omitted the **RFC 8628 device authorization grant** and **RFC 9470 step-up authorization**, both shipped flows. Added so the internal map reflects the current feature set.

## Test

The omitted-flag timeout defaults are asserted to be floats.

74 cli tests pass. No raw U+2028/U+2029/U+0085/U+FEFF bytes in source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)