### PR TITLE
fix(cli): propagate --oauth-timeout to the mid-session step-up flow

### DIFF
--- a/src/mcp_stdio/cli.py
+++ b/src/mcp_stdio/cli.py
@@ -152,12 +152,16 @@ def _build_scope_upgrader(
     headers: dict[str, str],
     timeout_connect: float,
     timeout_read: float,
+    oauth_timeout: float,
 ) -> Callable[[str], dict[str, str] | None]:
     """Build a scope-upgrade callback for the relay loop.
 
     Returns a callable that triggers an RFC 9470 / MCP step-up
     authorization flow for a given challenge scope and returns updated
-    headers on success, or None on failure.
+    headers on success, or None on failure. ``oauth_timeout`` bounds the
+    interactive wait (browser callback / device-code) the same way the
+    cold-start ``ensure_token`` does, so ``--oauth-timeout`` applies to a
+    mid-session step-up too, not just the initial authorization.
     """
 
     def upgrader(required_scope: str) -> dict[str, str] | None:
@@ -175,7 +179,9 @@ def _build_scope_upgrader(
             follow_redirects=False,
         )
         try:
-            data = step_up_authorize(server_url, client, required_scope)
+            data = step_up_authorize(
+                server_url, client, required_scope, timeout=oauth_timeout
+            )
             new_headers = dict(headers)
             new_headers["Authorization"] = _bearer_header_value(data.access_token)
         except Exception as e:
@@ -545,7 +551,11 @@ def main() -> None:
                     args.url, headers, args.timeout_connect, args.timeout_read
                 )
                 scope_upgrader = _build_scope_upgrader(
-                    args.url, headers, args.timeout_connect, args.timeout_read
+                    args.url,
+                    headers,
+                    args.timeout_connect,
+                    args.timeout_read,
+                    args.oauth_timeout,
                 )
         except Exception as e:
             print(f"error: OAuth authentication failed: {e}", file=sys.stderr)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -965,17 +965,24 @@ class TestBuildScopeUpgrader:
     def test_returns_bearer_headers_and_closes_client(self, monkeypatch):
         _SpyClient.instances.clear()
         monkeypatch.setattr("mcp_stdio.cli.httpx.Client", _SpyClient)
-        monkeypatch.setattr(
-            "mcp_stdio.oauth.step_up_authorize",
-            lambda url, client, scope: TokenData(access_token="upgraded"),
-        )
+        captured = {}
+
+        def fake_step_up(url, client, scope, *, timeout):
+            captured["timeout"] = timeout
+            return TokenData(access_token="upgraded")
+
+        monkeypatch.setattr("mcp_stdio.oauth.step_up_authorize", fake_step_up)
         upgrader = _build_scope_upgrader(
-            "https://example.com/mcp", {"X-Base": "1"}, 10, 120
+            "https://example.com/mcp", {"X-Base": "1"}, 10, 120, 90
         )
         out = upgrader("hr:read hr:write")
         assert out["Authorization"] == "Bearer upgraded"
         assert out["X-Base"] == "1"
         assert _SpyClient.instances[-1].closed
+        # #13(round26): --oauth-timeout must reach the mid-session step-up too,
+        # not just the cold-start ensure_token — otherwise a step-up silently
+        # falls back to step_up_authorize's hardcoded 120 s default.
+        assert captured["timeout"] == 90
         # #11(round19): the RFC 9470 step-up path carries the same credential-leak
         # exposure as refresh, so its client must pin follow_redirects=False too
         # (an AS-controlled token endpoint could otherwise 302 the credential POST
@@ -986,11 +993,11 @@ class TestBuildScopeUpgrader:
         _SpyClient.instances.clear()
         monkeypatch.setattr("mcp_stdio.cli.httpx.Client", _SpyClient)
 
-        def boom(url, client, scope):
+        def boom(url, client, scope, *, timeout):
             raise RuntimeError("step-up denied")
 
         monkeypatch.setattr("mcp_stdio.oauth.step_up_authorize", boom)
-        upgrader = _build_scope_upgrader("https://example.com/mcp", {}, 10, 120)
+        upgrader = _build_scope_upgrader("https://example.com/mcp", {}, 10, 120, 90)
         assert upgrader("hr:read") is None
         assert _SpyClient.instances[-1].closed
         assert "step-up authorization failed" in capsys.readouterr().err


### PR DESCRIPTION
Round-26 review fix for `cli.py` (file-grouped PR 3/5).

## Change
- **[low] `--oauth-timeout` step-up gap** — `main()` passed `args.oauth_timeout` to the cold-start `ensure_token`, but `_build_scope_upgrader` called `step_up_authorize` *without* a timeout, so a mid-session RFC 9470 / MCP step-up re-authorization silently fell back to `step_up_authorize`'s hardcoded `120` s default. A user who set `--oauth-timeout 300` got 300 s at cold start but only 120 s on a step-up. Thread `oauth_timeout` through `_build_scope_upgrader` → `step_up_authorize`.

## Tests
- `test_returns_bearer_headers_and_closes_client` now asserts the upgrader forwards `timeout=args.oauth_timeout`.
- Both existing `TestBuildScopeUpgrader` tests updated for the new signature (the `step_up_authorize` mocks take the keyword-only `timeout`).

Full cli suite: 83 passed. Raw separator scan clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)