### PR TITLE
fix(relay): dedup MCP-Protocol-Version / Mcp-Session-Id in _prepare_headers

### DIFF
--- a/src/mcp_stdio/relay.py
+++ b/src/mcp_stdio/relay.py
@@ -839,6 +839,14 @@ def _post_and_stream(
                     # left hanging, mirroring the >=400 fall-through in run().
                     # Notifications (has_id False) stay silent.
                     _write_line(_error_response("empty response from server", req_id))
+                # pv is intentionally None here: no InitializeResult was
+                # delivered, so an empty-200 to an `initialize` request leaves
+                # the relay's protocol_version unset rather than guessing a
+                # version it never negotiated (#6 round27). The client received
+                # the synthesized error above and will re-initialize; the server
+                # that answered initialize with an empty 200 is already
+                # non-compliant. Contrast the partial-delivery path below, which
+                # deliberately PRESERVES a pv captured before the stream broke.
                 return _StreamResult(session, 200, protocol_version=pv)
         except httpx.HTTPError as e:
             # httpx.HTTPError is the broadest request-level supertype: every
@@ -1669,11 +1677,23 @@ def run(
     )
 
     def _prepare_headers() -> dict[str, str]:
-        """Build per-request headers with the current session + protocol version."""
+        """Build per-request headers with the current session + protocol version.
+
+        When the relay injects a value, it first drops any case-variant the
+        operator pinned via ``-H`` (e.g. ``-H 'mcp-protocol-version: x'``), so
+        httpx never serialises TWO ``MCP-Protocol-Version`` / ``Mcp-Session-Id``
+        header lines — a strict 2025-06-18 server treats these as singleton
+        fields and would reject or mis-select. Mirrors the initialize-path strip
+        in ``_dispatch`` / ``_reinitialize``. The strip is gated on the relay
+        actually having a value, so an operator pin still rides through on the
+        paths where the relay manages no value of its own. See #3 (round27).
+        """
         h = dict(headers)
         if session_id:
+            h = {k: v for k, v in h.items() if k.lower() != "mcp-session-id"}
             h["Mcp-Session-Id"] = session_id
         if protocol_version:
+            h = {k: v for k, v in h.items() if k.lower() != "mcp-protocol-version"}
             h["MCP-Protocol-Version"] = protocol_version
         return h
 

--- a/tests/test_relay.py
+++ b/tests/test_relay.py
@@ -1742,6 +1742,54 @@ class TestRun:
         # The step-up retry (req 3) must carry the id rotated on the 401 retry.
         assert reqs[3].headers.get("mcp-session-id") == "sess-2"
 
+    def test_successful_403_stepup_adopts_rotated_session_id(self, httpx_mock):
+        """#7(round27): a 403 step-up retry that SUCCEEDS (200) while rotating the
+        mcp-session-id must adopt that rotated id for the next stdin line —
+        symmetric with the 401 branch. Pins the post-step-up adoption at
+        relay.py ~1904 (`if result.session_id and result.status_code < 400`),
+        which the existing 403 tests leave uncovered (their retry 200 carries no
+        rotated id)."""
+        # 1: init -> sess-1
+        httpx_mock.add_response(
+            text='{"jsonrpc":"2.0","result":{},"id":1}',
+            headers={"content-type": "application/json", "mcp-session-id": "sess-1"},
+        )
+        # 2: call -> 403 insufficient_scope (triggers step-up)
+        httpx_mock.add_response(
+            status_code=403,
+            text="",
+            headers={
+                "content-type": "application/json",
+                "www-authenticate": 'Bearer error="insufficient_scope", scope="extra"',
+            },
+        )
+        # 3: step-up retry -> 200 AND rotates the session id to sess-rotated
+        httpx_mock.add_response(
+            text='{"jsonrpc":"2.0","result":{"ok":true},"id":2}',
+            headers={
+                "content-type": "application/json",
+                "mcp-session-id": "sess-rotated",
+            },
+        )
+        # 4: a later call -> 200 (must carry the rotated id)
+        httpx_mock.add_response(
+            text='{"jsonrpc":"2.0","result":{},"id":3}',
+            headers={"content-type": "application/json"},
+        )
+
+        self._run_with_stdin(
+            httpx_mock,
+            [
+                '{"jsonrpc":"2.0","method":"init","id":1}',
+                '{"jsonrpc":"2.0","method":"call","id":2}',
+                '{"jsonrpc":"2.0","method":"call","id":3}',
+            ],
+            scope_upgrader=lambda _s: {"Authorization": "Bearer broader"},
+        )
+        reqs = httpx_mock.get_requests()
+        # Line 3's request (index 3) carries the id rotated on the step-up 200.
+        assert reqs[3].headers.get("mcp-session-id") == "sess-rotated"
+
     def test_chained_403_stepup_then_404_reinitializes_and_replays(self, httpx_mock):
         """#6(round21): a 403 whose step-up retry returns 404 must cascade into
         the 404 reinitialize branch — initialize a fresh session, then replay the


### PR DESCRIPTION
Round-27 review fixes for `relay.py` (file-grouped PR 2/3).

## Changes
- **[low] duplicate header lines** — `_prepare_headers` did `dict(headers)` then unconditionally set the canonical-case key. An operator who pinned a case-variant via `-H 'mcp-protocol-version: x'` (cli.py's case-insensitive dedup only applies to the built-in seed, not `-H` values) ended up with **two** `MCP-Protocol-Version` lines after negotiation. httpx serialises both; a strict 2025-06-18 server treats it as a singleton field → rejects / mis-selects → broken session. Now drop any case-variant before injecting, **gated on the relay actually having a value** so an operator pin still rides through where the relay manages none. Mirrors the initialize-path strip in `_dispatch` / `_reinitialize`.
- **[low] empty-200 invariant comment** — document that an empty-200 to an `initialize` leaves `protocol_version` unset deliberately (no `InitializeResult` was delivered; the server is already non-compliant and the client gets a synthesized error). No behavior change.

## Tests
- `test_successful_403_stepup_adopts_rotated_session_id` — pins the post-step-up session-id adoption (`status_code < 400`) that the existing 403 tests left uncovered. (#7)

Full relay suite: 352 passed, 3 skipped. Raw separator scan clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)