### PR TITLE
fix(token_store): widen save soft-fail to non-OSError; warn on lock symlink

### DIFF
--- a/src/mcp_stdio/token_store.py
+++ b/src/mcp_stdio/token_store.py
@@ -51,6 +51,11 @@ _O_NONBLOCK = getattr(os, "O_NONBLOCK", 0)
 # so the credential-sharing warning is emitted only once per process.
 _warned_userinfo_key = False
 
+# Set once if the advisory lock file could not be opened because a symlink was
+# planted at its path (O_NOFOLLOW -> ELOOP). That silently disables
+# cross-process serialization, so the operator gets one warning per process.
+_warned_lock_symlink = False
+
 
 def _normalize_key(server_url: str) -> str:
     """Normalise a server URL into a stable token-store key.
@@ -503,7 +508,23 @@ def _store_lock() -> Iterator[None]:
             os.O_WRONLY | os.O_CREAT | _O_NOFOLLOW,
             stat.S_IRUSR | stat.S_IWUSR,
         )
-    except OSError:
+    except OSError as e:
+        # A symlink planted at the lock path (O_NOFOLLOW -> ELOOP) silently
+        # disables cross-process serialization — distinct from a benign
+        # read-only / missing-dir failure that just degrades to a no-op lock.
+        # Warn ONCE so the operator can notice the advisory-lock DoS, then
+        # proceed unlocked (a lock failure must never block the save). The dir's
+        # 0o700 mode is the primary guard against another user planting it.
+        if e.errno == errno.ELOOP:
+            global _warned_lock_symlink
+            if not _warned_lock_symlink:
+                _warned_lock_symlink = True
+                print(
+                    f"warning: token store lock path {lock_path} is a symlink "
+                    f"(refused via O_NOFOLLOW); proceeding without cross-process "
+                    f"locking — concurrent saves may last-writer-wins",
+                    file=sys.stderr,
+                )
         yield
         return
     # #9 (round19): the 0o600 mode above applies only on CREATION. Re-tighten a
@@ -649,7 +670,7 @@ def save_token(server_url: str, data: TokenData) -> None:
         store[key] = asdict(data)
         try:
             _write_store(store)
-        except OSError as e:
+        except Exception as e:
             # #4 (round21): a write failure (full / read-only FS, permission)
             # must fail SOFT, mirroring the _StoreUnreadable read path above. The
             # token is simply not cached — the caller re-auths next time — rather
@@ -657,6 +678,10 @@ def save_token(server_url: str, data: TokenData) -> None:
             # a worse case: a refresh whose save fails would otherwise propagate
             # out of refresh_cached_token and make the relay emit an auth error
             # even though the freshly refreshed token was perfectly usable.
+            # #12 (round26): catch Exception, not just OSError — _write_store's
+            # json.dumps runs before its inner try, so a non-serializable value
+            # injected upstream raises ValueError/TypeError that would otherwise
+            # bypass this soft-fail contract and crash the relay mid-session.
             print(
                 f"warning: could not write token store ({e}); token not cached, "
                 f"will re-authenticate next time",
@@ -687,11 +712,12 @@ def delete_token(server_url: str) -> None:
         if removed:
             try:
                 _write_store(store)
-            except OSError as e:
-                # Fail soft like save_token (#4 round21): a failed delete leaves
-                # the (stale) entry in place — a stale cached token at worst —
-                # rather than propagating an OSError up the caller. A later
-                # successful write reconciles it.
+            except Exception as e:
+                # Fail soft like save_token (#4 round21, #12 round26): a failed
+                # delete leaves the (stale) entry in place — a stale cached token
+                # at worst — rather than propagating up the caller. Catch
+                # Exception so a non-OSError from _write_store's pre-try
+                # json.dumps also degrades. A later successful write reconciles.
                 print(
                     f"warning: could not write token store ({e}); "
                     f"token not deleted",

--- a/tests/test_token_store.py
+++ b/tests/test_token_store.py
@@ -474,6 +474,10 @@ class TestLoadSaveDelete:
         assert stat.S_ISFIFO(os.stat(store_file).st_mode)
         assert "could not be read" in capsys.readouterr().err
 
+    @pytest.mark.skipif(
+        sys.platform == "win32",
+        reason="O_NOFOLLOW is 0 on Windows, so the symlink is not refused (ELOOP)",
+    )
     def test_lock_symlink_emits_one_warning_and_proceeds(
         self, tmp_path, monkeypatch, capsys
     ):

--- a/tests/test_token_store.py
+++ b/tests/test_token_store.py
@@ -451,6 +451,72 @@ class TestLoadSaveDelete:
         assert load_token("https://b.com/mcp").access_token == "tok-b"
         assert "could not be read" in capsys.readouterr().err
 
+    @pytest.mark.skipif(
+        sys.platform == "win32" or not hasattr(os, "mkfifo"),
+        reason="os.mkfifo is POSIX-only",
+    )
+    def test_save_aborts_when_store_is_fifo(self, tmp_path, monkeypatch, capsys):
+        """#13(round26): a FIFO (non-regular file) pre-planted at the store path
+        must make a save ABORT — the for_write=True fstat regular-file guard
+        raises _StoreUnreadable, so save_token skips the write rather than
+        clobbering (or hanging on) the special file. Complements the read-path
+        FIFO test (which only covers for_write=False -> {})."""
+        store_file = tmp_path / "tokens.json"
+        monkeypatch.setattr("mcp_stdio.token_store._STORE_DIR", tmp_path)
+        monkeypatch.setattr("mcp_stdio.token_store._STORE_FILE", store_file)
+
+        os.mkfifo(store_file)
+        # Must not hang and must not raise — the save aborts soft.
+        save_token("https://example.com/mcp", TokenData(access_token="tok"))
+
+        # The FIFO is untouched (not overwritten by a regular file) and a
+        # warning explains the skipped save.
+        assert stat.S_ISFIFO(os.stat(store_file).st_mode)
+        assert "could not be read" in capsys.readouterr().err
+
+    def test_lock_symlink_emits_one_warning_and_proceeds(
+        self, tmp_path, monkeypatch, capsys
+    ):
+        """#11(round26): a symlink planted at the lock path (refused via
+        O_NOFOLLOW -> ELOOP) silently disables cross-process serialization. The
+        save must still proceed unlocked AND emit a one-time warning so the
+        advisory-lock DoS is visible to the operator."""
+        store_file = tmp_path / "tokens.json"
+        lock_path = tmp_path / "tokens.json.lock"
+        monkeypatch.setattr("mcp_stdio.token_store._STORE_DIR", tmp_path)
+        monkeypatch.setattr("mcp_stdio.token_store._STORE_FILE", store_file)
+        monkeypatch.setattr("mcp_stdio.token_store._warned_lock_symlink", False)
+
+        # Plant a symlink at the lock path; O_NOFOLLOW makes os.open raise ELOOP.
+        lock_path.symlink_to(tmp_path / "decoy")
+
+        save_token("https://example.com/mcp", TokenData(access_token="tok"))
+
+        # The save still succeeded (unlocked) and warned about the symlink.
+        assert load_token("https://example.com/mcp").access_token == "tok"
+        err = capsys.readouterr().err
+        assert "lock path" in err and "symlink" in err
+
+    def test_save_soft_fails_on_non_serializable_value(
+        self, tmp_path, monkeypatch, capsys
+    ):
+        """#12(round26): _write_store's json.dumps runs before its inner try, so a
+        non-serializable value raises a non-OSError (TypeError). save_token's
+        except must catch Exception (not only OSError) so the soft-fail contract
+        holds and the relay is not crashed mid-session."""
+        store_file = tmp_path / "tokens.json"
+        monkeypatch.setattr("mcp_stdio.token_store._STORE_DIR", tmp_path)
+        monkeypatch.setattr("mcp_stdio.token_store._STORE_FILE", store_file)
+
+        # object() survives asdict() and makes json.dumps raise TypeError.
+        bad = TokenData(access_token=object())  # type: ignore[arg-type]
+        # Must not raise — degrades to a warning.
+        save_token("https://example.com/mcp", bad)
+
+        assert "could not write token store" in capsys.readouterr().err
+        # Nothing persisted (the write was aborted), so a later load re-auths.
+        assert load_token("https://example.com/mcp") is None
+
     def test_save_degrades_to_unlocked_when_lock_open_fails(
         self, tmp_path, monkeypatch
     ):


### PR DESCRIPTION
Round-26 review fixes for `token_store.py` (file-grouped PR 2/5).

## Changes
- **[nit] soft-fail contract** — `save_token` / `delete_token` catch `Exception` (not only `OSError`) around `_write_store`. Its `json.dumps` runs *before* the inner `try`, so a non-serializable value injected upstream raises `ValueError`/`TypeError` that would otherwise bypass the degrade-don't-crash contract and crash the relay mid-session.
- **[nit] advisory-lock DoS visibility** — `_store_lock` emits a one-time stderr warning when the lock file is refused because a symlink was planted at its path (`O_NOFOLLOW` → `ELOOP`). That silently disabled cross-process serialization. A benign read-only / missing-dir failure stays silent; the save still proceeds unlocked (a lock failure must never block a write).

## Tests
- `test_save_aborts_when_store_is_fifo` — drives the `for_write=True` fstat regular-file guard (complements the read-path FIFO test).
- `test_lock_symlink_emits_one_warning_and_proceeds`.
- `test_save_soft_fails_on_non_serializable_value`.

## Accepted (documented design, no change)
- **load-side migration copy-through race** — wrapping it in `_store_lock` would **deadlock**: `_read_store` → `_migrate_legacy_store` is reachable from inside `save_token`'s held lock, and a second `fcntl.flock(LOCK_EX)` on a new fd in the same process blocks on the first. The lock-free migration is deliberate; the one-time race is already documented and bounded.
- **empty-string `token_type` on load** — self-heals downstream (`_bearer_header_value` hardcodes `Bearer`); no normalization needed.

Full token_store suite: 71 passed. Raw separator scan clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)