### PR TITLE
docs(oauth): explain the device-flow poll's RFC 8707 resource omission

### DIFF
--- a/src/mcp_stdio/oauth.py
+++ b/src/mcp_stdio/oauth.py
@@ -1551,6 +1551,14 @@ def _run_device_authorization_flow(
         time.sleep(min(poll_interval, max(0.0, deadline - time.monotonic())))
 
     while time.monotonic() < deadline:
+        # No RFC 8707 ``resource`` is sent on the poll, unlike exchange_code /
+        # refresh_access_token. The Device Authorization Request already carried
+        # it (see the device-authorization POST above), so the AS has bound the
+        # audience to this ``device_code``; RFC 8707 §2.2 phrases the token-request
+        # ``resource`` as optional ("the client CAN indicate ... by way of the
+        # resource parameter") and lets the AS scope to the original grant — it
+        # does not require resending it on the device_code exchange. The omission
+        # is therefore intentional, mirroring the auth-method divergence below.
         poll_data: dict[str, str] = {
             "grant_type": "urn:ietf:params:oauth:grant-type:device_code",
             "device_code": device_code,


### PR DESCRIPTION
Round-30 review fix for `oauth.py` (file-grouped PR 2/2). Comment-only.

## Change
- **[nit] device-flow `resource` omission note** — the device-flow token poll omits the RFC 8707 `resource` indicator that `exchange_code` / `refresh_access_token` send, with no explanation. It is intentional: the Device Authorization Request already carried `resource`, so the AS bound the audience to the `device_code`, and RFC 8707 §2.2 phrases the token-request `resource` as **optional** ("the client *can* indicate ... by way of the resource parameter"), not mandatory. Add a one-line note (citation verified against the RFC text via curl), mirroring the existing auth-method-divergence comment.

## Accepted (documented design / out of scope, no change)
- **`client_id` logged to stderr** (nit) — `client_id` is a public OAuth identifier (sent in the clear on every authorize/token request), not a secret; logging it aids debugging. The `state`/`client_id` redaction difference reflects a real sensitivity-class difference (CSRF token vs durable public id), not an inconsistency.
- **token_store partial-read from a non-atomic external writer** (nit) — out of our control; mcp-stdio always uses `os.replace`. A torn read degrades to `{}` (safe).
- **token_store other-cased duplicate cruft** (nit) — `load_token` tries the normalized key first, so no correctness bug; cruft is bounded and self-healing.
- **`--check` ignores `--no-tcp-keepalive`** (nit) — `--check` is a single-shot probe that completes before keepalive engages; `check_connection` has no such parameter.

Full oauth suite: 273 passed. Raw separator scan clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)