### PR TITLE
feat(cli): add --oauth-timeout for the interactive flow; fix README RFC 8414 sections

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -29,8 +29,8 @@ Bearer token、カスタムヘッダー、OAuth 2.1 認証情報をリモート�
     - §3.3 `resource` フィールド検証（不一致は警告して続行）
     - §5.1 `WWW-Authenticate: Bearer resource_metadata=` ヒント — discovery 前にサーバーへ probe を送り、well-known パスの推測に頼らず PRM の所在を直接特定する
   - [RFC 8414](https://www.rfc-editor.org/rfc/rfc8414) Authorization Server Metadata
-    - §3 well-known URL 構築。パス付き issuer のパス挿入ルール対応
-    - §3 `issuer` 検証（不一致は警告して続行）
+    - §3.1 well-known URL 構築。パス付き issuer のパス挿入ルール対応
+    - §3.3 `issuer` 検証（不一致は警告して続行）
   - [RFC 8707](https://www.rfc-editor.org/rfc/rfc8707) Resource Indicators
     - §2 `resource` パラメータを認可リクエスト・トークン交換・**リフレッシュ**に送信
   - [RFC 7636](https://www.rfc-editor.org/rfc/rfc7636) PKCE

--- a/README.md
+++ b/README.md
@@ -31,8 +31,8 @@ Bearer tokens, custom headers, and OAuth 2.1 credentials are forwarded to the re
     - §3.3 `resource` field validation — warn on mismatch, continue
     - §5.1 `WWW-Authenticate: Bearer resource_metadata=` hint — probes the server before discovery so servers that publish PRM at a non-standard URL are found without well-known path guessing
   - [RFC 8414](https://www.rfc-editor.org/rfc/rfc8414) Authorization Server Metadata
-    - §3 well-known URL construction, including path insertion for issuers with path components
-    - §3 `issuer` validation — warn on mismatch, continue
+    - §3.1 well-known URL construction, including path insertion for issuers with path components
+    - §3.3 `issuer` validation — warn on mismatch, continue
   - [RFC 8707](https://www.rfc-editor.org/rfc/rfc8707) Resource Indicators
     - §2 `resource` parameter in authorization, token exchange, **and refresh** requests
   - [RFC 7636](https://www.rfc-editor.org/rfc/rfc7636) PKCE

--- a/src/mcp_stdio/cli.py
+++ b/src/mcp_stdio/cli.py
@@ -266,6 +266,22 @@ def main() -> None:
         ),
     )
     parser.add_argument(
+        "--oauth-timeout",
+        type=_positive_float,
+        # #13 (round25): how long the interactive OAuth flow waits for the user —
+        # the browser-callback redirect (auth-code flow) or the device-code
+        # confirmation. Was a hardcoded 120 s; expose it so a user who needs
+        # longer (slow device-code entry) is not cut off. Distinct from the HTTP
+        # --timeout-* (those bound network reads, not human interaction).
+        default=120.0,
+        metavar="SECONDS",
+        help=(
+            "Seconds to wait for the interactive OAuth flow (browser callback / "
+            "device-code confirmation) before giving up (default: 120). Only "
+            "used with --oauth / --oauth-device"
+        ),
+    )
+    parser.add_argument(
         "-H",
         "--header",
         action="append",
@@ -495,6 +511,7 @@ def main() -> None:
                 device_flow=args.oauth_device,
                 refresh_leeway=args.oauth_refresh_leeway,
                 resource_indicator=not args.no_resource_indicator,
+                timeout=args.oauth_timeout,
             )
             # Drop any differently-cased 'authorization' header a -H supplied
             # earlier (the -H loop ran before this block), so the OAuth token is

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -206,6 +206,37 @@ class TestMain:
             main()
         assert mock_ensure.call_args.kwargs["refresh_leeway"] == 300.0
 
+    def test_oauth_timeout_default_and_flag(self):
+        """#13(round25): the interactive-OAuth wait is configurable via
+        --oauth-timeout (default 120) and propagated to ensure_token(timeout=)."""
+        # Default.
+        with (
+            patch("sys.argv", ["mcp-stdio", "--oauth", "https://example.com/mcp"]),
+            patch("mcp_stdio.oauth.ensure_token") as mock_ensure,
+            patch("mcp_stdio.cli.run"),
+        ):
+            mock_ensure.return_value.access_token = "tok"
+            main()
+        assert mock_ensure.call_args.kwargs["timeout"] == 120.0
+        # Custom flag.
+        with (
+            patch(
+                "sys.argv",
+                [
+                    "mcp-stdio",
+                    "--oauth",
+                    "--oauth-timeout",
+                    "300",
+                    "https://example.com/mcp",
+                ],
+            ),
+            patch("mcp_stdio.oauth.ensure_token") as mock_ensure,
+            patch("mcp_stdio.cli.run"),
+        ):
+            mock_ensure.return_value.access_token = "tok"
+            main()
+        assert mock_ensure.call_args.kwargs["timeout"] == 300.0
+
     def test_oauth_refresh_leeway_env_var(self, monkeypatch):
         """#56: MCP_OAUTH_REFRESH_LEEWAY env var is respected when flag absent."""
         monkeypatch.setenv("MCP_OAUTH_REFRESH_LEEWAY", "120")


### PR DESCRIPTION
## Overview

One LOW usability fix (#13) + two NIT doc-accuracy fixes (#16/#17) from the Opus 4.8 review (round 25).

## #13 — interactive-OAuth wait was a hardcoded 120 s (LOW)

`ensure_token` accepts a `timeout` that bounds how long the **interactive** OAuth flow waits for the user — the browser-callback redirect (auth-code flow) or the device-code confirmation. But `cli.py` never passed it, so the wait was a **hardcoded 120 s** with no way to extend it (a problem for slow device-code entry). Added `--oauth-timeout` (default 120) and pass it through. It is **distinct** from `--timeout-*` (those bound HTTP network reads, not human interaction).

## #16/#17 — README RFC 8414 section imprecision (NIT)

Both READMEs cited RFC 8414 well-known URL construction and issuer validation as **"§3"**, but the code cites **§3.1** (well-known, `oauth.py`) and **§3.3** (issuer mismatch, `oauth.py`). Corrected both READMEs in lockstep (English + Japanese).

## Test

`--oauth-timeout` default (120) and a custom flag value are propagated to `ensure_token(timeout=)`.

cli tests pass. READMEs in sync. No raw U+2028/U+2029/U+0085/U+FEFF bytes in source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)