### PR TITLE
fix(cli): float --sse-read-timeout default; cover OAuth-token header-injection guard

### DIFF
--- a/src/mcp_stdio/cli.py
+++ b/src/mcp_stdio/cli.py
@@ -296,7 +296,11 @@ def main() -> None:
     parser.add_argument(
         "--sse-read-timeout",
         type=_non_negative_float,
-        default=300,
+        # Float default (#11 round23): argparse applies ``type`` only to argv
+        # strings, never to the default object, so an int default would leave the
+        # attribute an int when the flag is omitted — keep it consistent with the
+        # _non_negative_float validator and the --timeout-* float defaults.
+        default=300.0,
         help=(
             "Idle read timeout (seconds) on the SSE GET stream "
             "(default: 300). A silent half-open TCP connection will "

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -579,6 +579,21 @@ class TestMain:
             assert exc_info.value.code == 1
         assert "forbidden control character" in capsys.readouterr().err
 
+    def test_oauth_token_with_control_char_exits(self, monkeypatch, capsys):
+        """#12(round23): an OAuth-acquired access_token carrying CR/LF/NUL (a
+        compromised/malicious AS smuggling control chars) must fail startup
+        (exit 1), not split request headers on the wire. Covers the initial-flow
+        header-build guard, distinct from the --bearer-token and refresher paths."""
+        monkeypatch.setattr(
+            "mcp_stdio.oauth.ensure_token",
+            lambda *a, **k: TokenData(access_token="tok\nInjected: x"),
+        )
+        with patch("sys.argv", ["mcp-stdio", "--oauth", "https://example.com/mcp"]):
+            with pytest.raises(SystemExit) as exc_info:
+                main()
+        assert exc_info.value.code == 1
+        assert "forbidden control character" in capsys.readouterr().err
+
     def test_dash_h_overrides_default_content_type_case_insensitively(self):
         with (
             patch(


### PR DESCRIPTION
## Overview

One NIT consistency fix (#11) + one LOW coverage fix (#12) from the Opus 4.8 review (round 23).

## #11 — int `--sse-read-timeout` default

`--sse-read-timeout` used `default=300` (int), diverging from the deliberate **float** defaults of `--timeout-connect` / `--timeout-read`. argparse applies `type=` only to argv strings, never to the default object, so the omitted-flag attribute was an `int`. Changed to `300.0` for consistency with the `_non_negative_float` validator.

## #12 — OAuth-token header-injection guard uncovered (LOW, coverage)

The round-21 guard that fails startup (exit 1) when the OAuth-acquired `access_token` carries CR/LF/NUL was **uncovered** — the existing control-char tests only hit `--bearer-token` and the refresher closure. Added a `TestMain` case that monkeypatches `ensure_token` to return a token with a newline and asserts `SystemExit(1)` + the forbidden-control-character message.

82 cli tests pass. No raw U+2028/U+2029/U+0085/U+FEFF bytes in source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)