### PR TITLE
fix(token_store): tighten newly-created parent dirs to 0o700

### DIFF
--- a/src/mcp_stdio/token_store.py
+++ b/src/mcp_stdio/token_store.py
@@ -156,10 +156,24 @@ def _ensure_store_dir() -> None:
 
     ``mkdir``'s ``mode`` only applies on creation, so re-assert 0o700 in case
     the directory pre-existed with looser permissions (created earlier by
-    another tool, or under a permissive umask).
+    another tool, or under a permissive umask). ``mkdir(mode=)`` also tightens
+    only the FINAL component; any intermediate dir ``parents=True`` creates
+    (e.g. ``~/.config`` on a fresh home) uses the umask, so each ancestor WE
+    create is 0o700'd too — but a pre-existing ancestor (the user's shared
+    ``~/.config``) is left untouched.
     """
     global _warned_loose_store_dir
+    # #L2 (round29): the ancestors that do not yet exist are exactly the ones
+    # mkdir(parents=True) is about to create. Capture them BEFORE mkdir so we can
+    # tighten only those — never re-mode a directory we did not create. The list
+    # stops naturally at the first existing ancestor (home is always present).
+    new_ancestors = [p for p in _STORE_DIR.parents if not p.exists()]
     _STORE_DIR.mkdir(mode=0o700, parents=True, exist_ok=True)
+    for ancestor in new_ancestors:
+        try:
+            os.chmod(ancestor, stat.S_IRWXU)  # 0o700, only dirs we just created
+        except OSError:
+            pass  # best-effort; the 0o600 token file is the primary guard
     try:
         os.chmod(_STORE_DIR, stat.S_IRWXU)  # 0o700
     except OSError:

--- a/tests/test_token_store.py
+++ b/tests/test_token_store.py
@@ -105,6 +105,34 @@ class TestLoadSaveDelete:
         sys.platform == "win32",
         reason="POSIX mode bits don't model the NTFS ACL Windows uses",
     )
+    def test_newly_created_parent_dirs_are_tightened(self, tmp_path, monkeypatch):
+        """#L2(round29): mkdir(mode=) only tightens the final component, so an
+        intermediate dir parents=True creates (e.g. ~/.config on a fresh home)
+        would otherwise be left at the umask. Each ancestor WE create must be
+        0o700. A pre-existing ancestor (tmp_path) is untouched."""
+        # Store nested two levels deep so an intermediate parent is created.
+        store_dir = tmp_path / "config" / "mcp-stdio"
+        store_file = store_dir / "tokens.json"
+        monkeypatch.setattr("mcp_stdio.token_store._STORE_DIR", store_dir)
+        monkeypatch.setattr("mcp_stdio.token_store._STORE_FILE", store_file)
+
+        old_umask = os.umask(0o000)  # loosest umask → intermediate would be 0o777
+        try:
+            save_token("https://example.com/mcp", TokenData(access_token="tok"))
+        finally:
+            os.umask(old_umask)
+
+        # The intermediate dir we created is 0o700, not umask-loose.
+        intermediate_mode = stat.S_IMODE(os.stat(tmp_path / "config").st_mode)
+        assert intermediate_mode & (stat.S_IRWXG | stat.S_IRWXO) == 0
+        assert stat.S_IMODE(os.stat(store_dir).st_mode) & (
+            stat.S_IRWXG | stat.S_IRWXO
+        ) == 0
+
+    @pytest.mark.skipif(
+        sys.platform == "win32",
+        reason="POSIX mode bits don't model the NTFS ACL Windows uses",
+    )
     def test_lock_file_retightened_to_0600(self, tmp_path, monkeypatch):
         """#9(round19): a PRE-EXISTING loose-mode lock file is re-tightened to
         0o600 via fchmod when _store_lock opens it — the O_CREAT mode only


### PR DESCRIPTION
Round-29 review fix for `token_store.py` (file-grouped PR 2/4).

## Change
- **[low] umask-dependent intermediate dirs** (L2) — `_STORE_DIR.mkdir(mode=0o700, parents=True)` applies the mode only to the **final** component; any intermediate dir `parents=True` creates (e.g. `~/.config` on a fresh home) is created with the umask, leaving a possibly group/other-accessible ancestor of the `0o700` store dir — widening the symlink-swap / rename-race surface. (The token file is always `0o600`, the primary guard, and `~/.config` usually pre-exists, so this only triggers on a fresh home + loose umask.) Capture the ancestors that don't yet exist **before** mkdir (exactly the ones it will create) and `0o700` each afterward — never re-mode a directory we didn't create, so the user's pre-existing shared `~/.config` is untouched.

## Test
- `test_newly_created_parent_dirs_are_tightened` — with the loosest umask, a nested store's freshly-created intermediate parent is `0o700`.

Full token_store suite: 76 passed. Raw separator scan clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)