### PR TITLE
docs/test(relay): document batch + rate-limit-stall limits; pin cancel TTL & cap resumability

### DIFF
--- a/src/mcp_stdio/relay.py
+++ b/src/mcp_stdio/relay.py
@@ -1577,6 +1577,17 @@ def run(
             and returns updated headers containing a broader-scope
             token, or None on failure (RFC 9470 step-up authorization;
             cf. anthropics/claude-code#44652).
+
+    Limitation — JSON-RPC batches (#2 round22): a top-level array (a batch) is
+    treated like a notification for error synthesis. ``_extract_id_and_presence``
+    returns ``has_id=False`` for any non-object line, so if a batch's POST fails
+    upstream (transport exhaustion, an empty 200, a >=400, or a non-compliant
+    202), NO JSON-RPC error is synthesized and any requests-with-ids INSIDE the
+    batch are left unanswered — a silent hang rather than a per-id error. This
+    mirrors the cancel-filter's deliberate batch exemption: synthesizing an
+    ``id:null`` error for a batch would itself violate JSON-RPC, and MCP removed
+    batching in spec rev 2025-06-18, so the exposure is minimal. A single
+    (non-batch) request always gets a synthesized error on the same failures.
     """
 
     # Graceful shutdown on SIGTERM/SIGINT
@@ -2246,6 +2257,15 @@ def run_sse(
                     # retries-exhausted falls through with the final status and
                     # is surfaced to the caller by the generic 4xx/5xx branch
                     # below (typescript-sdk#1892).
+                    #
+                    # NOTE (#4 round22): this time.sleep runs on the STDIN thread,
+                    # so while parked here (up to the 60 s cap) the loop cannot
+                    # read the next stdin line — a notifications/cancelled for the
+                    # very request being rate-limit-retried sits unprocessed until
+                    # the sleep ends. Accepted: the cancel only delays, never
+                    # corrupts; the reader thread keeps delivering replies; and an
+                    # interruptible sleep would add cross-thread signalling the
+                    # project deliberately avoids. The Retry-After cap bounds it.
                     for attempt in range(1, MAX_RETRIES + 1):
                         resp = client.post(
                             endpoint,

--- a/tests/test_relay.py
+++ b/tests/test_relay.py
@@ -2598,6 +2598,10 @@ class TestPagination:
         names = [t["name"] for t in merged["result"]["tools"]]
         assert names == ["t1", "t2", "t3"]  # exactly MAX_LIST_PAGES pages
         assert len(httpx_mock.get_requests()) == 3
+        # #14(round22): page 3 still advertised nextCursor 'p4', so the cap path
+        # MUST re-expose it on the merged result for the client to resume past
+        # the cap — pinning resumability like the sibling truncation tests.
+        assert merged["result"]["nextCursor"] == "p4"
 
     def test_mid_flow_error_returns_partial_result(self, httpx_mock):
         """Page N>=2 HTTP error returns the pages collected so far."""
@@ -5031,6 +5035,22 @@ class TestCancelTracker:
         clock.advance(31)  # past 60 s
         assert not t.contains(5)
 
+    def test_default_ttl_constant_is_60s_and_wired(self):
+        """#15(round22): pin the production TTL constant AND that the DEFAULT
+        tracker (the one run()/run_sse() build) uses it, so an accidental change
+        to _CANCEL_TTL_SECS — or a default-arg that stops referencing it — is
+        caught rather than silently widening/shrinking the cancel window."""
+        from mcp_stdio.relay import _CANCEL_TTL_SECS
+
+        assert _CANCEL_TTL_SECS == 60.0
+        clock = _FakeClock()
+        t = _CancelTracker(now=clock)  # default ttl
+        t.add(5)
+        clock.advance(59)
+        assert t.contains(5)  # still within the 60 s default
+        clock.advance(2)  # past 60 s
+        assert not t.contains(5)
+
     def test_consume_drops_once_then_id_reuse_passes(self):
         """consume() removes the entry on first match, so a cancelled id's late
         response is dropped exactly once; a reused id within the TTL passes."""
@@ -5507,6 +5527,60 @@ class TestRunSseCancelFilter:
             run_sse(self.URL, {"Content-Type": "application/json"})
 
         assert "late" not in stdout.getvalue()
+
+    def test_cancel_ttl_expired_then_sse_message_is_delivered(
+        self, httpx_mock, monkeypatch
+    ):
+        """#16(round22): the cancel-drop is TTL-bounded END-TO-END. With the
+        tracker's TTL already elapsed, a cancelled id's late SSE response is
+        DELIVERED, not dropped — the integration analogue of the unit
+        consume-expired test. (Patch the tracker run_sse builds to a negative TTL
+        so any entry is immediately past-window.)"""
+        import mcp_stdio.relay as relay_mod
+
+        real_cls = relay_mod._CancelTracker
+        monkeypatch.setattr(
+            "mcp_stdio.relay._CancelTracker", lambda: real_cls(ttl=-1.0)
+        )
+
+        payload = '{"jsonrpc":"2.0","result":{"late":true},"id":11}'
+        post_received = threading.Event()
+        release_stdin = threading.Event()
+
+        def sse_gen():
+            yield b"event: endpoint\ndata: /messages?sessionId=abc\n\n"
+            post_received.wait(timeout=3)
+            yield f"event: message\ndata: {payload}\n\n".encode()
+            time.sleep(0.1)
+            release_stdin.set()
+
+        httpx_mock.add_response(
+            url=self.URL,
+            stream=IteratorStream(sse_gen()),
+            headers={"content-type": "text/event-stream"},
+        )
+
+        def on_post(request: httpx.Request) -> httpx.Response:
+            post_received.set()
+            return httpx.Response(status_code=202)
+
+        httpx_mock.add_callback(
+            on_post, url="https://example.com/messages?sessionId=abc"
+        )
+
+        stdin = _BlockingStdin(
+            (
+                '{"jsonrpc":"2.0","method":"notifications/cancelled",'
+                '"params":{"requestId":11}}'
+            ),
+            release_stdin,
+        )
+        stdout = StringIO()
+        with patch("sys.stdin", stdin), patch("sys.stdout", stdout):
+            run_sse(self.URL, {"Content-Type": "application/json"})
+
+        # TTL elapsed → the late response is NOT dropped.
+        assert "late" in stdout.getvalue()
 
     def test_sse_message_without_cancel_passes_through(self, httpx_mock):
         payload = '{"jsonrpc":"2.0","result":{"kept":true},"id":21}'


### PR DESCRIPTION
## Overview

round-22: two documentation notes (#2, #4) + three coverage tests (#14, #15, #16). **No production behaviour change.**

## #2 — JSON-RPC batch upstream-failure silent hang (LOW, doc)

Documented in `run()`'s docstring that a JSON-RPC **batch** (top-level array) is treated like a notification for error synthesis: `_extract_id_and_presence` returns `has_id=False` for any non-object, so a batch whose POST fails upstream (transport exhaustion, empty 200, ≥400, non-compliant 202) synthesizes **no** error and leaves its inner request-ids unanswered — a silent hang. This mirrors the cancel-filter's batch exemption; MCP removed batching in spec rev 2025-06-18, and synthesizing an `id:null` batch error would itself violate JSON-RPC, so silent pass-through is the defensible choice.

## #4 — rate-limit sleep stalls the stdin thread (NIT, doc)

Noted that `run_sse`'s 429/503 retry `time.sleep` runs on the **stdin thread**, so a `notifications/cancelled` for the request being retried waits up to the 60 s Retry-After cap. Accepted — the cancel only delays, never corrupts; an interruptible sleep would add cross-thread signalling the project avoids.

## #14 — page-cap resumability not asserted (LOW, test)

`test_page_cap_truncates_runaway_cursor` exercised the `MAX_LIST_PAGES` cap but never asserted the **`nextCursor`** it re-exposes. Added `assert merged["result"]["nextCursor"] == "p4"` so the cap path's resumability is pinned like the sibling error-truncation tests.

## #15 — cancel TTL constant not pinned (NIT, test)

Pinned `_CANCEL_TTL_SECS == 60.0` **and** that the default tracker (the one `run()`/`run_sse()` build) uses it, so an accidental change to the cancel window — or a default-arg that stops referencing it — is caught.

## #16 — cancel-TTL expiry not at integration level (NIT, test)

Added a `run_sse` end-to-end test: with the tracker's TTL elapsed, a cancelled id's late SSE response is **delivered, not dropped** — the integration analogue of the unit consume-expired test.

**339 relay tests pass** (3 skipped). No raw U+2028/U+2029/U+0085/U+FEFF bytes in source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)