### PR TITLE
fix(oauth): make RFC 9207 iss comparison trailing-slash tolerant

### DIFF
--- a/src/mcp_stdio/oauth.py
+++ b/src/mcp_stdio/oauth.py
@@ -1311,11 +1311,16 @@ def _run_authorization_flow(
         raise RuntimeError("OAuth state mismatch — possible CSRF attack")
 
     # RFC 9207 §2.4: if the authorization response carries an `iss` parameter,
-    # the client MUST validate it with a simple string comparison against the
-    # issuer the metadata was fetched from. This is the AS mix-up defence — it
-    # stops a code issued by AS-A from being exchanged at AS-B. Both values come
-    # from the same AS (its metadata `issuer` and its callback `iss`) so they are
-    # byte-identical; an exact compare (per §2.4, no normalisation) is correct.
+    # the client MUST validate it against the issuer the metadata was fetched
+    # from. This is the AS mix-up defence — it stops a code issued by AS-A from
+    # being exchanged at AS-B. On the metadata path both values come from the
+    # same AS (its metadata `issuer` and its callback `iss`) so they are
+    # byte-identical and the comparison is exact. The trailing-slash tolerance
+    # below (#7 round25) is a no-op there, but matters on the PHASE-3 fallback
+    # where `metadata.issuer` is a SYNTHESIZED guess (`as_base`, an origin with
+    # no path/slash): a real AS whose issuer is `https://as/` would otherwise
+    # false-mismatch and block a legitimate flow. A genuine mix-up always differs
+    # by HOST, which rstrip does not mask, so the defence is preserved.
     #
     # §2.4 has a SECOND MUST: a client MUST reject a response that OMITS `iss`
     # from an AS that advertises iss support (the RFC 9207 §3 metadata flag) —
@@ -1332,7 +1337,7 @@ def _run_authorization_flow(
     if (
         cb_result.iss is not None
         and metadata.issuer
-        and cb_result.iss != metadata.issuer
+        and cb_result.iss.rstrip("/") != metadata.issuer.rstrip("/")
     ):
         raise RuntimeError(
             "OAuth issuer mismatch (RFC 9207) — possible AS mix-up attack"

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -3868,6 +3868,35 @@ class TestRfc9207IssValidation:
         )
         assert data.access_token == "at"
 
+    def test_trailing_slash_iss_does_not_false_mismatch(
+        self, httpx_mock, tmp_path, monkeypatch
+    ):
+        """#7(round25): the iss compare is trailing-slash tolerant, so a Phase-3
+        synthesized issuer ('https://ex.com', no slash) does NOT false-mismatch an
+        AS whose real iss is 'https://ex.com/' — the flow proceeds. A genuine
+        mix-up (different host) is still caught (test_iss_mismatch_raises)."""
+        store_file = tmp_path / "tokens.json"
+        monkeypatch.setattr("mcp_stdio.token_store._STORE_DIR", tmp_path)
+        monkeypatch.setattr("mcp_stdio.token_store._STORE_FILE", store_file)
+        httpx_mock.add_response(
+            url="https://ex.com/token",
+            json={"access_token": "at", "token_type": "Bearer"},
+        )
+        monkeypatch.setattr(
+            "mcp_stdio.oauth.webbrowser.open",
+            self._driver("iss=https://ex.com/"),
+        )
+        client = httpx.Client()
+        data = _run_authorization_flow(
+            "https://ex.com/mcp",
+            client,
+            metadata=self.META,
+            cached=None,
+            client_id_override="cid",
+            timeout=5,
+        )
+        assert data.access_token == "at"
+
     def test_stepup_preserves_requested_scope_when_response_omits_it(
         self, httpx_mock, tmp_path, monkeypatch
     ):


### PR DESCRIPTION
## Overview

A LOW correctness fix from the Opus 4.8 review (round 25, #7).

## The bug

On the **Phase-3 default-endpoints fallback** (no RFC 8414 metadata found), `discover_oauth_metadata` pins `metadata.issuer` to a **synthesized guess** — `as_base`, an origin like `https://as.example.com` with **no path/slash**. The RFC 9207 §2.4 iss check then did an **exact** compare against the AS's real callback `iss`, so a conformant AS whose issuer is `https://as.example.com/` (trailing slash) would **false-mismatch and block a legitimate flow**.

## Fix

Make the comparison **trailing-slash tolerant** (`rstrip("/")` both sides):
- On the **metadata path** both values come from the same AS and are byte-identical, so `rstrip` is a **no-op** there — exactness preserved.
- A genuine **mix-up attack always differs by host**, which `rstrip` does not mask, so the defence is **fully preserved**.

Only the cosmetic trailing-slash false-block on the Phase-3 guess is removed.

## Test

A callback `iss` with a trailing slash does **not** false-mismatch a slash-less synthesized issuer; the flow proceeds. (The genuine different-host mismatch is still caught by `test_iss_mismatch_raises`.)

**269 oauth tests pass** (0 teardown errors). No raw U+2028/U+2029/U+0085/U+FEFF bytes in source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)