### PR TITLE
fix(cli): apply the CR/LF/NUL header ban to OAuth-acquired access tokens

### DIFF
--- a/src/mcp_stdio/cli.py
+++ b/src/mcp_stdio/cli.py
@@ -50,6 +50,22 @@ _HEADER_NAME_RE = re.compile(r"^[!#$%&'*+\-.^_`|~0-9A-Za-z]+$")
 _HEADER_VALUE_FORBIDDEN = ("\r", "\n", "\0")
 
 
+def _bearer_header_value(token: str) -> str:
+    """Build a ``Bearer <token>`` Authorization value, rejecting CR/LF/NUL.
+
+    An OAuth authorization server is LESS trusted than the operator, so an
+    AS-supplied access token gets the same control-character ban as ``-H``
+    values and ``--bearer-token`` (#14): a token carrying CR/LF could otherwise
+    inject / split request headers on the wire. Raises ValueError on a forbidden
+    character so the caller can fail the relevant flow. See #5 (round21).
+    """
+    if any(c in token for c in _HEADER_VALUE_FORBIDDEN):
+        raise ValueError(
+            "OAuth access token contains a forbidden control character (CR/LF/NUL)"
+        )
+    return f"Bearer {token}"
+
+
 def _parse_header(header: str) -> tuple[str, str]:
     """Parse a header string 'Key: Value' into a tuple.
 
@@ -115,7 +131,7 @@ def _build_token_refresher(
             if data is None:
                 return None
             new_headers = dict(headers)
-            new_headers["Authorization"] = f"Bearer {data.access_token}"
+            new_headers["Authorization"] = _bearer_header_value(data.access_token)
             return new_headers
         except Exception as e:
             # Mirror upgrader(): a refresh failure beyond the network call
@@ -160,13 +176,13 @@ def _build_scope_upgrader(
         )
         try:
             data = step_up_authorize(server_url, client, required_scope)
+            new_headers = dict(headers)
+            new_headers["Authorization"] = _bearer_header_value(data.access_token)
         except Exception as e:
             print(f"error: step-up authorization failed: {e}", file=sys.stderr)
             return None
         finally:
             client.close()
-        new_headers = dict(headers)
-        new_headers["Authorization"] = f"Bearer {data.access_token}"
         return new_headers
 
     return upgrader
@@ -481,7 +497,15 @@ def main() -> None:
                 )
             for existing in overridden:
                 del headers[existing]
-            headers["Authorization"] = f"Bearer {token_data.access_token}"
+            try:
+                headers["Authorization"] = _bearer_header_value(
+                    token_data.access_token
+                )
+            except ValueError as e:
+                # The AS handed us a token with CR/LF/NUL — fail startup clearly
+                # rather than splitting headers on the wire (#5 round21).
+                print(f"error: {e}", file=sys.stderr)
+                sys.exit(1)
             # The relay-loop 401/403 recovery callbacks are unused by the
             # one-shot --check / --test probe (check_connection never refreshes
             # or steps up), so only build them on the real relay path. See #15.

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5,12 +5,29 @@ from unittest.mock import patch
 import pytest
 
 from mcp_stdio.cli import (
+    _bearer_header_value,
     _build_scope_upgrader,
     _build_token_refresher,
     _parse_header,
     main,
 )
 from mcp_stdio.token_store import TokenData
+
+
+class TestBearerHeaderValue:
+    """#5(round21): an OAuth AS-supplied token gets the same CR/LF/NUL ban as
+    -H values and --bearer-token, so it cannot inject/split request headers."""
+
+    def test_clean_token_builds_header(self):
+        assert _bearer_header_value("abc.def-123") == "Bearer abc.def-123"
+
+    @pytest.mark.parametrize(
+        "bad",
+        ["tok\r\nX-Inject: 1", "tok\nX: 1", "tok\rX: 1", "tok\x00hidden"],
+    )
+    def test_control_char_token_rejected(self, bad):
+        with pytest.raises(ValueError, match="forbidden control character"):
+            _bearer_header_value(bad)
 
 
 class TestParseHeader:
@@ -831,6 +848,25 @@ class TestBuildTokenRefresher:
         assert _SpyClient.instances and _SpyClient.instances[-1].closed
         # AS-controlled redirects must not be auto-followed on the OAuth flow.
         assert _SpyClient.instances[-1].kwargs.get("follow_redirects") is False
+
+    def test_refresh_token_with_control_char_degrades_to_none(
+        self, monkeypatch, capsys
+    ):
+        """#5(round21): a refreshed token carrying CR/LF/NUL must NOT reach the
+        wire — the refresher degrades to None (relay emits an auth error) rather
+        than building an injectable Authorization header."""
+        _SpyClient.instances.clear()
+        monkeypatch.setattr("mcp_stdio.cli.httpx.Client", _SpyClient)
+        monkeypatch.setattr(
+            "mcp_stdio.oauth.refresh_cached_token",
+            lambda url, client: TokenData(access_token="bad\r\nX-Inject: 1"),
+        )
+        refresher = _build_token_refresher(
+            "https://example.com/mcp", {}, 10, 120
+        )
+        assert refresher() is None
+        assert _SpyClient.instances[-1].closed
+        assert "token refresh failed" in capsys.readouterr().err
 
     def test_returns_none_on_refresh_failure_and_closes(self, monkeypatch):
         _SpyClient.instances.clear()


### PR DESCRIPTION
## Overview

A NIT header-injection hardening from the Opus 4.8 review (round 21, #5).

## The gap

`-H` values and `--bearer-token` are screened for CR/LF/NUL (#14), but an OAuth **AS-supplied access token** was interpolated into `Authorization: Bearer <token>` **unchecked**. An authorization server is less trusted than the operator, so a token carrying CR/LF could split / inject request headers on the wire.

## Fix

A `_bearer_header_value()` helper screens the token against `_HEADER_VALUE_FORBIDDEN` and builds the `Bearer` header through it at **all three** OAuth sites:
- the **initial** flow → fail startup with a clear error (the AS is misbehaving)
- the relay **refresher** / step-up **upgrader** closures → degrade to `None` (the relay emits an auth error and keeps the session alive) rather than crashing or injecting

## Tests

- `_bearer_header_value` rejects CR / LF / NUL and builds a clean header for a normal token
- a refreshed token carrying a control char degrades the refresher to `None`

80 cli tests pass. No raw U+2028/U+2029/U+0085/U+FEFF bytes in source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)