### PR TITLE
fix(oauth): strip query from AS base before issuer comparison; cover edge branches

### DIFF
--- a/src/mcp_stdio/oauth.py
+++ b/src/mcp_stdio/oauth.py
@@ -407,6 +407,15 @@ def _fetch_authorization_server_metadata(
     """
     # RFC 8414 issuer has no query component, so do not carry one through.
     well_known = _build_well_known_url(auth_server_url, "oauth-authorization-server")
+    # #7 (round23): on the Phase-2 path-scoped fallback this function is called
+    # with the full operator server_url, which may carry a query. _build_well_known_url
+    # already strips the query when forming the discovery URL, so the issuer
+    # comparison and the synthesized default endpoints must use the SAME
+    # query/fragment-stripped base — otherwise a server_url like
+    # ``https://host/mcp?tenant=x`` produces a spurious §3.3 mismatch warning and
+    # malformed ``.../mcp?tenant=x/authorize`` defaults.
+    _asp = urlsplit(auth_server_url)
+    auth_server_base = urlunsplit((_asp.scheme, _asp.netloc, _asp.path, "", ""))
     try:
         resp = client.get(well_known)
         if resp.status_code == 200:
@@ -416,15 +425,15 @@ def _fetch_authorization_server_metadata(
             # (the spec says reject) — real servers may be slightly misconfigured
             # (trailing slash, etc.) and rejecting would be too strict.
             issuer = data.get("issuer")
-            if issuer and issuer.rstrip("/") != auth_server_url.rstrip("/"):
+            if issuer and issuer.rstrip("/") != auth_server_base.rstrip("/"):
                 log(
                     f"warning: RFC 8414 §3.3 issuer mismatch — "
-                    f"expected {auth_server_url!r}, got {issuer!r}"
+                    f"expected {auth_server_base!r}, got {issuer!r}"
                 )
             methods = data.get("token_endpoint_auth_methods_supported")
             # Strip a trailing slash before building default endpoints so an AS
             # URL like "https://as/" does not yield "https://as//authorize".
-            base = auth_server_url.rstrip("/")
+            base = auth_server_base.rstrip("/")
             # Validate every endpoint the metadata declares against the #13
             # cleartext-leak policy before it can receive a secret. An unsafe
             # authorization/token endpoint falls back to the default path on
@@ -447,7 +456,7 @@ def _fetch_authorization_server_metadata(
                     label="device_authorization_endpoint",
                 ),
                 token_endpoint_auth_methods_supported=methods if isinstance(methods, list) else None,
-                issuer=issuer or auth_server_url,
+                issuer=issuer or auth_server_base,
                 # RFC 9207 §3: a true value makes a missing `iss` on the
                 # authorization response a MUST-reject (§2.4). Coerce strictly to
                 # bool so a non-bool JSON value cannot accidentally enable the

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -168,6 +168,39 @@ class TestPKCE:
 # --- discover_oauth_metadata ---
 
 
+class TestFetchAuthServerMetadataIssuer:
+    """#7(round23): the issuer comparison and synthesized defaults must use the
+    query-stripped base — the path-scoped fallback passes the full server_url."""
+
+    def test_query_in_url_no_spurious_mismatch_and_clean_defaults(
+        self, httpx_mock, capsys
+    ):
+        from mcp_stdio.oauth import (
+            _build_well_known_url,
+            _fetch_authorization_server_metadata,
+        )
+
+        server_url = "https://ex.com/mcp?tenant=x"
+        well_known = _build_well_known_url(
+            server_url, "oauth-authorization-server"
+        )
+        # Metadata advertises the query-stripped issuer (the conformant value)
+        # and no endpoints, so they are synthesized from the base.
+        httpx_mock.add_response(
+            url=well_known, json={"issuer": "https://ex.com/mcp"}
+        )
+        client = httpx.Client()
+        meta = _fetch_authorization_server_metadata(server_url, client)
+
+        assert meta is not None
+        # Synthesized defaults derive from the query-stripped base — no '?tenant=x'.
+        assert meta.token_endpoint == "https://ex.com/mcp/token"
+        assert meta.authorization_endpoint == "https://ex.com/mcp/authorize"
+        assert meta.issuer == "https://ex.com/mcp"
+        # No spurious RFC 8414 §3.3 mismatch warning.
+        assert "issuer mismatch" not in capsys.readouterr().err
+
+
 class TestDiscoverMetadata:
     def _mock_no_prm(self, httpx_mock, base="https://api.example.com", path="/mcp"):
         """Mock RFC 9728 endpoints returning 404 (no protected resource metadata).
@@ -474,6 +507,33 @@ class TestDiscoverMetadata:
         client = httpx.Client()
         meta = discover_oauth_metadata("https://api.example.com/mcp", client)
         # Falls through to defaults
+        assert meta.token_endpoint == "https://api.example.com/token"
+
+    def test_rfc9728_non_json_200_falls_through(self, httpx_mock):
+        """#15(round23): a PRM candidate returning HTTP 200 with a NON-JSON body
+        must be skipped (continue to the next candidate / defaults), not crash on
+        the json() parse — closes the 200-non-JSON branch (the test above only
+        covers the 404-non-JSON case)."""
+        httpx_mock.add_response(
+            url="https://api.example.com/.well-known/oauth-protected-resource/mcp",
+            status_code=200,
+            text="<html>oops</html>",
+            headers={"content-type": "text/html"},
+        )
+        httpx_mock.add_response(
+            url="https://api.example.com/.well-known/oauth-protected-resource",
+            status_code=404,
+        )
+        httpx_mock.add_response(
+            url="https://api.example.com/.well-known/oauth-authorization-server",
+            status_code=404,
+        )
+        httpx_mock.add_response(
+            url="https://api.example.com/.well-known/oauth-authorization-server/mcp",
+            status_code=404,
+        )
+        client = httpx.Client()
+        meta = discover_oauth_metadata("https://api.example.com/mcp", client)
         assert meta.token_endpoint == "https://api.example.com/token"
 
     def test_separate_auth_server_rfc8414_fails_tries_base(self, httpx_mock):
@@ -944,6 +1004,27 @@ class TestRegisterClient:
                 "client_id": "cid",
                 "client_secret": "csec",
                 "client_secret_expires_at": "0",
+            },
+        )
+        meta = OAuthMetadata(
+            authorization_endpoint="https://api.example.com/authorize",
+            token_endpoint="https://api.example.com/token",
+            registration_endpoint="https://api.example.com/register",
+        )
+        client = httpx.Client()
+        reg = register_client(meta, "http://127.0.0.1:9999/callback", client)
+        assert reg.client_secret_expires_at is None
+
+    def test_client_secret_expires_at_garbage_coerced_to_none(self, httpx_mock):
+        """#15(round23): a non-numeric client_secret_expires_at (e.g. 'never')
+        that fails float() must coerce to None (no expiry), not crash DCR — closes
+        the uncovered garbage-value branch alongside the 0 / '0' / missing cases."""
+        httpx_mock.add_response(
+            url="https://api.example.com/register",
+            json={
+                "client_id": "cid",
+                "client_secret": "csec",
+                "client_secret_expires_at": "never",
             },
         )
         meta = OAuthMetadata(


### PR DESCRIPTION
## Overview

One LOW correctness fix (#7) + NIT branch coverage (#15) from the Opus 4.8 review (round 23).

## #7 — spurious issuer mismatch + malformed defaults on a query'd URL (LOW)

On the Phase-2 path-scoped fallback, `_fetch_authorization_server_metadata` is called with the **full operator `server_url`**, which may carry a query. `_build_well_known_url` already strips the query when forming the discovery URL, but the RFC 8414 §3.3 **issuer comparison** and the **synthesized default endpoints** still used `auth_server_url` verbatim. So a `server_url` like `https://host/mcp?tenant=x` produced:
- a **spurious** RFC 8414 §3.3 issuer-mismatch warning (issuer `https://host/mcp` vs expected `https://host/mcp?tenant=x`), and
- **malformed** `https://host/mcp?tenant=x/authorize` / `/token` default endpoints.

**Fix:** compute a query/fragment-stripped `auth_server_base` (via `urlsplit`/`urlunsplit`) and use it for the comparison, the default-endpoint base, and the `issuer` fallback.

## #15 — uncovered defensive branches (NIT, coverage)

Closed two previously-unexercised branches:
- `register_client` with a **garbage** `client_secret_expires_at` (`'never'`) coercing to `None` (the existing tests covered `0` / `'0'` / missing)
- a PRM discovery candidate returning **HTTP 200 with a non-JSON body** falling through to the next candidate (the existing test only covered the 404-non-JSON case)

The device-poll 200-non-JSON branch is left for a future pass.

## Test

A `server_url` with a query yields **no** spurious §3.3 warning and **query-free** default endpoints.

**268 oauth tests pass** (0 teardown errors). No raw U+2028/U+2029/U+0085/U+FEFF bytes in source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)