### PR TITLE
fix(cli): presence-based OAuth-only warning for --client-id; note leeway is OAuth-only

### DIFF
--- a/src/mcp_stdio/cli.py
+++ b/src/mcp_stdio/cli.py
@@ -259,7 +259,7 @@ def main() -> None:
             "expire (default: 60, or MCP_OAUTH_REFRESH_LEEWAY env var). "
             "Increase for ASes with significant clock skew; decrease for "
             "deployments where short-lived tokens make a 60 s window "
-            "exceed token TTL"
+            "exceed token TTL. Only used with --oauth / --oauth-device"
         ),
     )
     parser.add_argument(
@@ -403,9 +403,16 @@ def main() -> None:
     )
 
     # Warn if OAuth-only options are explicitly set without an OAuth flow — they
-    # are silently ignored otherwise.
+    # are silently ignored otherwise. client_id is presence-based (`is not None`)
+    # so an explicit `--client-id ''` trips it too, matching the --bearer-token
+    # discipline (#13 round22). oauth_scope's default is "" (not None), so an
+    # explicit empty value is indistinguishable from the default and stays on the
+    # truthiness check. --oauth-refresh-leeway is also OAuth-only but always has a
+    # default, so it cannot be presence-detected here — its help text says so.
     if not (args.oauth or args.oauth_device) and (
-        args.client_id or args.oauth_scope or args.no_resource_indicator
+        args.client_id is not None
+        or args.oauth_scope
+        or args.no_resource_indicator
     ):
         print(
             "warning: --client-id / --oauth-scope / --no-resource-indicator are "

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -548,6 +548,23 @@ class TestMain:
             main()
         assert "ignored without --oauth" in capsys.readouterr().err
 
+    def test_explicit_empty_client_id_without_oauth_warns(
+        self, monkeypatch, capsys
+    ):
+        """#13(round22): an explicit `--client-id ''` (falsy) without an OAuth
+        flow now trips the OAuth-only warning — the gate is presence-based
+        (`is not None`), matching the --bearer-token discipline."""
+        monkeypatch.delenv("MCP_OAUTH_CLIENT_ID", raising=False)
+        with (
+            patch(
+                "sys.argv",
+                ["mcp-stdio", "--client-id", "", "https://example.com/mcp"],
+            ),
+            patch("mcp_stdio.cli.run"),
+        ):
+            main()
+        assert "ignored without --oauth" in capsys.readouterr().err
+
     @pytest.mark.parametrize(
         "bad", ["tok\nInjected: x", "tok\rx", "tok\x00x", "tok\r\nInjected: x"]
     )


### PR DESCRIPTION
## Overview

Two NIT consistency fixes from the Opus 4.8 review (round 22).

## #13 — empty `--client-id` slipped the OAuth-only warning

The "OAuth-only flags ignored without `--oauth`" warning gated on `args.client_id` (truthiness), so an explicit `--client-id ''` (falsy) **silently passed** the warning — diverging from the presence-based discipline applied to `--bearer-token` (`is not None`). Switched `client_id` to `is not None` so an explicit empty value trips the warning too. `oauth_scope`'s default is `""` (not `None`), so its explicit empty is indistinguishable from the default and stays on the truthiness check (noted inline).

## #12 — `--oauth-refresh-leeway` not flagged as OAuth-only

`--oauth-refresh-leeway` is equally OAuth-only (consumed only inside the OAuth block) but always has a default, so it cannot be presence-detected for the warning. Added a one-line note to its help text that it is only used with `--oauth` / `--oauth-device`, matching the warning's intent.

## Test

An explicit `--client-id ''` without an OAuth flow now warns.

81 cli tests pass. No raw U+2028/U+2029/U+0085/U+FEFF bytes in source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)