### PR TITLE
docs(cli): note --oauth --check is interactive on a cold cache; test step-up redirect guard

### DIFF
--- a/src/mcp_stdio/cli.py
+++ b/src/mcp_stdio/cli.py
@@ -329,7 +329,13 @@ def main() -> None:
     parser.add_argument(
         "--check",
         action="store_true",
-        help="Check connection to the MCP server and exit",
+        help=(
+            "Check connection to the MCP server and exit. Note: combined with "
+            "--oauth / --oauth-device on a cold token cache this runs the FULL "
+            "interactive auth first (may open a browser or print a device code "
+            "and wait), so the check verifies the authenticated path end-to-end "
+            "rather than being a purely non-interactive probe."
+        ),
     )
     parser.add_argument(
         # Deprecated alias for --check; hidden from --help.
@@ -428,6 +434,12 @@ def main() -> None:
     token_refresher: Callable[[], dict[str, str] | None] | None = None
     scope_upgrader: Callable[[str], dict[str, str] | None] | None = None
     if args.oauth or args.oauth_device:
+        # NOTE (#10 round19): this runs BEFORE the --check branch below, and
+        # ensure_token only short-circuits on a valid cached/refreshable token.
+        # So `--oauth --check` on a COLD cache performs the full interactive auth
+        # (browser / device code, blocking up to the flow timeout) — by design,
+        # so a --check of the authenticated path is verified end-to-end. This is
+        # documented in the --check help text; it is not a non-interactive probe.
         from .oauth import ensure_token
 
         client = httpx.Client(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -877,6 +877,11 @@ class TestBuildScopeUpgrader:
         assert out["Authorization"] == "Bearer upgraded"
         assert out["X-Base"] == "1"
         assert _SpyClient.instances[-1].closed
+        # #11(round19): the RFC 9470 step-up path carries the same credential-leak
+        # exposure as refresh, so its client must pin follow_redirects=False too
+        # (an AS-controlled token endpoint could otherwise 302 the credential POST
+        # to a cleartext / cross-origin host). Symmetric with the refresher test.
+        assert _SpyClient.instances[-1].kwargs.get("follow_redirects") is False
 
     def test_returns_none_when_step_up_raises_and_closes(self, monkeypatch, capsys):
         _SpyClient.instances.clear()


### PR DESCRIPTION
## Overview

Two LOW findings from the Opus 4.8 review (round 19): one UX documentation note + one security-test symmetry fix.

## #10 — `--oauth --check` is interactive on a cold cache (LOW, doc)

The OAuth block runs **before** the `--check` branch, and `ensure_token` only short-circuits on a valid cached/refreshable token. So `mcp-stdio --oauth --check URL` on a **cold** cache performs the full interactive auth — it can open a browser or print a device code and **block** up to the flow timeout — rather than being a non-interactive health probe.

This is the intended semantics (a `--check` of the authenticated path should verify auth end-to-end), so this PR **documents** it in the `--check` help text and at the OAuth block, rather than changing behaviour.

## #11 — step-up redirect guard not asserted (LOW, coverage)

`TestBuildScopeUpgrader.test_returns_bearer_headers_and_closes_client` asserted Bearer headers + client close but — unlike the parallel **refresher** test — never asserted `follow_redirects=False`. The RFC 9470 step-up path carries the **same** 302-credential-leak exposure as refresh (an AS-controlled token endpoint could 302 the credential POST to a cleartext / cross-origin host). Added the symmetric assertion so a regression dropping the guard on the step-up client is caught.

74 cli tests pass. No raw U+2028/U+2029/U+0085/U+FEFF bytes in source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)