### PR TITLE
fix(token_store): reject bool expiry on load; cover the remaining type branches

### DIFF
--- a/src/mcp_stdio/token_store.py
+++ b/src/mcp_stdio/token_store.py
@@ -547,10 +547,18 @@ def load_token(server_url: str) -> TokenData | None:
     # degrade to None rather than propagate a TypeError up the OAuth path.
     if not isinstance(td.access_token, str) or not td.access_token:
         return None
-    if td.expires_at is not None and not isinstance(td.expires_at, (int, float)):
+    # #9 (round23): bool is an int SUBCLASS in Python, so a corrupted
+    # ``true``/``false`` in the JSON would pass an isinstance(..., (int, float))
+    # check and reach ensure_token as 1/0 — a nonsensical 1970-epoch expiry.
+    # Reject bool explicitly so it degrades to re-auth instead of a bogus expiry.
+    if td.expires_at is not None and (
+        isinstance(td.expires_at, bool)
+        or not isinstance(td.expires_at, (int, float))
+    ):
         return None
-    if td.client_secret_expires_at is not None and not isinstance(
-        td.client_secret_expires_at, (int, float)
+    if td.client_secret_expires_at is not None and (
+        isinstance(td.client_secret_expires_at, bool)
+        or not isinstance(td.client_secret_expires_at, (int, float))
     ):
         return None
     # The string fields are consumed via .split() (scope) or sent verbatim in

--- a/tests/test_token_store.py
+++ b/tests/test_token_store.py
@@ -253,6 +253,31 @@ class TestLoadSaveDelete:
         )
         assert load_token("https://example.com/mcp") is None
 
+    @pytest.mark.parametrize(
+        "entry",
+        [
+            # #9(round23): bool is an int subclass; a corrupted bool expiry must
+            # be rejected, not read as a 1970-epoch 1/0.
+            '{"access_token": "t", "expires_at": true}',
+            '{"access_token": "t", "client_secret_expires_at": false}',
+            # #14(round23): the sibling validation branches not previously covered.
+            '{"access_token": "t", "client_secret_expires_at": "never"}',
+            '{"access_token": "t", "no_resource_indicator": "yes"}',
+        ],
+    )
+    def test_load_corrupted_typed_fields_return_none(
+        self, tmp_path, monkeypatch, entry
+    ):
+        """#9/#14(round23): bool expiries and the not-previously-covered
+        client_secret_expires_at / no_resource_indicator type branches all
+        degrade load_token to None rather than reaching the OAuth path."""
+        store_file = tmp_path / "tokens.json"
+        monkeypatch.setattr("mcp_stdio.token_store._STORE_DIR", tmp_path)
+        monkeypatch.setattr("mcp_stdio.token_store._STORE_FILE", store_file)
+
+        store_file.write_text('{"https://example.com/mcp": ' + entry + "}")
+        assert load_token("https://example.com/mcp") is None
+
     def test_load_non_string_access_token_returns_none(self, tmp_path, monkeypatch):
         """A corrupted access_token (wrong type) must not produce a usable token."""
         store_file = tmp_path / "tokens.json"


### PR DESCRIPTION
## Overview

One NIT correctness fix (#9) + one LOW coverage fix (#14) from the Opus 4.8 review (round 23).

## #9 — bool slips the numeric-expiry validation (NIT)

`load_token` validated `expires_at` / `client_secret_expires_at` with `isinstance(..., (int, float))`, but **`bool` is an `int` subclass** in Python — a corrupted `true`/`false` would pass and reach `ensure_token` as `1`/`0`, a nonsensical 1970-epoch expiry (fails closed toward re-auth, but silently). Now `bool` is rejected explicitly so it degrades to re-auth.

## #14 — uncovered validation branches (LOW, coverage)

Two security-load-bearing validation branches in `load_token` were untested — a non-numeric `client_secret_expires_at` and a non-bool `no_resource_indicator`. Added parametrized cases (alongside the new bool-expiry cases) so the validation matrix is closed and a future field-list edit that drops a check is caught.

64 token_store tests pass. No raw U+2028/U+2029/U+0085/U+FEFF bytes in source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)