### PR TITLE
feat(oauth): enforce RFC 9207 missing-iss rejection; validate fallback endpoints

### DIFF
--- a/src/mcp_stdio/oauth.py
+++ b/src/mcp_stdio/oauth.py
@@ -79,6 +79,9 @@ class OAuthMetadata:
     # RFC 8414 issuer identifier — used to validate the RFC 9207 ``iss``
     # parameter on the authorization response (AS mix-up defence).
     issuer: str | None = None
+    # RFC 9207 §3 metadata flag. When the AS advertises this true, RFC 9207 §2.4
+    # makes the client MUST reject an authorization response that lacks ``iss``.
+    iss_parameter_supported: bool = False
 
 
 # ---------------------------------------------------------------------------
@@ -445,6 +448,14 @@ def _fetch_authorization_server_metadata(
                 ),
                 token_endpoint_auth_methods_supported=methods if isinstance(methods, list) else None,
                 issuer=issuer or auth_server_url,
+                # RFC 9207 §3: a true value makes a missing `iss` on the
+                # authorization response a MUST-reject (§2.4). Coerce strictly to
+                # bool so a non-bool JSON value cannot accidentally enable the
+                # stricter check off a truthy string.
+                iss_parameter_supported=(
+                    data.get("authorization_response_iss_parameter_supported")
+                    is True
+                ),
             )
     except Exception:
         pass
@@ -567,10 +578,30 @@ def discover_oauth_metadata(
     # wrong origin entirely. When no PRM AS was found, auth_server_url == base,
     # so this reduces to the previous MCP-host defaults.
     as_base = auth_server_url.rstrip("/")
+    # #5 (round19): re-validate the synthesized endpoints through the same #13
+    # policy the metadata path applies (no cleartext / no userinfo), so this
+    # fallback enforces the credential-leak guard too. as_base was already
+    # validated upstream (_validate_auth_server_url or _authorization_base_url),
+    # so this is defense-in-depth — but if that upstream check ever weakened we
+    # must not silently POST code + client_secret + PKCE verifier to an unsafe
+    # endpoint. Hard-fail instead.
+    authorize_ep = _validate_endpoint_url(
+        f"{as_base}/authorize", label="default authorization_endpoint"
+    )
+    token_ep = _validate_endpoint_url(
+        f"{as_base}/token", label="default token_endpoint"
+    )
+    if not authorize_ep or not token_ep:
+        raise ValueError(
+            f"refusing to synthesize default OAuth endpoints from an unsafe "
+            f"authorization-server base {as_base!r}"
+        )
     return OAuthMetadata(
-        authorization_endpoint=f"{as_base}/authorize",
-        token_endpoint=f"{as_base}/token",
-        registration_endpoint=f"{as_base}/register",
+        authorization_endpoint=authorize_ep,
+        token_endpoint=token_ep,
+        registration_endpoint=_validate_endpoint_url(
+            f"{as_base}/register", label="default registration_endpoint"
+        ),
         # No metadata was validated on this fallback, so it is the LEAST
         # trustworthy discovery outcome — keep the RFC 9207 iss mix-up check
         # active by pinning the issuer to the base the endpoints derive from.
@@ -710,7 +741,11 @@ def generate_pkce() -> tuple[str, str]:
 
     Returns (code_verifier, code_challenge).
     """
-    verifier = secrets.token_urlsafe(64)[:96]  # ~86 chars, capped well within 43-128
+    # token_urlsafe(64) is always 86 chars (64 bytes base64url, unpadded) = 512
+    # bits of entropy, within the RFC 7636 §4.1 43-128 range and well above the
+    # OAuth 2.1 256-bit floor. (#6 round19: a former [:96] slice was a dead
+    # no-op — 86 < 96 — and is dropped; nothing is truncated.)
+    verifier = secrets.token_urlsafe(64)
     digest = hashlib.sha256(verifier.encode("ascii")).digest()
     challenge = base64.urlsafe_b64encode(digest).rstrip(b"=").decode("ascii")
     return verifier, challenge
@@ -817,8 +852,12 @@ def _parse_token_response(resp: httpx.Response) -> dict[str, Any]:
     content_type = resp.headers.get("content-type", "")
     if "application/x-www-form-urlencoded" in content_type:
         parsed = dict(parse_qs(resp.text, keep_blank_values=True))
-        # parse_qs returns lists; unwrap single values
-        result = {k: v[0] if len(v) == 1 else v for k, v in parsed.items()}
+        # parse_qs returns lists; take the FIRST value for every key (#8 round19).
+        # A non-conformant duplicate (e.g. access_token=a&access_token=b) must NOT
+        # leave a LIST in result — that would flow into TokenData.access_token or
+        # be str()-ed by _sanitize_oauth_error. No real provider emits duplicates;
+        # fail closed to a string. (load_token's type check is the final backstop.)
+        result = {k: (v[0] if v else "") for k, v in parsed.items()}
         _raise_for_body_error(result)
         return result
 
@@ -1205,8 +1244,19 @@ def _run_authorization_flow(
     # stops a code issued by AS-A from being exchanged at AS-B. Both values come
     # from the same AS (its metadata `issuer` and its callback `iss`) so they are
     # byte-identical; an exact compare (per §2.4, no normalisation) is correct.
-    # Only checked when both are present; PKCE + state already cover the common
-    # attacks, so this is defence-in-depth.
+    #
+    # §2.4 has a SECOND MUST: a client MUST reject a response that OMITS `iss`
+    # from an AS that advertises iss support (the RFC 9207 §3 metadata flag) —
+    # otherwise a mix-up attacker could simply strip `iss` to silence the compare
+    # above. Enforce that when the AS advertised support. (When it did NOT
+    # advertise, a missing `iss` is accepted: PKCE + state already cover the
+    # common attacks, so this whole check is defence-in-depth.) See #4 (round19).
+    if metadata.iss_parameter_supported and cb_result.iss is None:
+        raise RuntimeError(
+            "OAuth issuer missing (RFC 9207 §2.4) — the authorization server "
+            "advertises iss support but its response omitted iss; possible AS "
+            "mix-up attack"
+        )
     if (
         cb_result.iss is not None
         and metadata.issuer

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -335,6 +335,39 @@ class TestDiscoverMetadata:
         assert meta.authorization_endpoint == "https://api.example.com/auth"
         assert meta.registration_endpoint is None  # not in response
 
+    def test_iss_parameter_supported_parsed(self, httpx_mock):
+        """#4(round19): the RFC 9207 §3 flag is parsed into OAuthMetadata so the
+        §2.4 missing-iss rejection can fire; a non-true value stays False."""
+        self._mock_no_prm(httpx_mock)
+        httpx_mock.add_response(
+            url="https://api.example.com/.well-known/oauth-authorization-server",
+            json={
+                "issuer": "https://api.example.com",
+                "authorization_endpoint": "https://api.example.com/auth",
+                "token_endpoint": "https://api.example.com/tok",
+                "authorization_response_iss_parameter_supported": True,
+            },
+        )
+        client = httpx.Client()
+        meta = discover_oauth_metadata("https://api.example.com/mcp", client)
+        assert meta.iss_parameter_supported is True
+
+    def test_iss_parameter_supported_defaults_false(self, httpx_mock):
+        """Absent the RFC 9207 §3 flag, iss_parameter_supported is False — a
+        response without iss is then accepted (present-only check)."""
+        self._mock_no_prm(httpx_mock)
+        httpx_mock.add_response(
+            url="https://api.example.com/.well-known/oauth-authorization-server",
+            json={
+                "issuer": "https://api.example.com",
+                "authorization_endpoint": "https://api.example.com/auth",
+                "token_endpoint": "https://api.example.com/tok",
+            },
+        )
+        client = httpx.Client()
+        meta = discover_oauth_metadata("https://api.example.com/mcp", client)
+        assert meta.iss_parameter_supported is False
+
     def test_partial_metadata_uses_defaults(self, httpx_mock):
         """Server returns metadata with only some endpoints."""
         self._mock_no_prm(httpx_mock)
@@ -1606,6 +1639,21 @@ class TestParseTokenResponse:
         assert result["access_token"] == "at123"
         assert result["token_type"] == "bearer"
         assert result["scope"] == "repo"
+
+    def test_form_urlencoded_duplicate_key_collapses_to_first(self, httpx_mock):
+        """#8(round19): a non-conformant duplicated form field must collapse to
+        its first value (a string), never leave a LIST that would flow into
+        TokenData.access_token or be str()-ed by the error sanitiser."""
+        httpx_mock.add_response(
+            url="https://example.com/token",
+            text="access_token=first&access_token=second&token_type=bearer",
+            headers={"content-type": "application/x-www-form-urlencoded"},
+        )
+        client = httpx.Client()
+        resp = client.post("https://example.com/token")
+        result = _parse_token_response(resp)
+        assert result["access_token"] == "first"
+        assert isinstance(result["access_token"], str)
 
     def test_http_200_with_error_body(self, httpx_mock):
         """GitHub legacy: HTTP 200 with error in body."""
@@ -3661,6 +3709,57 @@ class TestRfc9207IssValidation:
             "https://ex.com/mcp",
             client,
             metadata=self.META,
+            cached=None,
+            client_id_override="cid",
+            timeout=5,
+        )
+        assert data.access_token == "at"
+
+    # RFC 9207 §2.4 second MUST: reject a missing iss from an AS that advertises
+    # support (authorization_response_iss_parameter_supported). #4/#7 (round19).
+    META_ISS_SUPPORTED = OAuthMetadata(
+        authorization_endpoint="https://ex.com/authorize",
+        token_endpoint="https://ex.com/token",
+        issuer="https://ex.com",
+        iss_parameter_supported=True,
+    )
+
+    def test_missing_iss_rejected_when_as_advertises_support(self, monkeypatch):
+        """An AS that advertised iss support but whose response OMITS iss must be
+        rejected (a mix-up attacker could otherwise strip iss to silence the
+        compare)."""
+        monkeypatch.setattr("mcp_stdio.oauth.webbrowser.open", self._driver(""))
+        client = httpx.Client()
+        with pytest.raises(RuntimeError, match="issuer missing"):
+            _run_authorization_flow(
+                "https://ex.com/mcp",
+                client,
+                metadata=self.META_ISS_SUPPORTED,
+                cached=None,
+                client_id_override="cid",
+                timeout=5,
+            )
+
+    def test_present_iss_accepted_when_as_advertises_support(
+        self, httpx_mock, tmp_path, monkeypatch
+    ):
+        """When the AS advertises iss support and the response carries a matching
+        iss, the flow proceeds normally."""
+        store_file = tmp_path / "tokens.json"
+        monkeypatch.setattr("mcp_stdio.token_store._STORE_DIR", tmp_path)
+        monkeypatch.setattr("mcp_stdio.token_store._STORE_FILE", store_file)
+        httpx_mock.add_response(
+            url="https://ex.com/token",
+            json={"access_token": "at", "token_type": "Bearer"},
+        )
+        monkeypatch.setattr(
+            "mcp_stdio.oauth.webbrowser.open", self._driver("iss=https://ex.com")
+        )
+        client = httpx.Client()
+        data = _run_authorization_flow(
+            "https://ex.com/mcp",
+            client,
+            metadata=self.META_ISS_SUPPORTED,
             cached=None,
             client_id_override="cid",
             timeout=5,


### PR DESCRIPTION
## Overview

round-19 OAuth findings: one RFC-9207 conformance fix (#4/#7) + three hardening/clarity NITs (#5, #6, #8).

## #4/#7 — RFC 9207 §2.4 missing-iss rejection (LOW)

The iss mix-up check only fired when the authorization response **carried** an `iss`. But RFC 9207 §2.4 has a **second MUST**: a client MUST reject a response that **omits** `iss` from an AS that advertises iss support — otherwise a mix-up attacker simply strips `iss` to silence the compare. Support is signalled by the RFC 9207 §3 metadata flag `authorization_response_iss_parameter_supported`, which the code never parsed.

**Fix:** parse that flag into `OAuthMetadata.iss_parameter_supported` (strict `is True`), and when set, reject a callback whose `iss` is absent. When the AS does **not** advertise support, a missing `iss` is still accepted (PKCE + state cover the practical attacks, so this is defence-in-depth either way).

## #5 — fallback endpoints not re-validated (NIT)

The phase-3 default-endpoint fallback synthesized `/authorize` and `/token` from the AS base **without** `_validate_endpoint_url`, unlike the metadata path. The base was already validated upstream, so this is defence-in-depth — now re-validated, and **hard-fails** (`ValueError`) if somehow unsafe, so a future weakening of the upstream check can't silently POST `code` + `client_secret` + PKCE verifier to a cleartext / userinfo host.

## #6 — dead PKCE slice (NIT)

`secrets.token_urlsafe(64)[:96]` never truncates (the value is always 86 chars). Dropped the slice and corrected the comment; entropy (512 bits) and length (within RFC 7636 43–128) unchanged.

## #8 — multi-valued form fields (NIT)

`_parse_token_response` kept multi-valued form-urlencoded keys as **lists**. A non-conformant duplicate (`access_token=a&access_token=b`) would put a list into `TokenData` / the error sanitiser. Now every key collapses to its first value (a string); no real provider emits duplicates and `load_token`'s type check is the backstop.

## Tests

- missing-iss **rejected** / present-iss **accepted** when the AS advertises support
- the §3 flag parses (true / default-false)
- duplicate form key collapses to its first value

**255 oauth tests pass** (0 teardown errors). No raw U+2028/U+2029/U+0085/U+FEFF bytes in source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)