### PR TITLE
fix(token_store): widen legacy-migration copy-through soft-fail to non-OSError

### DIFF
--- a/src/mcp_stdio/token_store.py
+++ b/src/mcp_stdio/token_store.py
@@ -269,9 +269,14 @@ def _migrate_legacy_store() -> None:
                             _LEGACY_STORE_FILE.unlink()
                         except OSError:
                             pass
-                except OSError:
+                except Exception:
                     # Unlocked read path: a failed stat/write must never crash
                     # the read — leave the legacy file for a later run to retry.
+                    # Catch Exception, not just OSError (#C-3 round28): _write_store
+                    # runs json.dumps before its inner try, mirroring the widened
+                    # save_token/delete_token contract. `data` is json.loads output
+                    # so a non-OSError is unreachable today, but the symmetry keeps
+                    # a future caller's non-serializable value from crashing a read.
                     pass
     else:
         _ensure_store_dir()
@@ -355,11 +360,13 @@ def _migrate_legacy_store() -> None:
                     try:
                         _write_store(data)
                         written = True
-                    except OSError:
+                    except Exception:
                         # This copy-through runs UNLOCKED from load_token. A
                         # failed write (disk full, read-only FS, permission) must
                         # NOT propagate out and crash the read — leave the legacy
                         # file intact for a later run to retry the migration.
+                        # Catch Exception, not just OSError (#C-3 round28), to match
+                        # the widened save_token/delete_token soft-fail contract.
                         pass
                     if written:
                         try:

--- a/tests/test_token_store.py
+++ b/tests/test_token_store.py
@@ -951,6 +951,37 @@ class TestLegacyMigration:
         assert not new_file.exists()
         assert stat.S_ISFIFO(os.lstat(legacy_file).st_mode)  # FIFO left in place
 
+    def test_placeholder_copy_through_non_serializable_does_not_crash_read(
+        self, tmp_path, monkeypatch
+    ):
+        """#C-3(round28): the empty-placeholder copy-through catches Exception
+        (not just OSError), matching the widened save/delete contract. A
+        non-serializable legacy value makes _write_store's json.dumps raise a
+        TypeError, which must NOT propagate out of the unlocked read path —
+        load returns None and the legacy file is left for a later retry."""
+        legacy_dir = tmp_path / "legacy"
+        new_dir = tmp_path / "new"
+        legacy_dir.mkdir()
+        new_dir.mkdir()
+        legacy_file = legacy_dir / "tokens.json"
+        new_file = new_dir / "tokens.json"
+        legacy_file.write_text('{"https://example.com/mcp": {"access_token": "x"}}')
+        new_file.write_text("")  # empty placeholder → triggers copy-through
+
+        monkeypatch.setattr("mcp_stdio.token_store._STORE_DIR", new_dir)
+        monkeypatch.setattr("mcp_stdio.token_store._STORE_FILE", new_file)
+        monkeypatch.setattr("mcp_stdio.token_store._LEGACY_STORE_DIR", legacy_dir)
+        monkeypatch.setattr("mcp_stdio.token_store._LEGACY_STORE_FILE", legacy_file)
+        # Return a non-serializable dict so _write_store's json.dumps raises
+        # TypeError (a non-OSError) inside the copy-through.
+        monkeypatch.setattr(
+            "mcp_stdio.token_store._read_legacy_data", lambda: {"k": object()}
+        )
+
+        # Must NOT raise; the read degrades to None.
+        assert load_token("https://example.com/mcp") is None
+        assert legacy_file.exists()  # migration left it for a later retry
+
     def test_migration_survives_cross_device_rename(self, tmp_path, monkeypatch):
         """An EXDEV (cross-filesystem) rename must not brick the store — the
         copy-through fallback persists the tokens at the new path."""


### PR DESCRIPTION
Round-28 review fix for `token_store.py` (file-grouped PR 4/4).

## Change
- **[nit] migration copy-through soft-fail symmetry** — the two migration copy-through `_write_store` calls (empty-placeholder branch and EXDEV/ENOENT fallback) caught only `OSError`, while `save_token` / `delete_token` were widened to `except Exception` in round-26 (#12) because `_write_store` runs `json.dumps` before its inner `try`. The migration `data` comes from `_read_legacy_data` (json.loads output) so a non-OSError is unreachable today, but the asymmetry was a footgun: a future caller's non-serializable value would crash the **unlocked** read path. Widen both to `except Exception`. (#C-3)

## Test
- `test_placeholder_copy_through_non_serializable_does_not_crash_read` — a non-serializable legacy value makes `json.dumps` raise `TypeError`, which is swallowed; load returns None and the legacy file is left for a later retry.

Full token_store suite: 75 passed. Raw separator scan clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)