### PR TITLE
fix(token_store): re-tighten a pre-existing lock file to 0o600

### DIFF
--- a/src/mcp_stdio/token_store.py
+++ b/src/mcp_stdio/token_store.py
@@ -469,6 +469,18 @@ def _store_lock() -> Iterator[None]:
     except OSError:
         yield
         return
+    # #9 (round19): the 0o600 mode above applies only on CREATION. Re-tighten a
+    # pre-existing lock file via the fd (fchmod, anchored to this inode like
+    # _read_store) so a lock file left group/other-writable — e.g. pre-planted by
+    # a local user once the dir-tightening already failed — cannot become the
+    # handle another user holds LOCK_EX on to stall every save_token. Best-effort:
+    # the dir's 0o700 mode is the primary guard and a chmod failure must not block.
+    _fchmod = getattr(os, "fchmod", None)
+    if _fchmod is not None:
+        try:
+            _fchmod(fd, stat.S_IRUSR | stat.S_IWUSR)  # 0o600, fd-anchored
+        except OSError:
+            pass
     locked = False
     try:
         try:

--- a/tests/test_token_store.py
+++ b/tests/test_token_store.py
@@ -101,6 +101,31 @@ class TestLoadSaveDelete:
         assert mode & stat.S_IRWXG == 0  # no group access
         assert mode & stat.S_IRWXO == 0  # no other access
 
+    @pytest.mark.skipif(
+        sys.platform == "win32",
+        reason="POSIX mode bits don't model the NTFS ACL Windows uses",
+    )
+    def test_lock_file_retightened_to_0600(self, tmp_path, monkeypatch):
+        """#9(round19): a PRE-EXISTING loose-mode lock file is re-tightened to
+        0o600 via fchmod when _store_lock opens it — the O_CREAT mode only
+        applies on creation, so a pre-planted group/other-writable lock file
+        (a local-DoS handle) is closed off, mirroring the store-file re-chmod."""
+        store_file = tmp_path / "tokens.json"
+        lock_file = tmp_path / "tokens.json.lock"
+        monkeypatch.setattr("mcp_stdio.token_store._STORE_DIR", tmp_path)
+        monkeypatch.setattr("mcp_stdio.token_store._STORE_FILE", store_file)
+
+        # Pre-plant a loose-mode lock file (the case the O_CREAT mode misses).
+        lock_file.write_text("")
+        os.chmod(lock_file, 0o666)
+
+        # save_token acquires _store_lock, which re-tightens the lock fd.
+        save_token("https://a.com/mcp", TokenData(access_token="a"))
+
+        mode = stat.S_IMODE(os.stat(lock_file).st_mode)
+        assert mode & stat.S_IRWXG == 0  # no group access
+        assert mode & stat.S_IRWXO == 0  # no other access
+
     def test_multiple_servers(self, tmp_path, monkeypatch):
         store_file = tmp_path / "tokens.json"
         monkeypatch.setattr("mcp_stdio.token_store._STORE_DIR", tmp_path)


### PR DESCRIPTION
## Overview

A LOW local-DoS hardening from the Opus 4.8 review (round 19, #9).

## The gap

`_store_lock` opens `tokens.json.lock` with `os.O_WRONLY | os.O_CREAT | _O_NOFOLLOW` and mode `0o600` — but the mode applies only **on creation**. Unlike `_read_store` (fd-anchored `fchmod`) and `_write_store` (`O_EXCL`), the lock open had **neither** `O_EXCL` nor a post-open `fchmod`. If a local unprivileged user pre-plants `~/.config/mcp-stdio/tokens.json.lock` group/other-writable (which requires the store dir to already be loose — the documented chmod-failure case), they could open the same file and hold `fcntl.flock(LOCK_EX)` indefinitely, **stalling every `save_token` / `delete_token`** (each waits on `LOCK_EX`).

**Fix:** best-effort `fchmod(fd, 0o600)` right after open, mirroring the store-fd tightening in `_read_store`. The lock file holds no secrets, so this is denial-of-availability, not disclosure, and the dir's `0o700` mode is the primary guard — hence best-effort and non-blocking.

## Test

A pre-planted `0o666` lock file is re-tightened to `0o600` after `save_token`.

56 token_store tests pass. No raw U+2028/U+2029/U+0085/U+FEFF bytes in source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)