### PR TITLE
fix(oauth): clear error on non-JSON token body; ignore non-positive expires_in

### DIFF
--- a/src/mcp_stdio/oauth.py
+++ b/src/mcp_stdio/oauth.py
@@ -890,7 +890,20 @@ def _parse_token_response(resp: httpx.Response) -> dict[str, Any]:
         _raise_for_body_error(result)
         return result
 
-    result = resp.json()
+    # #8 (round22): a 200 with any other content-type (text/plain, text/html, or
+    # a missing content-type over a non-JSON body) would otherwise raise a raw
+    # json.JSONDecodeError out of resp.json() — fine on the refresh path (caught,
+    # degrades to None) but it propagates as an opaque error on the auth-code
+    # path. Raise a clear RuntimeError naming the unexpected content-type instead,
+    # matching the explicit-error style of the missing-access_token guard below.
+    try:
+        result = resp.json()
+    except ValueError as exc:  # json.JSONDecodeError is a ValueError subclass
+        ct = resp.headers.get("content-type", "<none>")
+        raise RuntimeError(
+            f"token endpoint returned a non-JSON, non-form-urlencoded body "
+            f"(content-type {ct!r})"
+        ) from exc
     _raise_for_body_error(result)
     return result
 
@@ -1036,9 +1049,21 @@ def _token_response_to_data(
         # form-urlencoded ones (GitHub-legacy path via _parse_token_response).
         # Coerce defensively so a string value cannot crash the whole flow.
         try:
-            expires_at = time.time() + float(raw["expires_in"])
+            expires_in = float(raw["expires_in"])
         except (TypeError, ValueError):
-            expires_at = None
+            expires_in = None
+        # #9 (round22): a non-positive expires_in (0 or negative — malformed or
+        # hostile) would make expires_at <= now, so ensure_token would treat the
+        # FRESHLY obtained token as already expired and immediately re-refresh /
+        # re-run the whole flow instead of using it once. Treat it as "no expiry
+        # advertised" (expires_at = None) and warn, rather than burning the token.
+        if expires_in is not None and expires_in > 0:
+            expires_at = time.time() + expires_in
+        elif expires_in is not None:
+            log(
+                f"warning: ignoring non-positive expires_in ({expires_in!r}); "
+                f"treating the token as having no advertised expiry"
+            )
 
     # `.get(default)` only substitutes when the key is ABSENT; a provider that
     # returns an explicit `"token_type": null` (or a non-string) would otherwise

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -1628,11 +1628,42 @@ class TestTokenResponseToData:
         )
         assert data.token_type == "Bearer"
 
+    @pytest.mark.parametrize("bad", [0, -100, "0", "-5"])
+    def test_non_positive_expires_in_treated_as_no_expiry(self, bad, capsys):
+        """#9(round22): expires_in of 0 or negative must NOT yield an
+        immediately-expired token (which would force an instant re-refresh) —
+        treat it as no advertised expiry (expires_at=None) and warn."""
+        data = _token_response_to_data(
+            {"access_token": "at", "expires_in": bad}, self.META, "cid", None
+        )
+        assert data.expires_at is None
+        assert "non-positive expires_in" in capsys.readouterr().err
+
+    def test_positive_expires_in_still_computes_expiry(self):
+        data = _token_response_to_data(
+            {"access_token": "at", "expires_in": 3600}, self.META, "cid", None
+        )
+        assert data.expires_at is not None and data.expires_at > 0
+
 
 # --- _parse_token_response ---
 
 
 class TestParseTokenResponse:
+    def test_non_json_non_form_body_raises_clear_error(self, httpx_mock):
+        """#8(round22): a 200 with a non-JSON, non-form body (e.g. a text/html
+        maintenance page) must raise a clear RuntimeError naming the
+        content-type, not a raw JSONDecodeError that surfaces opaquely."""
+        httpx_mock.add_response(
+            url="https://example.com/token",
+            text="<html>maintenance</html>",
+            headers={"content-type": "text/html"},
+        )
+        client = httpx.Client()
+        resp = client.post("https://example.com/token")
+        with pytest.raises(RuntimeError, match="non-JSON"):
+            _parse_token_response(resp)
+
     def test_json_response(self, httpx_mock):
         httpx_mock.add_response(
             url="https://example.com/token",


### PR DESCRIPTION
## Overview

Two LOW robustness fixes from the Opus 4.8 review (round 22).

## #8 — opaque error on a non-JSON token body (LOW)

`_parse_token_response` handles JSON and `application/x-www-form-urlencoded`, but a 200 with **any other** content-type (text/plain, text/html, or a missing content-type over a non-JSON body) fell through to `resp.json()` and raised a raw `json.JSONDecodeError`. That's caught on the refresh path (degrades to `None`), but on the **auth-code** path it propagated opaquely. Now the final `resp.json()` is wrapped and raises a clear `RuntimeError` naming the unexpected content-type, matching the missing-access_token error style.

## #9 — non-positive expires_in yields an immediately-expired token (LOW)

`_token_response_to_data` computed `expires_at = now + expires_in` with no lower bound, so a malformed / hostile `expires_in` of **0 or negative** produced `expires_at <= now`. `ensure_token` then treated the **freshly obtained** token as already expired and immediately re-refreshed / re-ran the whole flow instead of using it once. Now a non-positive `expires_in` is treated as "no expiry advertised" (`expires_at = None`) with a warning.

## Tests

- a `text/html` token body raises a clear `RuntimeError` (not a raw JSONDecodeError)
- `expires_in` of 0 / negative (int and string forms) yields `expires_at = None` with a warning; a positive value still computes the expiry

**265 oauth tests pass.** No raw U+2028/U+2029/U+0085/U+FEFF bytes in source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)