### PR TITLE
docs: add --oauth-timeout to Options tables; update RFC 8414 §3.3 wording

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -30,7 +30,7 @@ Bearer token、カスタムヘッダー、OAuth 2.1 認証情報をリモート�
     - §5.1 `WWW-Authenticate: Bearer resource_metadata=` ヒント — discovery 前にサーバーへ probe を送り、well-known パスの推測に頼らず PRM の所在を直接特定する
   - [RFC 8414](https://www.rfc-editor.org/rfc/rfc8414) Authorization Server Metadata
     - §3.1 well-known URL 構築。パス付き issuer のパス挿入ルール対応
-    - §3.3 `issuer` 検証（不一致は警告して続行）
+    - §3.3 `issuer` 検証（クロスオリジンの issuer は AS mix-up 対策で拒否、同一オリジンの差異〔trailing slash / path / case〕は警告して続行）
   - [RFC 8707](https://www.rfc-editor.org/rfc/rfc8707) Resource Indicators
     - §2 `resource` パラメータを認可リクエスト・トークン交換・**リフレッシュ**に送信
   - [RFC 7636](https://www.rfc-editor.org/rfc/rfc7636) PKCE
@@ -188,6 +188,9 @@ mcp-stdio [OPTIONS] URL
   --oauth-refresh-leeway SECONDS
                          アクセストークンを expire の何秒前に proactive refresh
                          するか（デフォルト: 60、または MCP_OAUTH_REFRESH_LEEWAY 環境変数）
+  --oauth-timeout SECONDS
+                         対話的 OAuth フロー（ブラウザコールバック / デバイス
+                         コード確認）の待機秒数（デフォルト: 120、OAuth 時のみ有効）
   --no-resource-indicator
                          すべての OAuth リクエストから RFC 8707 resource
                          パラメータを除外する。api:// スコープを使う Microsoft

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Bearer tokens, custom headers, and OAuth 2.1 credentials are forwarded to the re
     - §5.1 `WWW-Authenticate: Bearer resource_metadata=` hint — probes the server before discovery so servers that publish PRM at a non-standard URL are found without well-known path guessing
   - [RFC 8414](https://www.rfc-editor.org/rfc/rfc8414) Authorization Server Metadata
     - §3.1 well-known URL construction, including path insertion for issuers with path components
-    - §3.3 `issuer` validation — warn on mismatch, continue
+    - §3.3 `issuer` validation — reject a cross-origin issuer (AS mix-up guard), warn on a same-origin mismatch (trailing slash / path / case) and continue
   - [RFC 8707](https://www.rfc-editor.org/rfc/rfc8707) Resource Indicators
     - §2 `resource` parameter in authorization, token exchange, **and refresh** requests
   - [RFC 7636](https://www.rfc-editor.org/rfc/rfc7636) PKCE
@@ -190,6 +190,10 @@ Options:
   --oauth-refresh-leeway SECONDS
                          Proactively refresh tokens this many seconds before
                          expiry (default: 60, or MCP_OAUTH_REFRESH_LEEWAY)
+  --oauth-timeout SECONDS
+                         Seconds to wait for the interactive OAuth flow (browser
+                         callback / device-code confirmation) before giving up
+                         (default: 120; OAuth only)
   --no-resource-indicator
                          Omit the RFC 8707 resource parameter from all OAuth
                          requests. Required for AS that reject it, such as


### PR DESCRIPTION
Round-26 review fixes for the docs (file-grouped PR 5/5).

## Changes
- **[low] `--oauth-timeout` missing from Options tables** — the flag (added in `b4cd7a9`) is user-facing (operators with slow device-code entry need it) but was absent from the Options table in **both** README.md and README.ja.md, while the table claims `--help` parity. Added in both, kept EN/JA in sync.
- **RFC 8414 §3.3 wording** — updated to match PR #185: a cross-origin issuer is rejected (AS mix-up guard); a same-origin mismatch (trailing slash / path / case) still warns and continues.

No code change. Raw separator scan clean.

> Merge after #185 (oauth) so the README §3.3 wording matches the shipped behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)