### PR TITLE
fix(relay): deliver interleaved server-initiated messages on the pagination path

### DIFF
--- a/src/mcp_stdio/relay.py
+++ b/src/mcp_stdio/relay.py
@@ -875,6 +875,7 @@ def _post_parsed(
     headers: dict[str, str],
     req_id: Any,
     *,
+    tracker: "_CancelTracker | None" = None,
     has_id: bool = True,
     emit_error_on_failure: bool = True,
 ) -> tuple[dict[str, Any] | None, _StreamResult | None]:
@@ -934,17 +935,32 @@ def _post_parsed(
                 # neither, and returning it would make the pagination merge treat
                 # it as the page result and drop the real list. Mirrors the
                 # keep-reading gate in _check_connection_sse.
+                #
+                # #5 (round23): every NON-response message event (a server-
+                # initiated request / notification) must still be DELIVERED to
+                # stdout — _post_and_stream emits every message event, so the
+                # pagination path must too, or interleaved frames are silently
+                # dropped only on the paginated methods.
                 for event_type, payload in _iter_sse_events(_split_sse_text(resp.text)):
                     if event_type != "message":
                         continue
                     try:
                         parsed = json.loads(payload)
                     except json.JSONDecodeError:
+                        # Non-JSON message: not the response object. Leave it to
+                        # trigger the parsed=None fallback (re-POST) rather than
+                        # forwarding garbage — the fallback re-fetches the real
+                        # result, so dropping the malformed frame loses nothing.
                         continue
                     if isinstance(parsed, dict) and (
                         "result" in parsed or "error" in parsed
                     ):
                         return parsed, _StreamResult(session, 200)
+                    # A well-formed but NON-response message (a server-initiated
+                    # request / notification interleaved before the response) must
+                    # be delivered, not dropped — _post_and_stream emits every
+                    # message event, so the pagination path must too.
+                    _emit(payload, tracker)
                 return None, _StreamResult(session, 200)
 
             text = resp.text.strip()
@@ -1082,6 +1098,7 @@ def _paginate_and_stream(
             page_content,
             headers,
             req_id,
+            tracker=tracker,
             has_id=has_id,
             # Page 1 has no partial to flush, so its exhaustion error IS the
             # response. Page>=2 flushes the partial below, so suppress the error
@@ -1751,11 +1768,16 @@ def run(
 
                 # Recovery is single-pass and ordered auth-before-session: the three
                 # branches below are sequential `if`s (not `elif`), each firing at
-                # most once per stdin line. A 401/403 whose retry returns 404 still
-                # flows into the 404 branch and recovers; the converse does NOT — a
-                # 404 retry that comes back 401/403 (token expired during the reinit
-                # window), or a 401/403 retry that fails the same way again, is not
-                # re-recovered and surfaces as a JSON-RPC error (never a hang, #11).
+                # most once per stdin line. A 401/403 whose retry returns 404 flows
+                # into the 404 branch and recovers ONLY when a session_id was
+                # already established — the 404 branch is gated on `and session_id`
+                # (#1 round23). A COLD 404 (no session ever existed, e.g. the
+                # initialize itself 401'd) is a genuine not-found, not a session
+                # expiry, so it correctly surfaces as a JSON-RPC error rather than
+                # re-initializing a session that never was. The converse does NOT
+                # recover either — a 404 retry that comes back 401/403 (token
+                # expired during the reinit window), or a 401/403 retry that fails
+                # the same way again, surfaces as a JSON-RPC error (never a hang, #11).
                 # The downstream client retries at its own level. This bounded
                 # single attempt is deliberate: it avoids unbounded recovery loops.
                 #

--- a/tests/test_relay.py
+++ b/tests/test_relay.py
@@ -1083,6 +1083,45 @@ class TestRun:
         assert err["error"]["code"] == -32000
         assert "session lost" in err["error"]["message"]
 
+    def test_reinitialize_notifications_initialized_transport_error_returns_error(
+        self, httpx_mock
+    ):
+        """#13(round23): if the initialize succeeds but the
+        notifications/initialized POST RAISES a transport error (not just a
+        non-200), _reinitialize's except httpx.HTTPError branch must still treat
+        the re-init as failed and surface 'session lost' — exercising the
+        raise-path, distinct from the non-200-status path above."""
+        httpx_mock.add_response(
+            text='{"jsonrpc":"2.0","result":{},"id":1}',
+            headers={
+                "content-type": "application/json",
+                "mcp-session-id": "sess-old",
+            },
+        )
+        httpx_mock.add_response(status_code=404, text="")
+        # Initialize succeeds — server assigns sess-new
+        httpx_mock.add_response(
+            text='{"jsonrpc":"2.0","result":{},"id":0}',
+            headers={
+                "content-type": "application/json",
+                "mcp-session-id": "sess-new",
+            },
+        )
+        # notifications/initialized POST raises a transport error.
+        httpx_mock.add_exception(httpx.ConnectError("connection reset"))
+
+        output = self._run_with_stdin(
+            httpx_mock,
+            [
+                '{"jsonrpc":"2.0","method":"init","id":1}',
+                '{"jsonrpc":"2.0","method":"call","id":2}',
+            ],
+        )
+        lines = [x for x in output.strip().splitlines() if x]
+        err = json.loads(lines[-1])
+        assert err["id"] == 2
+        assert "session lost" in err["error"]["message"]
+
     def test_reinitialize_missing_session_id_returns_error(self, httpx_mock):
         """#12: a re-initialize that returns 200 with a valid InitializeResult
         but NO mcp-session-id header (a plausible broken-server bug) must
@@ -2892,10 +2931,12 @@ class TestPagination:
         assert merged["result"]["_meta"] == {"total": 2}  # late field kept
         assert "nextCursor" not in merged["result"]
 
-    def test_page_sse_skips_interleaved_notification(self, httpx_mock):
-        """#1: a server may interleave a notification on the POST's SSE stream
-        BEFORE the list result. _post_parsed must skip it and return the real
-        response, not mistake the notification for the page result."""
+    def test_page_sse_forwards_interleaved_notification(self, httpx_mock):
+        """#5(round23): a server may interleave a notification on the POST's SSE
+        stream BEFORE the list result. _post_parsed must FORWARD it to stdout
+        (like the streaming path _post_and_stream) AND still return the real
+        response — not mistake the notification for the page result, nor drop it
+        only on the paginated methods."""
         notif = '{"jsonrpc":"2.0","method":"notifications/message","params":{}}'
         result = '{"jsonrpc":"2.0","id":1,"result":{"tools":[{"name":"a"}]}}'
         body = (
@@ -2911,10 +2952,13 @@ class TestPagination:
             httpx_mock,
             [json.dumps({"jsonrpc": "2.0", "id": 1, "method": "tools/list"})],
         )
-        merged = json.loads(output.strip())
+        lines = [json.loads(x) for x in output.strip().splitlines() if x]
+        # The interleaved notification was DELIVERED (not dropped, not mistaken
+        # for the result).
+        assert any(d.get("method") == "notifications/message" for d in lines)
+        # The real list result is still parsed correctly.
+        merged = next(d for d in lines if "result" in d)
         assert [t["name"] for t in merged["result"]["tools"]] == ["a"]
-        # The interleaved notification must not have been forwarded as the result.
-        assert "notifications/message" not in output
 
 
 # --- check_connection ---


### PR DESCRIPTION
## Overview

round-23: one LOW spec-compliance fix (#5) + a comment correction (#1) + a coverage test (#13).

## #5 — pagination path drops interleaved server-initiated messages (LOW)

`_post_and_stream` `_emit`s **every** SSE message event, but `_post_parsed` (the buffered POST used only by the auto-pagination helper) returned the first response object and **silently dropped every other message event**. So a spec-permitted **server-initiated request / notification** interleaved before the JSON-RPC response was delivered on non-paginated methods but **dropped** on `tools/list` / `resources/list` / `prompts/list`.

**Fix:** thread the `tracker` into `_post_parsed` and `_emit` each well-formed **non-response** message (one lacking `result`/`error`). A non-JSON frame still falls through to the `parsed=None` re-POST fallback (no garbage forwarded), preserving the existing fallback behaviour.

## #1 — 401/403→404 cascade comment (NIT)

The recovery comment claimed the cascade "still flows into the 404 branch and recovers" unconditionally; the 404 branch is gated on `and session_id`, so a **cold 404** (no session ever existed — e.g. the initialize itself 401'd) correctly surfaces as a JSON-RPC error rather than re-initializing a session that never was. Comment clarified.

## #13 — reinit transport-error branch untested (LOW, test)

Covered `_reinitialize`'s `except httpx.HTTPError` branch: a `notifications/initialized` POST that **raises** (not just returns non-200) still surfaces `session lost`.

## Tests

An interleaved notification on a paginated POST's SSE stream is now forwarded (not dropped) while the list result still parses; the reinit transport-error path surfaces `session lost`.

**340 relay tests pass** (3 skipped). No raw U+2028/U+2029/U+0085/U+FEFF bytes in source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)