### PR TITLE
fix(cli): warn on an empty --bearer-token; route bearer via _bearer_header_value

### DIFF
--- a/src/mcp_stdio/cli.py
+++ b/src/mcp_stdio/cli.py
@@ -459,6 +459,18 @@ def main() -> None:
             file=sys.stderr,
         )
 
+    # An explicit but EMPTY --bearer-token counts as an auth choice for the
+    # mutual-exclusion check above (presence, not truthiness), yet the header
+    # build below (`if bearer_token`) would attach NO Authorization header —
+    # silently unauthenticated. Surface that asymmetry so an operator whose
+    # shell expansion produced '' is not misled into thinking the request is
+    # authenticated. (#C-1 round28)
+    if bearer_from_flag and not bearer_token:
+        print(
+            "warning: --bearer-token is empty; sending no Authorization header",
+            file=sys.stderr,
+        )
+
     # When an OAuth flow is selected, ignore any ambient env bearer token —
     # the flow below sets the Authorization header itself.
     if args.oauth or args.oauth_device:
@@ -481,7 +493,11 @@ def main() -> None:
         "Accept": "application/json, text/event-stream",
     }
     if bearer_token:
-        headers["Authorization"] = f"Bearer {bearer_token}"
+        # Route through _bearer_header_value so the "Bearer " literal and the
+        # CR/LF/NUL ban live in one place (#C-2 round28). The control-char check
+        # above already guarantees this cannot raise, but keeping a single
+        # builder avoids the contract drifting between the two call sites.
+        headers["Authorization"] = _bearer_header_value(bearer_token)
     for h in args.headers:
         key, value = _parse_header(h)
         # HTTP header names are case-insensitive (RFC 7230 §3.2). Drop any

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -449,6 +449,24 @@ class TestMain:
                 main()
             assert exc_info.value.code == 1
 
+    def test_empty_bearer_flag_alone_warns_no_auth(self, monkeypatch, capsys):
+        """#C-1(round28): `--bearer-token ''` alone (no OAuth) is counted as an
+        auth choice by the mutual-exclusion check but attaches NO Authorization
+        header — silently unauthenticated. Surface a stderr warning, and confirm
+        no Authorization header is built."""
+        monkeypatch.delenv("MCP_BEARER_TOKEN", raising=False)
+        with (
+            patch(
+                "sys.argv",
+                ["mcp-stdio", "https://example.com/mcp", "--bearer-token", ""],
+            ),
+            patch("mcp_stdio.cli.run") as mock_run,
+        ):
+            main()
+        assert "--bearer-token is empty" in capsys.readouterr().err
+        headers = mock_run.call_args.kwargs["headers"]
+        assert "Authorization" not in headers
+
     def test_explicit_authorization_header_with_oauth_warns(
         self, monkeypatch, capsys
     ):


### PR DESCRIPTION
Round-28 review fixes for `cli.py` (file-grouped PR 2/4).

## Changes
- **[low] silent unauthenticated start** — `--bearer-token ''` is counted as an explicit auth choice by the mutual-exclusion check (presence, not truthiness), but the header build (`if bearer_token`) attaches **no** Authorization header, so `mcp-stdio URL --bearer-token ''` starts the relay silently unauthenticated. Emit a stderr warning so an operator whose shell expansion produced `''` is not misled. (#C-1)
- **[nit] single bearer builder** — route the flag/env bearer path through `_bearer_header_value()` like the OAuth-token path, so the `"Bearer "` literal and the CR/LF/NUL contract live in one place. (#C-2)

## Tests
- `test_empty_bearer_flag_alone_warns_no_auth` — warns and builds no Authorization header.

Full cli suite: 99 passed. Raw separator scan clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)