### PR TITLE
fix(token_store): validate iss_parameter_supported on load; document temp orphans

### DIFF
--- a/src/mcp_stdio/token_store.py
+++ b/src/mcp_stdio/token_store.py
@@ -405,6 +405,14 @@ def _write_store(data: dict[str, Any]) -> None:
     cannot corrupt existing tokens. After the rename the parent directory is
     fsynced so the directory entry change is itself durable across a power
     loss (the file data fsync alone does not guarantee the rename survives).
+
+    Note (#11 round22): a HARD kill (SIGKILL / power loss / OOM) between the temp
+    file's creation and the os.replace leaves an orphaned ``tokens.json.tmp.*``
+    sibling (0o600) that is never swept. This is accepted as harmless: the real
+    store is untouched (os.replace is atomic), the unique random suffix prevents
+    any collision with a future write, and the bytes stay 0o600. No per-write
+    directory scan is done to reclaim them — that cost is not worth paying on the
+    hot path for a leak that only a hard crash can produce.
     """
     _ensure_store_dir()
     # sort_keys for stable, diff-friendly on-disk output (#8 round17): without it
@@ -565,6 +573,13 @@ def load_token(server_url: str) -> TokenData | None:
         if value is not None and not isinstance(value, str):
             return None
     if not isinstance(td.no_resource_indicator, bool):
+        return None
+    # #10 (round22): iss_parameter_supported is SECURITY-load-bearing — it gates
+    # the RFC 9207 §2.4 missing-iss MUST-reject on the step-up cache-hit path. A
+    # corrupted store flipping it to a non-bool (or a truthy string that reads as
+    # enabled, or a 0 that reads as disabled) must degrade to None / re-auth, not
+    # silently mis-set the defence. Validate it like no_resource_indicator.
+    if not isinstance(td.iss_parameter_supported, bool):
         return None
     return td
 

--- a/tests/test_token_store.py
+++ b/tests/test_token_store.py
@@ -288,6 +288,36 @@ class TestLoadSaveDelete:
         )
         assert load_token("https://example.com/mcp") is None
 
+    def test_load_non_bool_iss_parameter_supported_returns_none(
+        self, tmp_path, monkeypatch
+    ):
+        """#10(round22): iss_parameter_supported is security-load-bearing (it
+        gates the RFC 9207 §2.4 missing-iss reject on step-up). A corrupted
+        non-bool value must degrade to None / re-auth, not silently mis-set the
+        defence — validated like no_resource_indicator."""
+        store_file = tmp_path / "tokens.json"
+        monkeypatch.setattr("mcp_stdio.token_store._STORE_DIR", tmp_path)
+        monkeypatch.setattr("mcp_stdio.token_store._STORE_FILE", store_file)
+
+        store_file.write_text(
+            '{"https://example.com/mcp": '
+            '{"access_token": "t", "iss_parameter_supported": "yes"}}'
+        )
+        assert load_token("https://example.com/mcp") is None
+
+    def test_load_bool_iss_parameter_supported_loads(self, tmp_path, monkeypatch):
+        """A proper bool iss_parameter_supported round-trips."""
+        store_file = tmp_path / "tokens.json"
+        monkeypatch.setattr("mcp_stdio.token_store._STORE_DIR", tmp_path)
+        monkeypatch.setattr("mcp_stdio.token_store._STORE_FILE", store_file)
+
+        save_token(
+            "https://example.com/mcp",
+            TokenData(access_token="t", iss_parameter_supported=True),
+        )
+        loaded = load_token("https://example.com/mcp")
+        assert loaded is not None and loaded.iss_parameter_supported is True
+
     def test_save_over_corrupt_store_succeeds(self, tmp_path, monkeypatch):
         """A corrupt store file is replaced (not appended to) on the next save."""
         store_file = tmp_path / "tokens.json"


### PR DESCRIPTION
## Overview

One LOW validation fix (#10) + one NIT doc note (#11) from the Opus 4.8 review (round 22).

## #10 — iss_parameter_supported not validated on load (LOW)

`load_token` exhaustively type-checks every load-bearing field against a corrupted store (access_token, expires_at, the string fields, `no_resource_indicator` as bool) — but **not** `iss_parameter_supported`, even though it is **security-load-bearing**: it gates the RFC 9207 §2.4 missing-iss MUST-reject on the step-up cache-hit rehydration path. A corrupted store flipping it to a non-bool (a truthy string reading as *enabled*, a `0` reading as *disabled*) would silently mis-set the defence. Now validated like `no_resource_indicator` — a non-bool degrades to `None` / re-auth.

## #11 — temp-file orphans on a hard crash (NIT, doc)

Documented in `_write_store` that a hard kill (SIGKILL / power loss / OOM) between the temp file's creation and the `os.replace` leaves an orphaned `tokens.json.tmp.*` sibling that is never swept. Accepted as harmless — the real store is untouched (atomic `os.replace`), the unique random suffix prevents collisions, and the bytes stay 0o600 — rather than paying a per-write directory scan to reclaim a leak only a hard crash can produce.

## Tests

- a non-bool `iss_parameter_supported` degrades `load_token` to `None`
- a proper bool round-trips through save/load

60 token_store tests pass. No raw U+2028/U+2029/U+0085/U+FEFF bytes in source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)