### PR TITLE
fix(relay): gate inline 401-retry session-id adoption on a parseable scope

### DIFF
--- a/src/mcp_stdio/relay.py
+++ b/src/mcp_stdio/relay.py
@@ -487,11 +487,13 @@ def _handle_rate_limit(
     resp_headers: Any,
     attempt: int,
 ) -> float | None:
-    """Decide how long to sleep for a 429 before retrying.
+    """Decide how long to sleep for a 429/503 before retrying.
 
-    Returns the seconds to sleep if a retry should be attempted, or
-    ``None`` if the caller should give up (wait exceeds the cap, or this
-    was the last allowed attempt — caller must then surface the 429).
+    Status-agnostic: callers gate on ``_RETRYABLE_RATE_LIMIT_STATUSES``
+    (429, 503), the two spec-sanctioned ``Retry-After`` carriers, and pass
+    the response here. Returns the seconds to sleep if a retry should be
+    attempted, or ``None`` if the caller should give up (wait exceeds the cap,
+    or this was the last allowed attempt — caller must then surface the status).
 
     ``resp_headers`` accepts anything with ``.get("retry-after")``.
     ``attempt`` is the 1-based retry counter shared with the surrounding
@@ -1284,9 +1286,14 @@ def _reinitialize(
     # output), but an operator who pinned `-H MCP-Protocol-Version: <x>` would
     # otherwise have it ride this initialize POST — inconsistent with the
     # dispatch path, which strips it from a real initialize (see #3 round18).
-    # Mirror that strip so both initialize paths behave identically.
+    # Mirror that strip so both initialize paths behave identically. Also drop a
+    # pinned case-variant Mcp-Session-Id: an initialize POST establishes a FRESH
+    # session, so a stale operator-pinned session id must not ride it (#B-1
+    # round28).
     init_headers = {
-        k: v for k, v in headers.items() if k.lower() != "mcp-protocol-version"
+        k: v
+        for k, v in headers.items()
+        if k.lower() not in ("mcp-protocol-version", "mcp-session-id")
     }
     try:
         resp = client.post(url, content=initialize_msg, headers=init_headers)
@@ -1320,9 +1327,22 @@ def _reinitialize(
     initialized_msg = json.dumps(
         {"jsonrpc": "2.0", "method": "notifications/initialized"}
     )
-    initialized_headers = dict(headers)
+    # Drop any operator-pinned case-variant before injecting, mirroring
+    # _prepare_headers' strip discipline, so the notifications/initialized POST
+    # never serialises two Mcp-Session-Id / MCP-Protocol-Version lines that a
+    # strict 2025-06-18 server treats as a singleton field (#B-1 round28). The
+    # protocol-version strip is gated on `negotiated` (only stripped when set),
+    # so an operator pin still rides through if the relay negotiated none.
+    initialized_headers = {
+        k: v for k, v in headers.items() if k.lower() != "mcp-session-id"
+    }
     initialized_headers["Mcp-Session-Id"] = new_session_id
     if negotiated:
+        initialized_headers = {
+            k: v
+            for k, v in initialized_headers.items()
+            if k.lower() != "mcp-protocol-version"
+        }
         initialized_headers["MCP-Protocol-Version"] = negotiated
     try:
         resp = client.post(url, content=initialized_msg, headers=initialized_headers)
@@ -1873,19 +1893,26 @@ def run(
                         # Re-adopt a session id the server rotated alongside this 401
                         # retry's response, so a chained 403 step-up below rebuilds
                         # its retry headers from the fresh id, not the stale one.
-                        # Gate it like the pre-recovery adoption (#1 round24): adopt
+                        # Gate it like the pre-recovery adoption (#1 round24/26): adopt
                         # only when the retry SUCCEEDED, or returned a 403 that the
-                        # step-up branch below will actually consume. A TERMINAL
-                        # status (bare 500/400, or a 403 with no scope_upgrader) that
-                        # merely echoes a session id must NOT poison session_id for
-                        # the next stdin line — that id was just rejected. (A 404 is
-                        # excluded: its branch reinitializes from scratch, ignoring
-                        # any rotated id, and a cold 404 must stay a terminal error.)
+                        # step-up branch below will actually CONSUME — i.e. a PARSEABLE
+                        # insufficient_scope challenge. A terminal status (bare 500/400,
+                        # a 403 with no scope_upgrader, or a 403 whose challenge does
+                        # not parse so step-up never fires) that merely echoes a session
+                        # id must NOT poison session_id for the next stdin line — that
+                        # id was just rejected. The parseable-scope conjunct mirrors the
+                        # top-level feeds_recovery gate exactly (#1 round28). (A 404 is
+                        # excluded: its branch reinitializes from scratch, ignoring any
+                        # rotated id, and a cold 404 must stay a terminal error.)
                         if result.session_id and (
                             result.status_code < 400
                             or (
                                 result.status_code == 403
                                 and scope_upgrader is not None
+                                and _parse_www_authenticate_scope(
+                                    result.www_authenticate
+                                )
+                                is not None
                             )
                         ):
                             session_id = result.session_id

--- a/tests/test_relay.py
+++ b/tests/test_relay.py
@@ -1007,6 +1007,56 @@ class TestRun:
         # Line 3's request (index 3) still carries "s1", not the 500's "bad-rotated".
         assert reqs[3].headers.get("mcp-session-id") == "s1"
 
+    def test_inline_401_retry_unparseable_403_session_id_not_adopted(
+        self, httpx_mock
+    ):
+        """#1(round28): the INLINE 401-retry re-adoption must require a PARSEABLE
+        insufficient_scope challenge on a 403, mirroring the top-level
+        feeds_recovery gate. A 401 retry that returns a 403 with a generic
+        (unparseable) WWW-Authenticate AND a rotated session id, while a
+        scope_upgrader is configured, must NOT adopt the rotated id — the step-up
+        branch declines to fire (no parseable scope), so the id is never consumed
+        and would poison the next stdin line."""
+        # Line 1: init -> 200, session "s1".
+        httpx_mock.add_response(
+            text='{"jsonrpc":"2.0","result":{},"id":1}',
+            headers={"content-type": "application/json", "mcp-session-id": "s1"},
+        )
+        # Line 2: call -> 401 (triggers refresh).
+        httpx_mock.add_response(
+            status_code=401, text="", headers={"content-type": "application/json"}
+        )
+        # 401 refresh retry -> 403 with a NON-insufficient_scope challenge
+        # (unparseable) AND a rotated id. Step-up will NOT fire; the id must not
+        # be adopted.
+        httpx_mock.add_response(
+            status_code=403,
+            text="",
+            headers={
+                "content-type": "application/json",
+                "www-authenticate": 'Bearer realm="x"',
+                "mcp-session-id": "bad-rotated",
+            },
+        )
+        # Line 3: call -> 200.
+        httpx_mock.add_response(
+            text='{"jsonrpc":"2.0","result":{},"id":3}',
+            headers={"content-type": "application/json"},
+        )
+        self._run_with_stdin(
+            httpx_mock,
+            [
+                '{"jsonrpc":"2.0","method":"init","id":1}',
+                '{"jsonrpc":"2.0","method":"call","id":2}',
+                '{"jsonrpc":"2.0","method":"call","id":3}',
+            ],
+            token_refresher=lambda: {"Authorization": "Bearer new"},
+            scope_upgrader=lambda _s: {"Authorization": "Bearer broader"},
+        )
+        reqs = httpx_mock.get_requests()
+        # Line 3's request still carries "s1", not the 403's "bad-rotated".
+        assert reqs[3].headers.get("mcp-session-id") == "s1"
+
     def test_session_expired_triggers_reinitialize_then_retry(self, httpx_mock):
         """Reproduces the 404 -> 400 hang from FastMCP StreamableHTTP.
 
@@ -3226,6 +3276,40 @@ class TestPagination:
         )
         merged = json.loads(output.strip())
         assert [t["name"] for t in merged["result"]["tools"]] == ["a"]
+
+    def test_page2_nonlist_result_key_keeps_page1_and_merges_late_field(
+        self, httpx_mock
+    ):
+        """#F-2(round28): a page-2 dict whose result_key is present but NOT a list
+        (e.g. tools:"oops") must not crash or discard page-1 items — the
+        non-list value is skipped (isinstance(items, list) is False) while the
+        late top-level field still merges. Complements the page-1 non-list and
+        page-2 non-dict cases."""
+        page1 = {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "result": {"tools": [{"name": "a"}], "nextCursor": "p2"},
+        }
+        page2 = {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "result": {"tools": "not-a-list", "_meta": {"x": 1}},
+        }
+        for page in (page1, page2):
+            httpx_mock.add_response(
+                url=self.URL,
+                text=json.dumps(page),
+                headers={"content-type": "application/json"},
+            )
+        output = self._run_with_stdin(
+            httpx_mock,
+            [json.dumps({"jsonrpc": "2.0", "id": 1, "method": "tools/list"})],
+        )
+        merged = json.loads(output.strip())
+        # Page-1 items survive; page-2's non-list value is ignored, late merges.
+        assert [t["name"] for t in merged["result"]["tools"]] == ["a"]
+        assert merged["result"]["_meta"] == {"x": 1}
+        assert "nextCursor" not in merged["result"]
 
     def test_late_top_level_result_field_preserved(self, httpx_mock):
         """#14: a top-level result field (e.g. _meta) that appears only on a
@@ -5966,6 +6050,54 @@ class TestRunSseCancelFilter:
             run_sse(self.URL, {"Content-Type": "application/json"})
 
         # TTL elapsed → the late response is NOT dropped.
+        assert "late" in stdout.getvalue()
+
+    def test_no_cancel_filter_lets_sse_response_through(self, httpx_mock):
+        """#F-1(round28): run_sse(..., cancel_filter=False) builds no tracker, so
+        the SSE reader's None-tracker branch is taken and a late response for a
+        cancelled id is DELIVERED, not dropped. The opt-out is the cancel
+        filter's reason to exist, and the late-drop only reproduces on the SSE
+        path, so its runtime behaviour must be pinned here (the run() side is
+        already covered)."""
+        payload = '{"jsonrpc":"2.0","result":{"late":true},"id":11}'
+        post_received = threading.Event()
+        release_stdin = threading.Event()
+
+        def sse_gen():
+            yield b"event: endpoint\ndata: /messages?sessionId=abc\n\n"
+            post_received.wait(timeout=3)
+            yield f"event: message\ndata: {payload}\n\n".encode()
+            time.sleep(0.1)
+            release_stdin.set()
+
+        httpx_mock.add_response(
+            url=self.URL,
+            stream=IteratorStream(sse_gen()),
+            headers={"content-type": "text/event-stream"},
+        )
+
+        def on_post(request: httpx.Request) -> httpx.Response:
+            post_received.set()
+            return httpx.Response(status_code=202)
+
+        httpx_mock.add_callback(
+            on_post, url="https://example.com/messages?sessionId=abc"
+        )
+
+        stdin = _BlockingStdin(
+            (
+                '{"jsonrpc":"2.0","method":"notifications/cancelled",'
+                '"params":{"requestId":11}}'
+            ),
+            release_stdin,
+        )
+        stdout = StringIO()
+        with patch("sys.stdin", stdin), patch("sys.stdout", stdout):
+            run_sse(
+                self.URL, {"Content-Type": "application/json"}, cancel_filter=False
+            )
+
+        # With the filter disabled the cancelled id is not tracked → delivered.
         assert "late" in stdout.getvalue()
 
     def test_sse_message_without_cancel_passes_through(self, httpx_mock):


### PR DESCRIPTION
Round-28 review fixes for `relay.py` (file-grouped PR 1/4). Includes the round's primary correctness bug.

## Changes
- **[low] inline 401-retry session-id poisoning** — the inline re-adoption gated its 403 disjunct on only `status_code == 403 and scope_upgrader is not None`, omitting the `_parse_www_authenticate_scope(...) is not None` check the top-level `feeds_recovery` gate carries. A 401 retry returning a 403 with a generic (unparseable) `WWW-Authenticate` **and** a rotated `Mcp-Session-Id` (with a `scope_upgrader` configured) adopted the rotated id even though step-up then declines to fire — poisoning `session_id` for the next stdin line with a rejected id (self-heals via 404 after one wasted round-trip). The verifier reproduced it (line-3 carried the bad id) and confirmed the fix passes with zero regressions. Now mirrors the top-level gate.
- **[nit] `_reinitialize` Mcp-Session-Id strip** — strip an operator-pinned case-variant from both the `initialize` and `notifications/initialized` POSTs, matching `_prepare_headers`' strip discipline (the lone handshake path that diverged). (#B-1)
- **[nit] docstring** — `_handle_rate_limit` says 429/503 (it is status-agnostic). (#E-1)

## Tests
- `test_inline_401_retry_unparseable_403_session_id_not_adopted` (#1)
- `test_no_cancel_filter_lets_sse_response_through` — pins the `run_sse(cancel_filter=False)` None-tracker branch. (#F-1)
- `test_page2_nonlist_result_key_keeps_page1_and_merges_late_field` (#F-2)

## Accepted (documented design, no change)
- `_CancelTracker` TTL boundary comparisons use different operators (`>`, `<=`, `<`) but the boundary `age == ttl` is treated as **live/kept** consistently in all three — purely cosmetic, no behavioral inconsistency.
- SSE late-cancel race (a response arriving between the POST and a same-line cancel) — an ordering imperfection, not a data race; the cancel spec is best-effort.

Full relay suite: 355 passed, 3 skipped. Raw separator scan clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)