### PR TITLE
fix(oauth): neutral callback page for a bare hit; correct RFC 9728 §3.3 comment

### DIFF
--- a/src/mcp_stdio/oauth.py
+++ b/src/mcp_stdio/oauth.py
@@ -518,9 +518,17 @@ def discover_oauth_metadata(
             prm_data = resp.json()
         except Exception:
             continue
-        # RFC 9728 §3.3: the `resource` field in the PRM response should match
-        # the server URL. Log a warning on mismatch but continue — strict
-        # rejection would break servers that normalise URLs differently.
+        # RFC 9728 §3.3 actually says the `resource` value MUST be identical to
+        # the protected-resource identifier and, if it is not, "the data
+        # contained in the response MUST NOT be used" (an impersonation guard).
+        # We deliberately downgrade that to warn-and-continue: strict rejection
+        # would break servers that normalise the identifier differently (trailing
+        # slash, case, default port) than the operator-supplied server_url. The
+        # impersonation risk the MUST guards against is independently closed
+        # downstream — every `authorization_servers` candidate is re-checked by
+        # _validate_auth_server_url (#13) before any credential is sent, and the
+        # PRM URL itself derives from the operator-trusted server_url — so the
+        # softening does not widen the trust boundary, only the citation's letter.
         prm_resource = prm_data.get("resource")
         if prm_resource and prm_resource.rstrip("/") != server_url.rstrip("/"):
             log(
@@ -828,8 +836,18 @@ def _make_callback_handler(
             if result.error:
                 msg = html.escape(result.error)
                 body = f"<h1>Authorization failed</h1><p>{msg}</p>"
-            else:
+            elif result.auth_code is not None:
                 body = "<h1>Authorization successful</h1><p>You can close this tab.</p>"
+            else:
+                # #2 (round21): a bare /callback hit with neither code nor error
+                # (a browser prefetch, a manual GET) captured nothing — the main
+                # loop is still waiting. Don't render "successful": a misleading
+                # success page could let an attacker convince a victim that a
+                # stray request "worked". Show a neutral waiting page instead.
+                body = (
+                    "<h1>Waiting for authorization...</h1>"
+                    "<p>No authorization response was received on this request.</p>"
+                )
             self.wfile.write(body.encode())
 
         def log_message(self, format: str, *args: Any) -> None:

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -1747,6 +1747,39 @@ class TestCallbackServer:
         assert cb_result.auth_code == "test_code_123"
         assert cb_result.state == "test_state"
 
+    def test_bare_callback_hit_does_not_render_success(self):
+        """#2(round21): a /callback hit carrying neither code nor error (a
+        browser prefetch, a manual GET) captured nothing — the page must NOT say
+        'Authorization successful' (which could mislead a phishing victim), and
+        auth_code/error stay None so the main loop keeps waiting."""
+        cb_result = CallbackResult()
+        handler_cls = _make_callback_handler(cb_result)
+
+        from http.server import HTTPServer
+
+        server = HTTPServer(("127.0.0.1", 0), handler_cls)
+        port = server.server_address[1]
+        done = threading.Event()
+
+        def serve():
+            while not done.is_set():
+                server.handle_request()
+
+        t = threading.Thread(target=serve, daemon=True)
+        t.start()
+        time.sleep(0.3)
+
+        resp = httpx.get(f"http://127.0.0.1:{port}/callback")
+        done.set()
+        server.server_close()
+
+        assert resp.status_code == 200
+        assert "Authorization successful" not in resp.text
+        assert "Waiting for authorization" in resp.text
+        # Nothing captured → the main loop must keep blocking.
+        assert cb_result.auth_code is None
+        assert cb_result.error is None
+
     def test_receives_error(self):
         """Server sends an OAuth error via callback."""
         cb_result = CallbackResult()


### PR DESCRIPTION
## Overview

round-21: one LOW anti-phishing hardening (#2) + one RFC-citation correction (#3).

## #2 — misleading "successful" page on a bare callback hit (LOW)

The callback handler rendered **"Authorization successful"** for a bare `/callback` hit carrying neither `code` nor `error` (a browser prefetch, a manual GET). No security bypass — the state / PKCE / iss gates are all downstream, and `auth_code` stays `None` so the main loop keeps waiting — but the cosmetic success page could let an attacker convince a victim that a stray request "worked". Now the success HTML is gated on `result.auth_code is not None`; a bare hit shows a neutral **"Waiting for authorization..."** page instead.

## #3 — RFC 9728 §3.3 comment understated the spec (NIT)

The PRM resource-mismatch comment said §3.3 "should match". The verified RFC text is stronger: *"If these values are not identical, the data contained in the response MUST NOT be used"* (an impersonation guard). We deliberately keep **warn-and-continue** (strict rejection would break servers that normalise the identifier differently — trailing slash / case / default port), and the impersonation risk is independently closed downstream by the per-candidate `_validate_auth_server_url` re-check (#13). Corrected the comment to state the MUST and explain why the softening is safe, rather than understating the spec.

## Test

A bare `/callback` hit renders the neutral waiting page (not "successful") and captures nothing.

**259 oauth tests pass.** No raw U+2028/U+2029/U+0085/U+FEFF/U+2026 bytes in source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)