### PR TITLE
fix(relay): scope cancel filter to pure responses; cover pagination recovery

### DIFF
--- a/src/mcp_stdio/relay.py
+++ b/src/mcp_stdio/relay.py
@@ -566,7 +566,13 @@ def _emit(line: str, tracker: "_CancelTracker | None") -> None:
         _write_line(line)
         return
     rid = msg.get("id")
-    if rid is not None and ("result" in msg or "error" in msg):
+    # Drop only a pure JSON-RPC RESPONSE (id + result/error, NO method). A
+    # message carrying `method` is by definition a request / notification, not
+    # a response — so a malformed peer that sends `method` alongside
+    # result/error under a (coincidentally cancelled) id must still pass
+    # through, matching this function's documented scope ("server-initiated
+    # requests ... pass through"). See #1 (round30).
+    if rid is not None and "method" not in msg and ("result" in msg or "error" in msg):
         if tracker.consume(rid):
             log(f"dropped late response for cancelled id {rid!r}")
             return

--- a/tests/test_relay.py
+++ b/tests/test_relay.py
@@ -3203,6 +3203,87 @@ class TestPagination:
         requests = httpx_mock.get_requests()
         assert requests[1].headers["authorization"] == "Bearer new-token"
 
+    def test_page2_401_does_not_trigger_recovery_returns_partial(self, httpx_mock):
+        """#L(round30): a 401 on page>=2 must NOT reach run()'s token-refresh
+        recovery — _paginate_and_stream flushes the accumulated partial (status
+        coerced to 200) and re-exposes the cursor so the client can resume. The
+        refresher is never called and exactly one response is emitted. Pins the
+        page-1-only-recovery asymmetry."""
+        page1 = {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "result": {"tools": [{"name": "a"}], "nextCursor": "p2"},
+        }
+        httpx_mock.add_response(
+            url=self.URL,
+            text=json.dumps(page1),
+            headers={"content-type": "application/json"},
+        )
+        # Page 2 -> 401 (would trigger refresh on page 1, but not on page>=2).
+        httpx_mock.add_response(
+            url=self.URL,
+            status_code=401,
+            text="",
+            headers={"content-type": "application/json"},
+        )
+
+        called = {"refresh": False}
+
+        def spy_refresher():
+            called["refresh"] = True
+            return {"Content-Type": "application/json", "Authorization": "Bearer new"}
+
+        output = self._run_with_stdin(
+            httpx_mock,
+            [json.dumps({"jsonrpc": "2.0", "id": 1, "method": "tools/list"})],
+            token_refresher=spy_refresher,
+        )
+        lines = [x for x in output.strip().splitlines() if x]
+        assert len(lines) == 1  # one merged response, no duplicate error
+        merged = json.loads(lines[0])
+        assert merged["result"]["tools"] == [{"name": "a"}]  # page-1 partial
+        assert merged["result"]["nextCursor"] == "p2"  # resumable tail re-exposed
+        assert called["refresh"] is False  # page-2 401 stayed inside pagination
+
+    def test_pagination_adopts_last_page_session_id(self, httpx_mock):
+        """#1142(round30): when the server rotates Mcp-Session-Id across pages,
+        the LAST page's session is adopted (last-write-wins), so the NEXT stdin
+        request carries it — preserving session continuity for the 404
+        self-heal."""
+        page1 = {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "result": {"tools": [{"name": "a"}], "nextCursor": "p2"},
+        }
+        page2 = {"jsonrpc": "2.0", "id": 1, "result": {"tools": [{"name": "b"}]}}
+        httpx_mock.add_response(
+            url=self.URL,
+            text=json.dumps(page1),
+            headers={"content-type": "application/json", "mcp-session-id": "sess-1"},
+        )
+        httpx_mock.add_response(
+            url=self.URL,
+            text=json.dumps(page2),
+            headers={"content-type": "application/json", "mcp-session-id": "sess-2"},
+        )
+        # A later call on the next stdin line must carry sess-2 (last page's).
+        httpx_mock.add_response(
+            url=self.URL,
+            text='{"jsonrpc":"2.0","result":{},"id":2}',
+            headers={"content-type": "application/json"},
+        )
+
+        self._run_with_stdin(
+            httpx_mock,
+            [
+                json.dumps({"jsonrpc": "2.0", "id": 1, "method": "tools/list"}),
+                json.dumps({"jsonrpc": "2.0", "id": 2, "method": "tools/call"}),
+            ],
+        )
+        reqs = httpx_mock.get_requests()
+        # reqs[2] is the line-2 tools/call; it carries the LAST page's session.
+        assert reqs[2].headers.get("mcp-session-id") == "sess-2"
+
     def test_first_page_retry_exhaustion_emits_single_error(self, httpx_mock):
         """When page 1 exhausts all retries (repeated ConnectError), the
         buffered ``_post_parsed`` path writes exactly one JSON-RPC error for
@@ -5849,6 +5930,17 @@ class TestEmit:
         t = _CancelTracker()
         t.add(1)
         line = '{"jsonrpc":"2.0","method":"sampling/createMessage","id":1,"params":{}}'
+        _emit(line, t)
+        assert capsys.readouterr().out.strip() == line
+
+    def test_forwards_malformed_message_with_method_and_result(self, capsys):
+        # #1(round30): a malformed peer message carrying BOTH `method` and
+        # `result` under a cancelled id is a request by JSON-RPC definition
+        # (method present), not a response — the filter must pass it through,
+        # not eat a server-initiated request on a torn-frame technicality.
+        t = _CancelTracker()
+        t.add(1)
+        line = '{"jsonrpc":"2.0","method":"sampling/createMessage","id":1,"result":{}}'
         _emit(line, t)
         assert capsys.readouterr().out.strip() == line
 


### PR DESCRIPTION
Round-30 review fixes for `relay.py` (file-grouped PR 1/2). The review hit the asymptotic floor — 0 critical/high/medium, and this is the **only recommended code change** (one line).

## Changes
- **[nit] cancel filter scope** (#1) — `_emit`'s drop gate matched any object with an id and `result`/`error`, but its docstring scopes it to JSON-RPC *responses* and says "server-initiated requests ... pass through". A malformed peer that sends both `method` and `result`/`error` under a (coincidentally cancelled) id is a **request** by definition, yet was dropped. Add `"method" not in msg` so only a pure response is eaten — well-formed behavior unchanged.

## Tests
- `test_forwards_malformed_message_with_method_and_result` — the gate change.
- `test_page2_401_does_not_trigger_recovery_returns_partial` (LOW gap) — a 401 on page>=2 stays inside pagination (partial flushed, cursor re-exposed, `token_refresher` **not** called).
- `test_pagination_adopts_last_page_session_id` (#1142) — a server rotating `Mcp-Session-Id` across pages has the **last** page's session adopted for the next request.

## Accepted (documented design, recurring)
- **SSE duplicate id on auth retry / non-2xx POST** (low) — documented `NOTE #3 round16` / `NOTE #1`; no cross-thread per-id de-dup by design.
- **rate-limit `time.sleep` delays cancel ingestion** (low) — documented `NOTE #4 round22`; bounded by the 60 s cap, cancel delays never lost.
- **`_dispatch` closure redefined per line** (nit) — idiomatic same-iteration capture; negligible cost, no correctness impact.

Full relay suite: 359 passed, 3 skipped. Raw separator scan clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)