### PR TITLE
fix(cli): reject non-finite (nan/inf) values in the float validators

### DIFF
--- a/src/mcp_stdio/cli.py
+++ b/src/mcp_stdio/cli.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+import math
 import os
 import re
 import sys
@@ -19,6 +20,15 @@ def _non_negative_float(value: str) -> float:
         f = float(value)
     except ValueError as exc:
         raise argparse.ArgumentTypeError(f"invalid float value: {value!r}") from exc
+    # #4 (round27): float() parses "nan" / "inf" / "-inf", which silently slip
+    # past the `f < 0` / `f == 0` comparisons (every comparison with nan is
+    # False) and defeat the very failure mode these validators guard against — a
+    # nan/inf timeout makes httpx's elapsed-vs-deadline check always False, so a
+    # connect/read never times out (a silent hang); a nan refresh-leeway forces
+    # a refresh every call. Reject non-finite values up front. This also covers
+    # _positive_float and every flag that reuses these (one fix, five flags).
+    if not math.isfinite(f):
+        raise argparse.ArgumentTypeError(f"value must be finite (got {value!r})")
     if f < 0:
         raise argparse.ArgumentTypeError(f"value must be >= 0 (got {f})")
     return f

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -295,6 +295,31 @@ class TestMain:
             assert exc_info.value.code == 2
         assert "must be >= 0" in capsys.readouterr().err
 
+    @pytest.mark.parametrize(
+        "flag",
+        [
+            "--timeout-connect",
+            "--timeout-read",
+            "--sse-read-timeout",
+            "--oauth-refresh-leeway",
+            "--oauth-timeout",
+        ],
+    )
+    @pytest.mark.parametrize("value", ["nan", "inf", "Infinity"])
+    def test_non_finite_floats_rejected(self, flag, value, capsys):
+        """#4(round27): float() parses nan/inf, which slip past the < 0 / == 0
+        comparisons and defeat the validators (a nan/inf timeout never fires →
+        silent hang). Every float flag must reject non-finite values at parse
+        time. (-inf is omitted: argparse intercepts a leading '-' as an option
+        before the validator runs; it is already caught by the < 0 guard.)"""
+        with patch(
+            "sys.argv", ["mcp-stdio", flag, value, "https://example.com/mcp"]
+        ):
+            with pytest.raises(SystemExit) as exc_info:
+                main()
+            assert exc_info.value.code == 2
+        assert "must be finite" in capsys.readouterr().err
+
     @pytest.mark.parametrize("flag", ["--timeout-connect", "--timeout-read"])
     def test_zero_connect_read_timeout_rejected(self, flag, capsys):
         """#9: --timeout-connect 0 / --timeout-read 0 are rejected at parse time


### PR DESCRIPTION
Round-27 review fix for `cli.py` (file-grouped PR 3/3).

## Change
- **[low] nan/inf slip past the float validators** — `float()` parses `"nan"` / `"inf"`, which silently pass the `f < 0` / `f == 0` comparisons (every comparison with nan is False) and defeat the very failure mode the validators guard against: a nan/inf `--timeout-connect` makes httpx's elapsed-vs-deadline check always False → a connect/read **never times out** (silent hang); a nan `--oauth-refresh-leeway` forces a refresh every call; an inf `--sse-read-timeout` disables half-open detection. Add a `math.isfinite` guard in `_non_negative_float` before the sign check — one fix covers `_positive_float` and all five float flags.

## Tests
- `test_non_finite_floats_rejected` — every float flag rejects `nan`/`inf`/`Infinity` at parse time (5 flags × 3 values). `-inf` is omitted because argparse intercepts the leading `-` as an option before the validator runs; it is already caught by the `< 0` guard.

## Accepted (documented design, no change)
- **oauth step-up cache-hit drops `token_endpoint_auth_methods_supported`** — only matters in the rare expired-`client_secret` re-DCR subcase, and the new DCR persists a fresh method, so it self-corrects. Persisting the list to `TokenData` (plus its load-time validation) is not worth the schema churn for a cosmetic, self-healing path.
- NITs: `_SseState.endpoint_url` GIL-atomic publication (forward-looking only), rate-limit `time.sleep` on the stdin thread (documented cap), device-flow iss/PKCE binding (RFC 8628-inherent — no redirect to carry `iss`), pagination-twin untested edges (self-healing), WORKAROUNDS.md `#218` PR link (correct as-is — it *is* a PR) and version-pinned external claims (issue-anchored).

Full cli suite: 98 passed. Raw separator scan clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)