### PR TITLE
fix(oauth): sanitize device-flow poll error log; cover untested poll/cache edges

### DIFF
--- a/src/mcp_stdio/oauth.py
+++ b/src/mcp_stdio/oauth.py
@@ -1577,7 +1577,12 @@ def _run_device_authorization_flow(
                 headers=poll_headers,
             )
         except Exception as exc:
-            log(f"device flow poll error: {exc}")
+            # Sanitise like the refresh path (#B-2 round28): today's reachable
+            # exception is an httpx transport error whose str() carries only the
+            # operator-trusted token-endpoint URL (no AS body), but bounding it
+            # keeps any future exception type that embeds resp.text from writing
+            # raw AS-controlled bytes to the log.
+            log(f"device flow poll error: {_sanitize_oauth_error(exc)}")
             _poll_sleep()
             continue
 

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -2156,6 +2156,57 @@ class TestEnsureToken:
         data = ensure_token("https://example.com/mcp", client)
         assert data.access_token == "cached_at"
 
+    def test_expired_cached_token_without_refresh_token_skips_refresh(
+        self, tmp_path, monkeypatch
+    ):
+        """#F-3(round28): an EXPIRED cached token lacking a refresh_token must
+        skip the refresh branch (its gate needs refresh_token AND token_endpoint
+        AND client_id) and fall straight to the full authorization flow —
+        refresh_cached_token must not even be called."""
+        store_file = tmp_path / "tokens.json"
+        monkeypatch.setattr("mcp_stdio.token_store._STORE_DIR", tmp_path)
+        monkeypatch.setattr("mcp_stdio.token_store._STORE_FILE", store_file)
+
+        from mcp_stdio.token_store import save_token
+
+        save_token(
+            "https://example.com/mcp",
+            TokenData(
+                access_token="expired_at",
+                expires_at=time.time() - 10,  # already expired
+                refresh_token=None,  # no refresh path available
+                token_endpoint="https://example.com/token",
+                authorization_endpoint="https://example.com/authorize",
+            ),
+        )
+
+        called = {"refresh": False}
+
+        def spy_refresh(*a, **k):
+            called["refresh"] = True
+            return None
+
+        sentinel = TokenData(access_token="fresh_from_full_flow")
+        monkeypatch.setattr("mcp_stdio.oauth.refresh_cached_token", spy_refresh)
+        monkeypatch.setattr(
+            "mcp_stdio.oauth._probe_www_authenticate", lambda *a, **k: None
+        )
+        monkeypatch.setattr(
+            "mcp_stdio.oauth.discover_oauth_metadata",
+            lambda *a, **k: OAuthMetadata(
+                authorization_endpoint="https://example.com/authorize",
+                token_endpoint="https://example.com/token",
+            ),
+        )
+        monkeypatch.setattr(
+            "mcp_stdio.oauth._run_authorization_flow", lambda *a, **k: sentinel
+        )
+
+        client = httpx.Client()
+        data = ensure_token("https://example.com/mcp", client)
+        assert data is sentinel
+        assert called["refresh"] is False
+
     def test_refresh_leeway_zero_uses_actual_expiry(self, tmp_path, monkeypatch):
         """#56: refresh_leeway=0 disables proactive refresh — token valid until literal expiry.
 
@@ -4495,6 +4546,37 @@ class TestDeviceAuthorizationFlow:
             _run_device_authorization_flow(
                 MCP_URL, client, metadata=_device_meta(), cached=None
             )
+
+    def test_poll_2xx_non_json_body_sleeps_and_continues(
+        self, httpx_mock, tmp_path, monkeypatch
+    ):
+        """#F-4(round28): a non-200 2xx poll response (e.g. 202) with a non-JSON
+        body does not raise — raise_for_status only fires on 4xx/5xx, and .json()
+        raises but is caught — so the loop sleeps-and-continues rather than
+        crashing. A subsequent 200 then succeeds. Complements the 400 non-JSON
+        test (which exercises the raise side)."""
+        self._patch_store(tmp_path, monkeypatch)
+        monkeypatch.setattr(time, "sleep", lambda _s: None)
+        httpx_mock.add_response(url=REG_URL, json={"client_id": "cid"})
+        httpx_mock.add_response(url=DEVICE_AUTH_URL, json=_da_response())
+        # Poll #1: 202 (2xx but not 200) with a non-JSON body. json() raises,
+        # raise_for_status() does not (2xx) → sleep-and-continue.
+        httpx_mock.add_response(
+            url=TOKEN_URL,
+            status_code=202,
+            headers={"content-type": "text/html"},
+            text="<html>processing</html>",
+        )
+        # Poll #2: 200 success.
+        httpx_mock.add_response(
+            url=TOKEN_URL, json={"access_token": "acc", "token_type": "Bearer"}
+        )
+
+        client = httpx.Client()
+        data = _run_device_authorization_flow(
+            MCP_URL, client, metadata=_device_meta(), cached=None
+        )
+        assert data.access_token == "acc"
 
     def test_explicit_client_id_skips_dcr(self, httpx_mock, tmp_path, monkeypatch):
         """#7(round14): with an explicit --client-id (client_id_override) the


### PR DESCRIPTION
Round-28 review fixes for `oauth.py` (file-grouped PR 3/4).

## Changes
- **[nit] device-flow poll error sanitization** — route the poll error log through `_sanitize_oauth_error`, the lone AS-error log line that wasn't (the refresh path, body errors, and callback errors all are). Defensively bounds any future exception type that might embed `resp.text`. (#B-2)

## Tests (coverage gaps; behavior already correct)
- `test_expired_cached_token_without_refresh_token_skips_refresh` — an expired cached token lacking a `refresh_token` falls straight to the full flow; `refresh_cached_token` is not even called. (#F-3)
- `test_poll_2xx_non_json_body_sleeps_and_continues` — a 2xx-non-200 poll response with a non-JSON body sleeps-and-continues (raise_for_status only fires on 4xx/5xx, `.json()` is caught), then a 200 succeeds. (#F-4)

## Accepted (documented design, no change)
- **device-flow poll: valid-JSON non-200 with no recognized `error` silently retries** (D-1) — RFC 8628 §3.5 mandates 200=success / 400=pending-etc, so a 2xx-non-200 is unreachable for a compliant AS; 4xx/5xx still `raise_for_status`.
- **proactive refresh of sub-leeway tokens** (D-2) — documented tradeoff tunable via `--oauth-refresh-leeway`; not a tight loop (ensure_token runs at startup / on 401).

Full oauth suite: 273 passed, no teardown errors. Raw separator scan clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)