### PR TITLE
fix(token_store): fail soft when the store write fails in save/delete

### DIFF
--- a/src/mcp_stdio/token_store.py
+++ b/src/mcp_stdio/token_store.py
@@ -591,7 +591,21 @@ def save_token(server_url: str, data: TokenData) -> None:
         if server_url != key:
             store.pop(server_url, None)
         store[key] = asdict(data)
-        _write_store(store)
+        try:
+            _write_store(store)
+        except OSError as e:
+            # #4 (round21): a write failure (full / read-only FS, permission)
+            # must fail SOFT, mirroring the _StoreUnreadable read path above. The
+            # token is simply not cached — the caller re-auths next time — rather
+            # than the OSError propagating up the OAuth/relay path. This also fixes
+            # a worse case: a refresh whose save fails would otherwise propagate
+            # out of refresh_cached_token and make the relay emit an auth error
+            # even though the freshly refreshed token was perfectly usable.
+            print(
+                f"warning: could not write token store ({e}); token not cached, "
+                f"will re-authenticate next time",
+                file=sys.stderr,
+            )
 
 
 def delete_token(server_url: str) -> None:
@@ -615,4 +629,15 @@ def delete_token(server_url: str) -> None:
                 del store[key]
                 removed = True
         if removed:
-            _write_store(store)
+            try:
+                _write_store(store)
+            except OSError as e:
+                # Fail soft like save_token (#4 round21): a failed delete leaves
+                # the (stale) entry in place — a stale cached token at worst —
+                # rather than propagating an OSError up the caller. A later
+                # successful write reconciles it.
+                print(
+                    f"warning: could not write token store ({e}); "
+                    f"token not deleted",
+                    file=sys.stderr,
+                )

--- a/tests/test_token_store.py
+++ b/tests/test_token_store.py
@@ -137,6 +137,43 @@ class TestLoadSaveDelete:
         assert load_token("https://a.com/mcp").access_token == "tok-a"
         assert load_token("https://b.com/mcp").access_token == "tok-b"
 
+    def test_save_token_write_failure_is_fail_soft(
+        self, tmp_path, monkeypatch, capsys
+    ):
+        """#4(round21): a _write_store OSError (full / read-only FS) must NOT
+        propagate out of save_token — it warns and returns, so a refresh whose
+        cache-write fails still yields a usable token instead of crashing the
+        OAuth/relay path. Symmetric with the _StoreUnreadable read path."""
+        store_file = tmp_path / "tokens.json"
+        monkeypatch.setattr("mcp_stdio.token_store._STORE_DIR", tmp_path)
+        monkeypatch.setattr("mcp_stdio.token_store._STORE_FILE", store_file)
+
+        def failing_write(_data):
+            raise OSError(28, "No space left on device")
+
+        monkeypatch.setattr("mcp_stdio.token_store._write_store", failing_write)
+        # Must NOT raise.
+        save_token("https://a.com/mcp", TokenData(access_token="a"))
+        assert "could not write token store" in capsys.readouterr().err
+
+    def test_delete_token_write_failure_is_fail_soft(
+        self, tmp_path, monkeypatch, capsys
+    ):
+        """A failed delete write must also fail soft (leaves the stale entry)."""
+        store_file = tmp_path / "tokens.json"
+        monkeypatch.setattr("mcp_stdio.token_store._STORE_DIR", tmp_path)
+        monkeypatch.setattr("mcp_stdio.token_store._STORE_FILE", store_file)
+
+        save_token("https://a.com/mcp", TokenData(access_token="a"))
+
+        def failing_write(_data):
+            raise OSError(30, "Read-only file system")
+
+        monkeypatch.setattr("mcp_stdio.token_store._write_store", failing_write)
+        # Must NOT raise.
+        delete_token("https://a.com/mcp")
+        assert "could not write token store" in capsys.readouterr().err
+
     def test_corrupt_file(self, tmp_path, monkeypatch):
         store_file = tmp_path / "tokens.json"
         monkeypatch.setattr("mcp_stdio.token_store._STORE_DIR", tmp_path)


### PR DESCRIPTION
## Overview

A LOW robustness fix from the Opus 4.8 review (round 21, #4).

## The asymmetry

`save_token` / `delete_token` caught the **read** path's `_StoreUnreadable` and degraded gracefully (skip + warn), but the trailing `_write_store(store)` propagated any `OSError` (full / read-only FS, permission) **straight out to the caller**.

Worse than the asymmetry: `refresh_cached_token` calls `save_token` *after* a **successful** refresh, so a cache-write failure there propagated out of `refresh_cached_token` → the cli refresher's `except` → `None` → and the relay emitted an **authentication error even though the freshly refreshed token was perfectly usable**.

## Fix

Wrap the trailing `_write_store` in both functions in `try/except OSError` that warns to stderr and returns: the token is simply **not cached** (re-auth next time) / **not deleted** (a stale entry at worst), never an uncaught crash up the OAuth/relay path. The relay's callers already tolerate an uncached token.

## Tests

`save_token` and `delete_token` both swallow a `_write_store` `OSError`, warn, and do not raise. The full token_store + oauth + cli suites pass (390) — no caller relied on the propagation.

No raw U+2028/U+2029/U+0085/U+FEFF bytes in source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)