### PR TITLE
fix(relay): don't adopt a session id echoed on a rejected response; strengthen cancel-tracker test

### DIFF
--- a/src/mcp_stdio/relay.py
+++ b/src/mcp_stdio/relay.py
@@ -1717,12 +1717,25 @@ def run(
                     # fire its recovery branch, which is gated on session_id).
                     continue
 
-                # Adopt a server-supplied session id from THIS response before the
+                # Adopt a server-rotated session id from THIS response before the
                 # 401/403 recovery branches rebuild their retry headers, so a server
                 # that rotates/assigns Mcp-Session-Id alongside an auth challenge is
                 # honoured on the retry rather than re-sending the stale one. (The
                 # 404 branch re-establishes its own fresh session below.)
-                if result.session_id:
+                #
+                # Gate it (#1 round19): adopt only when this response is a SUCCESS
+                # or a 401/403 whose recovery retry actually needs the rotated id.
+                # A terminal 4xx/5xx with no recovery (e.g. a bare 500) that merely
+                # echoes a session id must NOT poison session_id for the next stdin
+                # line — the relay would otherwise send the next request an id the
+                # server just rejected.
+                feeds_recovery = (
+                    (result.status_code == 401 and token_refresher is not None)
+                    or (result.status_code == 403 and scope_upgrader is not None)
+                )
+                if result.session_id and (
+                    result.status_code < 400 or feeds_recovery
+                ):
                     session_id = result.session_id
 
                 # Recovery is single-pass and ordered auth-before-session: the three
@@ -1823,9 +1836,6 @@ def run(
                     if result is None:
                         continue
 
-                if result.session_id:
-                    session_id = result.session_id
-
                 # Fall-through error for any unhandled 4xx/5xx so the MCP client
                 # never hangs waiting for a response. 200 bodies were already
                 # streamed by _post_and_stream. 202 is reserved for the client's own
@@ -1837,7 +1847,20 @@ def run(
                 # the empty-200 guard in _post_and_stream. A 202 to a NOTIFICATION
                 # (no id) stays correctly silent. See #11 and #4 (round16).
                 req_202_hang = result.status_code == 202 and req_has_id
-                if result.status_code >= 400 or req_202_hang:
+                is_error = result.status_code >= 400 or req_202_hang
+
+                # Adopt a server-rotated session id only from a NON-error response.
+                # A 4xx/5xx (or a non-compliant 202-to-request we are about to
+                # error) can still echo an mcp-session-id header; carrying that
+                # into the next request would send an id the server JUST rejected.
+                # The next line's 404 recovery would self-heal it, but don't carry
+                # known-bad state forward. The inline 401/403 re-adoptions above
+                # stay unconditional — they feed the very next chained recovery
+                # dispatch, not the next stdin line. See #1 (round19).
+                if result.session_id and not is_error:
+                    session_id = result.session_id
+
+                if is_error:
                     log(f"upstream returned HTTP {result.status_code}")
                     if req_has_id:
                         # On a 429/503 whose retries were exhausted / over-cap,

--- a/tests/test_relay.py
+++ b/tests/test_relay.py
@@ -775,6 +775,43 @@ class TestRun:
         req2 = httpx_mock.get_requests()[1]
         assert req2.headers["mcp-session-id"] == "sess-123"
 
+    def test_error_response_session_id_not_adopted(self, httpx_mock):
+        """#1(round19): a session id echoed on a 4xx/5xx error response must NOT
+        be carried into the next request — the relay would otherwise send an id
+        the server just rejected. Only a non-error response rotates session_id."""
+        # Line 1: 200 establishes session "good".
+        httpx_mock.add_response(
+            text='{"jsonrpc":"2.0","result":{},"id":1}',
+            headers={"content-type": "application/json", "mcp-session-id": "good"},
+        )
+        # Line 2: 500 echoes a DIFFERENT session id — must be ignored (the relay
+        # synthesizes an error and does not adopt the rejected id).
+        httpx_mock.add_response(
+            status_code=500,
+            text="",
+            headers={
+                "content-type": "application/json",
+                "mcp-session-id": "bad-rotated",
+            },
+        )
+        # Line 3: 200 — must still carry "good", not "bad-rotated".
+        httpx_mock.add_response(
+            text='{"jsonrpc":"2.0","result":{},"id":3}',
+            headers={"content-type": "application/json"},
+        )
+        self._run_with_stdin(
+            httpx_mock,
+            [
+                '{"jsonrpc":"2.0","method":"init","id":1}',
+                '{"jsonrpc":"2.0","method":"call","id":2}',
+                '{"jsonrpc":"2.0","method":"call","id":3}',
+            ],
+        )
+        reqs = httpx_mock.get_requests()
+        assert reqs[1].headers.get("mcp-session-id") == "good"
+        # The 500's "bad-rotated" was NOT adopted — request 3 still sends "good".
+        assert reqs[2].headers.get("mcp-session-id") == "good"
+
     def test_session_expired_triggers_reinitialize_then_retry(self, httpx_mock):
         """Reproduces the 404 -> 400 hang from FastMCP StreamableHTTP.
 
@@ -4867,6 +4904,45 @@ class TestCancelTracker:
         assert not errors, f"threads raised: {errors!r}"
         for i in range(800):
             assert t.contains(i)
+
+    def test_consume_under_contention_is_exactly_once(self):
+        """#12(round19): consume() must return True EXACTLY once per id even when
+        many threads race on the SAME ids — the lock makes pop-and-check atomic.
+        A broken/removed lock could let two threads both pop-and-return-True for
+        one id (a double drop). Unlike test_thread_safety (disjoint ranges, which
+        passes even without the lock), this contends on shared ids and asserts an
+        invariant only a correct lock preserves: total True count == id count."""
+        t = _CancelTracker()
+        n_ids = 500
+        for i in range(n_ids):
+            t.add(i)
+
+        true_counts: list[int] = []
+        errors: list[BaseException] = []
+        barrier = threading.Barrier(8)
+
+        def worker() -> None:
+            try:
+                barrier.wait()  # release all threads together for max contention
+                local = sum(1 for i in range(n_ids) if t.consume(i))
+                true_counts.append(local)
+            except BaseException as e:  # noqa: BLE001
+                errors.append(e)
+
+        threads = [threading.Thread(target=worker) for _ in range(8)]
+        for th in threads:
+            th.start()
+        for th in threads:
+            th.join()
+
+        assert not errors, f"threads raised: {errors!r}"
+        # Every id consumed by exactly one thread → the True counts sum to n_ids.
+        assert sum(true_counts) == n_ids, (
+            f"expected exactly {n_ids} successful consumes (one per id), "
+            f"got {sum(true_counts)} across {true_counts!r}"
+        )
+        # And every id is gone afterwards.
+        assert all(not t.contains(i) for i in range(n_ids))
 
 
 class TestExtractCancelId:


### PR DESCRIPTION
## Overview

round-19: one LOW state-hygiene fix (#1) + one test-quality improvement (#12).

## #1 — session id adopted from a rejected response (LOW)

Both session-id adoptions in `run()` — the early one (before the recovery branches, so a 401/403 retry carries the rotated id) and the final post-branch one — ran **unconditionally**. So a terminal 4xx/5xx (e.g. a bare 500), or a 404 retry that itself returns 4xx, that merely **echoes** an `mcp-session-id` header would update `session_id` to a value the server just **rejected**. The next stdin line then sends that rejected id forward (the next 404 recovery self-heals it, but it carries known-bad state for one request).

**Fix:** gate both adoptions — adopt only from a **success** (`<400`) response, or from a **401/403** whose recovery retry genuinely needs the rotated id (those branches re-dispatch with it). A 404 already resets `session_id`, and a terminal error no longer poisons it. The inline 401/403 re-adoptions (which feed the immediate chained retry, not the next stdin line) stay unconditional.

## #12 — vacuous thread-safety test (NIT)

`test_thread_safety` had 8 threads writing **disjoint** id ranges, so it would pass even if `_CancelTracker`'s lock were removed entirely (CPython's GIL makes individual dict ops atomic). Added a **contended** test: 8 threads race `consume()` on the **same** ids and assert the lock's real invariant — each id is consumed **exactly once** (total `True` count == id count), which a torn pop-and-check would violate.

## Test

A 500 echoing a session id does not carry it into the next request; the existing 200 / 401 / 403 / 404 session-rotation tests still pass.

**331 relay tests pass** (3 skipped). No raw U+2028/U+2029/U+0085/U+FEFF bytes in source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)