### PR TITLE
fix(cli): warn when -H 'Authorization' overrides an explicit --bearer-token

### DIFF
--- a/src/mcp_stdio/cli.py
+++ b/src/mcp_stdio/cli.py
@@ -446,8 +446,9 @@ def main() -> None:
     # so an explicit `--client-id ''` trips it too, matching the --bearer-token
     # discipline (#13 round22). oauth_scope's default is "" (not None), so an
     # explicit empty value is indistinguishable from the default and stays on the
-    # truthiness check. --oauth-refresh-leeway is also OAuth-only but always has a
-    # default, so it cannot be presence-detected here — its help text says so.
+    # truthiness check. --oauth-refresh-leeway and --oauth-timeout are also
+    # OAuth-only but always carry a non-None default, so they cannot be
+    # presence-detected here — their help text flags them as OAuth-only instead.
     if not (args.oauth or args.oauth_device) and (
         args.client_id is not None
         or args.oauth_scope
@@ -505,6 +506,23 @@ def main() -> None:
         # the built-in default (e.g. -H 'authorization: ...' replaces the
         # bearer Authorization) instead of sending two same-named headers.
         for existing in [k for k in headers if k.lower() == key.lower()]:
+            # #N5 (round29): when a -H 'Authorization' displaces an EXPLICIT
+            # --bearer-token, warn instead of silently dropping it — mirroring
+            # the OAuth path's override warning. Gated on bearer_from_flag (so
+            # an ambient env token does not trip it) and on the displaced value
+            # still being the bearer's, so a second -H Authorization does not
+            # re-warn.
+            if (
+                key.lower() == "authorization"
+                and bearer_from_flag
+                and bearer_token
+                and headers.get(existing) == _bearer_header_value(bearer_token)
+            ):
+                print(
+                    "warning: explicit -H 'Authorization' header overrides "
+                    "--bearer-token",
+                    file=sys.stderr,
+                )
             del headers[existing]
         headers[key] = value
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -519,6 +519,53 @@ class TestMain:
             assert auth_keys == ["authorization"]
             assert headers["authorization"] == "Bearer override"
 
+    def test_dash_h_authorization_overriding_bearer_warns(self, monkeypatch, capsys):
+        """#N5(round29): a -H 'Authorization' that displaces an EXPLICIT
+        --bearer-token warns (mirroring the OAuth override warning) instead of
+        silently dropping the flag's value."""
+        monkeypatch.delenv("MCP_BEARER_TOKEN", raising=False)
+        with (
+            patch(
+                "sys.argv",
+                [
+                    "mcp-stdio",
+                    "https://example.com/mcp",
+                    "--bearer-token",
+                    "tok123",
+                    "-H",
+                    "Authorization: Bearer override",
+                ],
+            ),
+            patch("mcp_stdio.cli.run") as mock_run,
+        ):
+            main()
+        headers = mock_run.call_args.kwargs["headers"]
+        assert headers["Authorization"] == "Bearer override"  # -H wins
+        assert "overrides --bearer-token" in capsys.readouterr().err
+
+    def test_dash_h_authorization_without_bearer_flag_does_not_warn(
+        self, monkeypatch, capsys
+    ):
+        """An ambient env MCP_BEARER_TOKEN displaced by -H must NOT warn — the
+        warning is gated on an EXPLICIT --bearer-token (bearer_from_flag)."""
+        monkeypatch.setenv("MCP_BEARER_TOKEN", "env-tok")
+        with (
+            patch(
+                "sys.argv",
+                [
+                    "mcp-stdio",
+                    "https://example.com/mcp",
+                    "-H",
+                    "Authorization: Bearer override",
+                ],
+            ),
+            patch("mcp_stdio.cli.run") as mock_run,
+        ):
+            main()
+        headers = mock_run.call_args.kwargs["headers"]
+        assert headers["Authorization"] == "Bearer override"
+        assert "overrides --bearer-token" not in capsys.readouterr().err
+
     def test_oauth_authorization_dedups_case_variant_dash_h(self, monkeypatch):
         """--oauth together with a differently-cased -H authorization must not
         send two Authorization headers — the OAuth token is the only one."""


### PR DESCRIPTION
Round-29 review fixes for `cli.py` (file-grouped PR 3/4). UX/doc consistency.

## Changes
- **[nit] silent bearer override** (N5) — the non-OAuth header build let `-H 'Authorization: ...'` silently replace the Authorization set from an explicit `--bearer-token`, while the OAuth path warns on the same override. Mirror that warning. Gated on `bearer_from_flag` (an ambient env token doesn't trip it) and on the displaced value still being the bearer's (a second `-H Authorization` doesn't re-warn). Header set unchanged (`-H` still wins).
- **[nit] comment completeness** (N6) — note `--oauth-timeout` alongside `--oauth-refresh-leeway` in the "ignored without --oauth" comment; both are OAuth-only with a non-None default so neither can be presence-detected for that warning.

## Tests
- `test_dash_h_authorization_overriding_bearer_warns`
- `test_dash_h_authorization_without_bearer_flag_does_not_warn` (env token → no false warning)

Full cli suite: 101 passed. Raw separator scan clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)