### PR TITLE
fix(oauth): reject cross-origin issuer; sanitize refresh-failure log

### DIFF
--- a/src/mcp_stdio/oauth.py
+++ b/src/mcp_stdio/oauth.py
@@ -421,14 +421,30 @@ def _fetch_authorization_server_metadata(
         if resp.status_code == 200:
             data = resp.json()
             # RFC 8414 §3.3: the issuer in the response MUST be identical to the
-            # URL used for discovery. We log a warning on mismatch but continue
-            # (the spec says reject) — real servers may be slightly misconfigured
-            # (trailing slash, etc.) and rejecting would be too strict.
+            # URL used for discovery. We split the spec's MUST-reject by ORIGIN:
+            #   - A cross-ORIGIN issuer (different scheme/host/port) is a mix-up /
+            #     AS-spoofing signal — REJECT (return None) so this metadata is
+            #     never used. Otherwise it would anchor the RFC 9207 `iss` check
+            #     (see issuer= below) on a FOREIGN origin: an adversarial AS that
+            #     returns a different issuer AND echoes that same `iss` on the
+            #     callback would self-satisfy the mix-up defence.
+            #   - A SAME-origin mismatch (trailing slash, path, case) is the kind
+            #     of slight misconfiguration real servers ship, so warn and
+            #     continue — rejecting on a cosmetic difference is too strict.
             issuer = data.get("issuer")
+            if issuer and _origin(urlparse(issuer)) != _origin(
+                urlparse(auth_server_base)
+            ):
+                log(
+                    f"warning: RFC 8414 §3.3 issuer ORIGIN mismatch — expected "
+                    f"the origin of {auth_server_base!r}, got {issuer!r}; "
+                    f"refusing this authorization-server metadata (mix-up guard)"
+                )
+                return None
             if issuer and issuer.rstrip("/") != auth_server_base.rstrip("/"):
                 log(
-                    f"warning: RFC 8414 §3.3 issuer mismatch — "
-                    f"expected {auth_server_base!r}, got {issuer!r}"
+                    f"warning: RFC 8414 §3.3 issuer mismatch (same origin) — "
+                    f"expected {auth_server_base!r}, got {issuer!r}; continuing"
                 )
             methods = data.get("token_endpoint_auth_methods_supported")
             # Strip a trailing slash before building default endpoints so an AS
@@ -1151,7 +1167,12 @@ def refresh_cached_token(
             auth_method=auth_method,
         )
     except Exception as e:
-        log(f"token refresh failed: {e}")
+        # Sanitise the interpolated exception text: today's reachable exceptions
+        # (httpx.HTTPStatusError, _raise_for_body_error's RuntimeError) carry no
+        # token or raw AS body, but a future exception type embedding resp.text
+        # would otherwise leak AS-controlled bytes into the log. Bound it
+        # defensively so no exception type can write an unbounded/raw log line.
+        log(f"token refresh failed: {_sanitize_oauth_error(e)}")
         return None
     metadata = OAuthMetadata(
         authorization_endpoint=cached.authorization_endpoint,

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -746,24 +746,66 @@ class TestDiscoverMetadata:
             "https://api.example.com:8443/.well-known/oauth-protected-resource/mcp"
         )
 
-    def test_rfc8414_issuer_mismatch_warns_but_continues(self, httpx_mock, caplog):
-        """RFC 8414 §3: issuer in metadata mismatches discovery URL — warn, don't fail."""
-        import logging
-
+    def test_rfc8414_cross_origin_issuer_rejected(self, httpx_mock):
+        """#8(round26): RFC 8414 §3.3 — a CROSS-ORIGIN issuer (different host)
+        is a mix-up / AS-spoofing signal, so the metadata is REJECTED rather
+        than used. Discovery falls back to the synthesized defaults on the
+        discovery origin, so the spoofed endpoints never receive a credential."""
         self._mock_no_prm(httpx_mock)
         httpx_mock.add_response(
             url="https://api.example.com/.well-known/oauth-authorization-server",
             json={
-                "issuer": "https://other.example.com",  # mismatch
+                "issuer": "https://other.example.com",  # cross-origin → spoof
                 "authorization_endpoint": "https://api.example.com/auth",
                 "token_endpoint": "https://api.example.com/token",
             },
         )
         client = httpx.Client()
-        with caplog.at_level(logging.DEBUG):
-            meta = discover_oauth_metadata("https://api.example.com/mcp", client)
-        # Metadata is still returned despite mismatch
+        meta = discover_oauth_metadata("https://api.example.com/mcp", client)
+        # The spoofed metadata's "/auth" is NOT used — the synthesized default
+        # "/authorize" on the discovery origin is, proving the reject took hold.
+        assert meta.authorization_endpoint == "https://api.example.com/authorize"
+
+    def test_rfc8414_same_origin_issuer_trailing_slash_warns_but_continues(
+        self, httpx_mock
+    ):
+        """#8(round26): a SAME-origin issuer mismatch (trailing slash / path /
+        case) is the slight misconfiguration real servers ship — warn, but still
+        use the metadata. Only a cross-origin issuer is rejected."""
+        self._mock_no_prm(httpx_mock)
+        httpx_mock.add_response(
+            url="https://api.example.com/.well-known/oauth-authorization-server",
+            json={
+                "issuer": "https://api.example.com/",  # same origin, trailing /
+                "authorization_endpoint": "https://api.example.com/auth",
+                "token_endpoint": "https://api.example.com/token",
+            },
+        )
+        client = httpx.Client()
+        meta = discover_oauth_metadata("https://api.example.com/mcp", client)
+        # Same-origin drift is tolerated: the metadata endpoints ARE used.
         assert meta.authorization_endpoint == "https://api.example.com/auth"
+
+    def test_phase3_refuses_cleartext_synthesized_endpoints(self, httpx_mock):
+        """#15(round26): when discovery falls to Phase 3 (no PRM, no RFC 8414
+        metadata) and the only base is a cleartext non-loopback http:// origin,
+        synthesizing default /authorize + /token would POST the code +
+        client_secret in plaintext. _validate_endpoint_url rejects them and
+        discover_oauth_metadata HARD-FAILS with ValueError rather than returning
+        unsafe endpoints. Drives the integration path of the #5(round19) guard."""
+        base = "http://evil.example.com"
+        self._mock_no_prm(httpx_mock, base=base, path="/mcp")
+        # RFC 8414 metadata absent on both the base and the path-scoped issuer.
+        httpx_mock.add_response(
+            url=f"{base}/.well-known/oauth-authorization-server", status_code=404
+        )
+        httpx_mock.add_response(
+            url=f"{base}/.well-known/oauth-authorization-server/mcp",
+            status_code=404,
+        )
+        client = httpx.Client()
+        with pytest.raises(ValueError, match="refusing to synthesize"):
+            discover_oauth_metadata(f"{base}/mcp", client)
 
     def test_rfc8414_issuer_match_no_warning(self, httpx_mock):
         """RFC 8414 §3: issuer matches — no warning, metadata returned normally."""
@@ -3624,33 +3666,84 @@ class TestStateCsrfCheck:
         ]
         assert token_calls == []
 
-    def test_uses_constant_time_comparison(self, monkeypatch):
-        """The comparison goes through secrets.compare_digest, not ==.
+    def test_uses_constant_time_comparison(
+        self, tmp_path, monkeypatch, httpx_mock
+    ):
+        """#14(round26): the CSRF state check goes through secrets.compare_digest
+        on the PRODUCTION path, not ==.
 
-        Monkeypatches `secrets.compare_digest` in the oauth module and
-        asserts it was called with the expected (callback_state, local_state)
-        pair — no clever timing assertion, just structural evidence that
-        the constant-time path is wired up.
+        The previous version called compare_digest itself in the test body, so it
+        was tautological — a refactor to `==` would not have failed it. This runs
+        the real `ensure_token` flow with a spy installed and asserts the spy was
+        invoked with `(callback_state, sent_state)` from the production code.
+        Swapping the production comparison to `==` makes compare_digest go
+        uncalled, so this test fails — the regression is now guarded.
         """
         import mcp_stdio.oauth as oauth_mod
+        from urllib.parse import parse_qs, urlparse
+        from urllib.request import urlopen
+
+        store_file = tmp_path / "tokens.json"
+        monkeypatch.setattr("mcp_stdio.token_store._STORE_DIR", tmp_path)
+        monkeypatch.setattr("mcp_stdio.token_store._STORE_FILE", store_file)
 
         calls: list[tuple[str, str]] = []
         real_compare = oauth_mod.secrets.compare_digest
 
-        def spying_compare(a: str, b: str) -> bool:
+        def spying_compare(a, b):
             calls.append((a, b))
             return real_compare(a, b)
 
-        monkeypatch.setattr(
-            oauth_mod.secrets, "compare_digest", spying_compare
+        monkeypatch.setattr(oauth_mod.secrets, "compare_digest", spying_compare)
+
+        httpx_mock.add_response(url="https://example.com/mcp", status_code=401)
+        httpx_mock.add_response(
+            url="https://example.com/.well-known/oauth-protected-resource/mcp",
+            status_code=404,
+        )
+        httpx_mock.add_response(
+            url="https://example.com/.well-known/oauth-protected-resource",
+            status_code=404,
+        )
+        httpx_mock.add_response(
+            url="https://example.com/.well-known/oauth-authorization-server",
+            json={
+                "authorization_endpoint": "https://example.com/authorize",
+                "token_endpoint": "https://example.com/token",
+                "registration_endpoint": "https://example.com/register",
+            },
+        )
+        httpx_mock.add_response(
+            url="https://example.com/register",
+            json={"client_id": "cid"},
         )
 
-        # Exercise the comparison path directly (without running the full
-        # HTTP flow — that is covered by the previous test).
-        assert oauth_mod.secrets.compare_digest("abc", "abc") is True
-        assert calls[-1] == ("abc", "abc")
-        assert oauth_mod.secrets.compare_digest("abc", "abd") is False
-        assert calls[-1] == ("abc", "abd")
+        sent: dict[str, str] = {}
+
+        def fake_open(auth_url: str) -> bool:
+            q = parse_qs(urlparse(auth_url).query)
+            sent["state"] = q["state"][0]
+            redirect_uri = q["redirect_uri"][0]
+
+            def hit_callback() -> None:
+                cb_url = f"{redirect_uri}?code=evil&state=attacker-state"
+                try:
+                    urlopen(cb_url, timeout=5).read()
+                except Exception:
+                    pass
+
+            threading.Thread(target=hit_callback, daemon=True).start()
+            return True
+
+        monkeypatch.setattr("mcp_stdio.oauth.webbrowser.open", fake_open)
+
+        client = httpx.Client()
+        with pytest.raises(RuntimeError, match="state mismatch"):
+            ensure_token(self.SERVER_URL, client, timeout=5)
+
+        # The production CSRF check called compare_digest with the callback's
+        # state and the state we sent — proving the constant-time path is live.
+        assert ("attacker-state", sent["state"]) in calls
 
 
 class TestAuthorizationFlowFailurePaths:

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -760,6 +760,18 @@ class TestDiscoverMetadata:
                 "token_endpoint": "https://api.example.com/token",
             },
         )
+        # Rejecting the spoofed metadata makes discovery continue to the
+        # path-scoped RFC 8414 §3.1 fetch before Phase 3 — mock it as 404 so no
+        # unexpected request escapes. pytest_httpx strict mode flags it at
+        # TEARDOWN, where _fetch_authorization_server_metadata's broad except
+        # cannot swallow it (a local run passed without this; see #151 round21).
+        httpx_mock.add_response(
+            url=(
+                "https://api.example.com/.well-known/"
+                "oauth-authorization-server/mcp"
+            ),
+            status_code=404,
+        )
         client = httpx.Client()
         meta = discover_oauth_metadata("https://api.example.com/mcp", client)
         # The spoofed metadata's "/auth" is NOT used — the synthesized default


### PR DESCRIPTION
Round-26 review fixes for `oauth.py` (file-grouped PR 4/5).

## Changes
- **[low] RFC 8414 §3.3 issuer mix-up guard** — split the spec's MUST-reject by **origin**. A cross-origin issuer (different scheme/host/port) is a mix-up / AS-spoofing signal → the metadata is **rejected** (`return None`), so it never anchors the RFC 9207 `iss` callback check on a foreign origin. A same-origin mismatch (trailing slash / path / case) stays warn-and-continue (real servers ship that). On reject, discovery falls back to the synthesized defaults on the discovery origin, so a credential never reaches the spoofed endpoints.
- **[nit] refresh-failure log sanitization** — `refresh_cached_token` wraps the interpolated exception text in `_sanitize_oauth_error`, defensively bounding any future exception type that might embed `resp.text` so no AS-controlled bytes reach the log.

## Tests
- `test_rfc8414_cross_origin_issuer_rejected` — spoofed metadata rejected; discovery uses synthesized defaults.
- `test_rfc8414_same_origin_issuer_trailing_slash_warns_but_continues` — same-origin drift tolerated.
- `test_phase3_refuses_cleartext_synthesized_endpoints` — drives the Phase-3 cleartext hard-fail through `discover_oauth_metadata` (was only unit-tested at `_validate_endpoint_url`).
- `test_uses_constant_time_comparison` rewritten to run the real `ensure_token` flow and assert `compare_digest` is called with `(callback_state, sent_state)` — a regression to `==` now fails it (the old test was tautological).

## Accepted (documented design, no change)
- **cross-origin `authorization_server` warn-only** (`_validate_auth_server_url`) — federation is permitted by RFC 9728 §2; cleartext/userinfo are already hard-rejected, and the existing warning tells the operator to abort if federation was unexpected. The AS origin is also visible in the browser address bar at consent. (A `--no-cross-origin-as` opt-out knob is a candidate for a future dedicated PR.)

Full oauth suite: 271 passed, no teardown errors. Raw separator scan clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)