### PR TITLE
fix(oauth): reject malformed-port URLs instead of crashing the discovery walk

### DIFF
--- a/src/mcp_stdio/oauth.py
+++ b/src/mcp_stdio/oauth.py
@@ -158,7 +158,7 @@ def _is_loopback(host: str) -> bool:
         return False
 
 
-def _origin(parsed: ParseResult) -> tuple[str, str, int | None]:
+def _origin(parsed: ParseResult) -> tuple[str, str, int | str | None]:
     """Normalise a parsed URL to an RFC 6454 origin tuple for comparison.
 
     ``parsed.hostname`` already lowercases and strips userinfo; ``parsed.port``
@@ -168,7 +168,18 @@ def _origin(parsed: ParseResult) -> tuple[str, str, int | None]:
     or userinfo therefore compare equal.
     """
     host = (parsed.hostname or "").lower()
-    port = parsed.port
+    try:
+        port = parsed.port
+    except ValueError:
+        # #1 (round31): urllib parses the port LAZILY and raises ValueError on a
+        # non-numeric / out-of-range port (e.g. ``host:999999``) only on access.
+        # Guard it like _authorization_base_url / _build_well_known_url so a
+        # malformed-port URL never crashes a caller mid-discovery; return a
+        # string sentinel that can never equal a valid (scheme, host, int|None)
+        # origin, so such a URL reads as a distinct, non-matching origin. The
+        # #13 validators reject malformed-port URLs up front, so this is
+        # defense-in-depth for any other _origin caller.
+        return (parsed.scheme, host, "invalid-port")
     if port is None:
         port = _DEFAULT_PORTS.get(parsed.scheme)
     return (parsed.scheme, host, port)
@@ -220,6 +231,19 @@ def _validate_auth_server_url(auth_server_url: str, mcp_server_url: str) -> bool
             f"warning: authorization_server URL {auth_server_url!r} embeds "
             f"userinfo (user:pass@); refusing as a credential-exfiltration / "
             f"parser-confusion vector. See #13."
+        )
+        return False
+
+    try:
+        parsed.port  # force the lazy port parse; raises on out-of-range/non-numeric
+    except ValueError:
+        # #1 (round31): a malformed port makes this URL unusable AND would crash
+        # the _origin() comparison below. Skip the candidate (return False) so the
+        # discovery walk advances to the next authorization_server instead of
+        # letting a single bad entry abort the whole OAuth flow with a ValueError.
+        log(
+            f"warning: authorization_server URL {auth_server_url!r} has an "
+            f"invalid port, ignoring"
         )
         return False
 
@@ -348,6 +372,15 @@ def _validate_endpoint_url(endpoint_url: str | None, *, label: str) -> str | Non
         # endpoints; userinfo (``user:pass@host``) is an exfiltration / parser-
         # confusion vector, so refuse it outright.
         log(f"warning: refusing {label} URL with embedded userinfo, ignoring")
+        return None
+    try:
+        parsed.port  # force the lazy port parse; raises on out-of-range/non-numeric
+    except ValueError:
+        # #2 (round31): a malformed port (e.g. ``host:999999``) is unusable and
+        # must be dropped here — otherwise this attacker-influenced endpoint
+        # passes validation and a credential POST surfaces an opaque httpx error
+        # deep in exchange_code / refresh instead of a clean validation drop.
+        log(f"warning: malformed {label} URL {endpoint_url!r} (invalid port), ignoring")
         return None
     if parsed.scheme not in ("https", "http"):
         log(

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -3455,6 +3455,15 @@ class TestValidateAuthServerUrl:
     def test_malformed_url_rejected(self):
         assert _validate_auth_server_url("", self.SERVER_URL) is False
 
+    @pytest.mark.parametrize(
+        "bad", ["https://host:999999/as", "https://host:notaport/as"]
+    )
+    def test_malformed_port_rejected_not_raised(self, bad):
+        """#1(round31): an out-of-range / non-numeric port makes urllib raise on
+        lazy .port access — the validator must REJECT (False), not let the
+        ValueError escape and abort the discovery walk."""
+        assert _validate_auth_server_url(bad, self.SERVER_URL) is False
+
     def test_discover_skips_plaintext_auth_server_and_tries_fallback(
         self, httpx_mock
     ):
@@ -3514,6 +3523,34 @@ class TestValidateAuthServerUrl:
         meta = discover_oauth_metadata(server_url, client)
         assert meta.authorization_endpoint == "https://auth.example.com/authorize"
 
+    def test_discover_skips_malformed_port_auth_server(self, httpx_mock):
+        """#1(round31): a malformed-port AS candidate must be SKIPPED, not crash
+        the discovery walk. urllib parses the port lazily and raises ValueError
+        on .port access, which previously propagated out of the whole OAuth flow
+        — a single bad authorization_servers entry would DoS discovery."""
+        server_url = "https://mcp.example.com/mcp"
+        httpx_mock.add_response(
+            url="https://mcp.example.com/.well-known/oauth-protected-resource/mcp",
+            json={
+                "resource": server_url,
+                "authorization_servers": [
+                    "https://evil.example.net:999999/authorize",  # out-of-range port
+                    "https://auth.example.com",
+                ],
+            },
+        )
+        httpx_mock.add_response(
+            url="https://auth.example.com/.well-known/oauth-authorization-server",
+            json={
+                "authorization_endpoint": "https://auth.example.com/authorize",
+                "token_endpoint": "https://auth.example.com/token",
+            },
+        )
+        client = httpx.Client()
+        # Without the fix this raises ValueError instead of returning metadata.
+        meta = discover_oauth_metadata(server_url, client)
+        assert meta.authorization_endpoint == "https://auth.example.com/authorize"
+
 
 class TestValidateEndpointUrl:
     """AS-metadata endpoint URLs must pass the #13 cleartext-leak policy
@@ -3550,6 +3587,16 @@ class TestValidateEndpointUrl:
         assert _validate_endpoint_url(None, label="token") is None
         assert _validate_endpoint_url("", label="token") is None
         assert capsys.readouterr().err == ""
+
+    @pytest.mark.parametrize(
+        "bad", ["https://evil:999999/token", "https://evil:notaport/token"]
+    )
+    def test_malformed_port_returns_none(self, bad, capsys):
+        """#2(round31): a malformed port must be dropped (None), not returned as
+        a 'valid' endpoint that later receives a credential POST and surfaces an
+        opaque httpx error deep in exchange_code / refresh."""
+        assert _validate_endpoint_url(bad, label="token_endpoint") is None
+        assert "invalid port" in capsys.readouterr().err
 
     def test_discover_drops_cleartext_token_endpoint_and_uses_default(
         self, httpx_mock, capsys


### PR DESCRIPTION
Round-31 review fixes for `oauth.py` (file-grouped PR 1/3). Includes the round's **MEDIUM** (availability DoS).

## Changes
- **[medium] `_origin()` unguarded `.port`** (#1) — urllib parses the port **lazily** and raises `ValueError` on a non-numeric / out-of-range port (e.g. `host:999999`) only on access, unlike the sibling `_authorization_base_url` / `_build_well_known_url` which guard it. A malformed-port `authorization_servers` candidate passed scheme/userinfo/loopback and first hit `.port` inside `_origin`'s cross-origin comparison, where the `ValueError` propagated out of `discover_oauth_metadata` / `ensure_token` and **crashed the whole OAuth flow** — a single bad PRM entry DoS'd discovery, defeating the walk-and-skip design. Now: guard `_origin` (sentinel port), and have `_validate_auth_server_url` reject a malformed port (`False`) so the walk advances.
- **[low] `_validate_endpoint_url` ignored the port** (#2) — a malformed-port endpoint passed validation and was later POSTed credentials (surfacing an opaque httpx error). Reject it (`None`) at validation.

## Tests
- `test_malformed_port_rejected_not_raised` (auth server), `test_malformed_port_returns_none` (endpoint).
- `test_discover_skips_malformed_port_auth_server` — the regression: a malformed-port entry in `authorization_servers` is skipped, discovery picks the next valid AS (without the fix this raises).

## Accepted (documented design, no change)
- **Basic-auth `%20` vs RFC 6749 §2.3.1 `+`** (nit) — already documented as a deliberate, spec-aware choice (the inline comment states it); both forms decode to a space and real client credentials never contain one.
- **`_sanitize_oauth_error` truncates but doesn't redact** (nit) — no live leak (reachable exceptions carry only the operator-trusted endpoint URL, per the existing comments); base64 tokens are within NQSCHAR so redaction wouldn't apply anyway.

Full oauth suite: 278 passed, no teardown errors. Raw separator scan clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)