### PR TITLE
test(relay): de-flake the SSE stream-ends-before-response check test

### DIFF
--- a/tests/test_relay.py
+++ b/tests/test_relay.py
@@ -3585,16 +3585,34 @@ class TestCheckConnectionSse:
         )
 
     def test_sse_stream_ends_before_response_returns_false(self, httpx_mock):
-        """endpoint arrives but no initialize response before EOF → False."""
+        """endpoint arrives but no initialize response before EOF → False.
+
+        The stream is held open until the endpoint POST has been observed, so
+        the mocked POST is deterministically requested. Without this, the reader
+        thread's EOF could race ahead of the main thread's POST and leave the
+        POST mock 'mocked but not requested' — a flaky pytest_httpx teardown
+        error (it intermittently failed CI on ubuntu 3.11). The probe still
+        returns False because no initialize response ever arrives."""
+        post_attempted = threading.Event()
+
+        def sse_gen():
+            yield b"event: endpoint\ndata: /messages\n\n"
+            # Hold the stream open until the POST is in flight, then EOF with no
+            # initialize response so the probe reports 'stream ended' → False.
+            post_attempted.wait(timeout=3)
+
         httpx_mock.add_response(
             url=self.SSE_URL,
             method="GET",
-            stream=IteratorStream([b"event: endpoint\ndata: /messages\n\n"]),
+            stream=IteratorStream(sse_gen()),
             headers={"content-type": "text/event-stream"},
         )
-        httpx_mock.add_response(
-            url="https://example.com/messages", method="POST", status_code=202
-        )
+
+        def on_post(request: httpx.Request) -> httpx.Response:
+            post_attempted.set()
+            return httpx.Response(status_code=202)
+
+        httpx_mock.add_callback(on_post, url="https://example.com/messages")
         assert (
             check_connection(self.SSE_URL, dict(self.HEADERS), transport="sse")
             is False


### PR DESCRIPTION
Fixes a flaky CI failure that intermittently blocked the merge-on-green workflow.

## Problem
`test_sse_stream_ends_before_response_returns_false` failed on `#186`'s ubuntu-3.11 job with:

```
ERROR ... AssertionError: The following responses are mocked but not requested:
  - Match POST request on https://example.com/messages
```

The SSE GET stream yielded the `endpoint` event then hit EOF immediately. The reader thread's EOF could race ahead of the main thread's endpoint POST, so `check_connection` sometimes returned `False` (stream ended) before the POST went out — leaving the mocked POST unused, which `pytest_httpx` strict mode flags at teardown.

## Fix
Hold the stream open until the POST is observed — a `threading.Event` set by an `add_callback` POST handler, with `sse_gen()` waiting on it before EOF. Mirrors the sibling `test_sse_post_non_2xx_reports_post_failure` / `test_sse_post_raises_reports_post_failure` pattern. The probe still returns `False` (no initialize response arrives).

Ran the test 10× locally — deterministic pass. Full `TestCheckConnectionSse`: 12 passed. Raw separator scan clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)