### PR TITLE
fix(token_store): refuse to migrate a symlinked/non-regular legacy store

### DIFF
--- a/src/mcp_stdio/token_store.py
+++ b/src/mcp_stdio/token_store.py
@@ -192,8 +192,21 @@ def _read_legacy_data() -> dict[str, Any] | None:
     an attacker-redirected symlink target) over the XDG store.
     """
     try:
-        fd = os.open(_LEGACY_STORE_FILE, os.O_RDONLY | _O_NOFOLLOW)
+        fd = os.open(_LEGACY_STORE_FILE, os.O_RDONLY | _O_NOFOLLOW | _O_NONBLOCK)
     except OSError:
+        return None
+    # Refuse a non-regular legacy file the same way _read_store does (#2
+    # round27): O_NOFOLLOW blocks a symlink, but an O_RDONLY read of a
+    # writer-less FIFO planted at the legacy path would block forever and hang
+    # every token load / relay startup. O_NONBLOCK makes the open return at
+    # once (a no-op for the regular file we expect); fstat then rejects the
+    # special file before f.read() can hang on it.
+    try:
+        if not stat.S_ISREG(os.fstat(fd).st_mode):
+            os.close(fd)
+            return None
+    except OSError:
+        os.close(fd)
         return None
     try:
         with os.fdopen(fd, "r", encoding="utf-8") as f:
@@ -272,13 +285,50 @@ def _migrate_legacy_store() -> None:
             os.chmod(_LEGACY_STORE_DIR, stat.S_IRWXU)  # 0o700
         except OSError:
             pass
-        # Tighten the legacy file's mode BEFORE moving it, so the secrets never
-        # sit at the new XDG path with a looser (pre-0o600) mode, even briefly:
-        # rename() preserves the source inode's permission bits.
+        # #1 (round27): before moving the legacy file into the TRUSTED XDG store
+        # path, confirm it is a REGULAR file via an O_NOFOLLOW-anchored fd.
+        # Path.rename moves a SYMLINK itself, so a symlink planted at the legacy
+        # path (a dotfile manager like GNU Stow, a backup/restore — not
+        # necessarily an attacker) would otherwise land at
+        # ~/.config/mcp-stdio/tokens.json, after which every O_NOFOLLOW read
+        # ELOOPs and save/delete abort forever — a permanent token-cache DoS.
+        # Open with O_NOFOLLOW (refuses a symlink: ELOOP) + O_NONBLOCK (so a FIFO
+        # cannot block the open), fstat for S_ISREG, and fchmod through that fd
+        # (a path-based chmod would FOLLOW a symlink and 0o600 an attacker /
+        # user-chosen target). A non-regular / symlinked legacy file is left
+        # untouched — never followed into the store. The residual TOCTOU between
+        # this check and the path-based rename below is bounded by the legacy
+        # dir's 0o700 mode (re-asserted just above), so only the owning user
+        # could swap the inode, which is the self-induced dotfile-manager case.
+        legacy_is_regular = False
         try:
-            os.chmod(_LEGACY_STORE_FILE, stat.S_IRUSR | stat.S_IWUSR)
+            _lfd = os.open(
+                _LEGACY_STORE_FILE, os.O_RDONLY | _O_NOFOLLOW | _O_NONBLOCK
+            )
         except OSError:
-            pass
+            _lfd = -1
+        if _lfd >= 0:
+            try:
+                legacy_is_regular = stat.S_ISREG(os.fstat(_lfd).st_mode)
+            except OSError:
+                legacy_is_regular = False
+            if legacy_is_regular:
+                # Tighten the mode BEFORE moving it, so the secrets never sit at
+                # the new XDG path with a looser (pre-0o600) mode even briefly:
+                # rename() preserves the source inode's permission bits. fchmod
+                # is anchored to the fd, so it cannot follow a swapped-in symlink.
+                _fchmod = getattr(os, "fchmod", None)
+                if _fchmod is not None:
+                    try:
+                        _fchmod(_lfd, stat.S_IRUSR | stat.S_IWUSR)  # 0o600
+                    except OSError:
+                        pass
+            os.close(_lfd)
+        if not legacy_is_regular:
+            # Symlink / FIFO / device / vanished legacy file — do not rename or
+            # copy it into the trusted store. Leave it in place; the XDG store
+            # stays absent so load_token returns None (a clean re-auth).
+            return
         try:
             _LEGACY_STORE_FILE.rename(_STORE_FILE)
         except OSError:

--- a/tests/test_token_store.py
+++ b/tests/test_token_store.py
@@ -474,6 +474,59 @@ class TestLoadSaveDelete:
         assert stat.S_ISFIFO(os.stat(store_file).st_mode)
         assert "could not be read" in capsys.readouterr().err
 
+    def test_mid_read_failure_aborts_save_and_load_returns_none(
+        self, tmp_path, monkeypatch, capsys
+    ):
+        """#8(round27): _read_store's open SUCCEEDS but the read itself fails
+        (e.g. EIO on a flaky fs). The write path must raise _StoreUnreadable so a
+        save ABORTS (never clobbers the unread store), and the read path must
+        degrade to {} so a load returns None — the third raise site (mid-read),
+        symmetric with the open-failure and non-regular-file guards."""
+        store_file = tmp_path / "tokens.json"
+        monkeypatch.setattr("mcp_stdio.token_store._STORE_DIR", tmp_path)
+        monkeypatch.setattr("mcp_stdio.token_store._STORE_FILE", store_file)
+
+        save_token("https://a.com/mcp", TokenData(access_token="tok-a"))
+        save_token("https://b.com/mcp", TokenData(access_token="tok-b"))
+
+        real_fdopen = os.fdopen
+
+        class _BadReader:
+            def __init__(self, fd):
+                self._fd = fd
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *exc):
+                os.close(self._fd)
+                return False
+
+            def read(self, *a):
+                raise OSError(5, "EIO")
+
+        def failing_read_fdopen(fd, mode="r", *a, **k):
+            # Only the READ-open of the store gets a failing handle; the write
+            # path ("wb") and everything else stay real.
+            if "r" in mode:
+                return _BadReader(fd)
+            return real_fdopen(fd, mode, *a, **k)
+
+        monkeypatch.setattr(
+            "mcp_stdio.token_store.os.fdopen", failing_read_fdopen
+        )
+        # Read path: mid-read OSError degrades to {} → load returns None.
+        assert load_token("https://a.com/mcp") is None
+        # Write path: mid-read OSError raises _StoreUnreadable → save aborts soft.
+        save_token("https://c.com/mcp", TokenData(access_token="tok-c"))
+        assert "could not be read" in capsys.readouterr().err
+
+        monkeypatch.setattr("mcp_stdio.token_store.os.fdopen", real_fdopen)
+        # The pre-existing tokens survive; the aborted save persisted nothing.
+        assert load_token("https://a.com/mcp").access_token == "tok-a"
+        assert load_token("https://b.com/mcp").access_token == "tok-b"
+        assert load_token("https://c.com/mcp") is None
+
     @pytest.mark.skipif(
         sys.platform == "win32",
         reason="O_NOFOLLOW is 0 on Windows, so the symlink is not refused (ELOOP)",
@@ -837,6 +890,66 @@ class TestLegacyMigration:
         mode = os.stat(new_file).st_mode
         assert mode & stat.S_IRWXG == 0
         assert mode & stat.S_IRWXO == 0
+
+    @pytest.mark.skipif(
+        sys.platform == "win32",
+        reason="POSIX symlink semantics; O_NOFOLLOW is 0 on Windows",
+    )
+    def test_migration_refuses_symlinked_legacy_store(self, tmp_path, monkeypatch):
+        """#1(round27): a SYMLINK planted at the legacy path must NOT be renamed
+        into the trusted XDG store path — Path.rename would move the symlink
+        itself, after which every O_NOFOLLOW read ELOOPs and save/delete abort
+        forever (a permanent token-cache DoS). The migration is refused and the
+        XDG store is left absent (clean re-auth)."""
+        legacy_dir = tmp_path / "legacy"
+        new_dir = tmp_path / "new"
+        legacy_dir.mkdir()
+        legacy_file = legacy_dir / "tokens.json"
+        new_file = new_dir / "tokens.json"
+        # A real decoy the symlink points at — if the bug regressed and the
+        # symlink were moved to new_file, new_file.exists() would follow to it.
+        decoy = tmp_path / "decoy.json"
+        decoy.write_text('{"https://evil.com/mcp": {"access_token": "stolen"}}')
+        legacy_file.symlink_to(decoy)
+
+        monkeypatch.setattr("mcp_stdio.token_store._STORE_DIR", new_dir)
+        monkeypatch.setattr("mcp_stdio.token_store._STORE_FILE", new_file)
+        monkeypatch.setattr("mcp_stdio.token_store._LEGACY_STORE_DIR", legacy_dir)
+        monkeypatch.setattr("mcp_stdio.token_store._LEGACY_STORE_FILE", legacy_file)
+
+        # Migration is refused: nothing is read from or moved out of the symlink.
+        assert load_token("https://evil.com/mcp") is None
+        assert not new_file.exists()  # no symlink/file landed in the trusted path
+        assert not new_file.is_symlink()
+        assert legacy_file.is_symlink()  # the legacy symlink is left untouched
+        assert decoy.exists()  # the decoy target was never consumed
+
+    @pytest.mark.skipif(
+        sys.platform == "win32" or not hasattr(os, "mkfifo"),
+        reason="os.mkfifo is POSIX-only",
+    )
+    def test_migration_skips_fifo_legacy_store_without_hanging(
+        self, tmp_path, monkeypatch
+    ):
+        """#1/#2(round27): a FIFO at the legacy path must not be migrated and must
+        not hang the load — the rename-branch fstat guard (and _read_legacy_data's
+        O_NONBLOCK) refuse the special file. load returns None, no hang."""
+        legacy_dir = tmp_path / "legacy"
+        new_dir = tmp_path / "new"
+        legacy_dir.mkdir()
+        legacy_file = legacy_dir / "tokens.json"
+        new_file = new_dir / "tokens.json"
+        os.mkfifo(legacy_file)
+
+        monkeypatch.setattr("mcp_stdio.token_store._STORE_DIR", new_dir)
+        monkeypatch.setattr("mcp_stdio.token_store._STORE_FILE", new_file)
+        monkeypatch.setattr("mcp_stdio.token_store._LEGACY_STORE_DIR", legacy_dir)
+        monkeypatch.setattr("mcp_stdio.token_store._LEGACY_STORE_FILE", legacy_file)
+
+        # If the fstat/O_NONBLOCK guards regressed, this would hang forever.
+        assert load_token("https://example.com/mcp") is None
+        assert not new_file.exists()
+        assert stat.S_ISFIFO(os.lstat(legacy_file).st_mode)  # FIFO left in place
 
     def test_migration_survives_cross_device_rename(self, tmp_path, monkeypatch):
         """An EXDEV (cross-filesystem) rename must not brick the store — the


### PR DESCRIPTION
Round-27 review fixes for `token_store.py` (file-grouped PR 1/3). Includes the round's one **MEDIUM**.

## Changes
- **[medium] legacy migration symlink-rename DoS** (`_migrate_legacy_store`) — the rename branch moved the legacy file into the trusted XDG store path without confirming it is a regular file. `Path.rename` moves a **symlink itself**, so a symlink planted at `~/.mcp-stdio/tokens.json` (a dotfile manager like GNU Stow, a backup/restore — not necessarily an attacker) would land at `~/.config/mcp-stdio/tokens.json`, after which every `O_NOFOLLOW` read `ELOOP`s and `save`/`delete` abort forever — a **permanent token-cache DoS**. The path-based chmod also followed the symlink to `0o600` an arbitrary target. Now: open with `O_NOFOLLOW` + `O_NONBLOCK`, `fstat` for `S_ISREG`, `fchmod` through the fd, then rename only if regular. Non-regular/symlinked legacy file is left untouched. Residual rename TOCTOU is bounded by the legacy dir's `0o700` mode.
- **[low] `_read_legacy_data` FIFO hang** — added `O_NONBLOCK` + an `S_ISREG` `fstat` (matching `_read_store`), so a FIFO at the legacy path can no longer block a token load on the copy-through paths.

## Tests
- `test_migration_refuses_symlinked_legacy_store` — pins the MEDIUM fix (no symlink lands in the trusted path; decoy never consumed).
- `test_migration_skips_fifo_legacy_store_without_hanging`.
- `test_mid_read_failure_aborts_save_and_load_returns_none` — the third `_StoreUnreadable` raise site (open succeeds, read fails): save aborts, load → None. (#8)

Full suite: 779 passed, 3 skipped. Raw separator scan clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)