### PR TITLE
fix(relay): make the outer handler's recovery write survive a broken pipe

### DIFF
--- a/src/mcp_stdio/relay.py
+++ b/src/mcp_stdio/relay.py
@@ -2036,7 +2036,17 @@ def run(
                 # net. A request gets one error; a notification (no id) stays silent.
                 log(f"internal relay error handling request: {e}")
                 if req_has_id:
-                    _write_line(_error_response("internal relay error", req_id))
+                    try:
+                        _write_line(_error_response("internal relay error", req_id))
+                    except OSError:
+                        # #3 (round31): the original exception may itself be a
+                        # BrokenPipeError from _write_line (client closed stdout).
+                        # The recovery write would then re-raise it and crash out
+                        # of the loop — breaking the "keep the session alive"
+                        # guarantee this handler names. Swallow a second write
+                        # failure (nothing can reach a dead stdout anyway); the
+                        # stderr log above already recorded it.
+                        pass
                 continue
     finally:
         client.close()
@@ -2530,7 +2540,14 @@ def run_sse(
                 # request to an error and keeps the loop alive, never crashing.
                 log(f"internal relay error handling request: {e}")
                 if req_has_id:
-                    _write_line(_error_response("internal relay error", req_id))
+                    try:
+                        _write_line(_error_response("internal relay error", req_id))
+                    except OSError:
+                        # #3 (round31): swallow a second write failure when the
+                        # original exception was a BrokenPipeError from
+                        # _write_line — mirrors run(); a dead stdout can receive
+                        # nothing, and the stderr log above already recorded it.
+                        pass
                 continue
     finally:
         state.stop.set()

--- a/tests/test_relay.py
+++ b/tests/test_relay.py
@@ -448,6 +448,31 @@ class TestPostAndStream:
         err = json.loads(stdout.getvalue().strip())
         assert err["id"] == 1 and "error" in err
 
+    def test_recovery_write_brokenpipe_does_not_crash(self, httpx_mock):
+        """#3(round31): when the client has closed stdout, _write_line raises
+        BrokenPipeError. The outer run() handler's own recovery write would then
+        re-raise it and crash out of the loop — breaking the documented
+        keep-the-session-alive guarantee. The recovery write must swallow a
+        second OSError so run() exits cleanly instead of propagating."""
+        httpx_mock.add_response(
+            text='{"jsonrpc":"2.0","result":{},"id":1}',
+            headers={"content-type": "application/json"},
+        )
+        stdin_data = '{"jsonrpc":"2.0","method":"call","id":1}\n'
+        # Every _write_line raises a broken pipe (client gone): the response
+        # write raises, the outer handler catches it, and its recovery write
+        # raises again — which must be swallowed, not propagate out of run().
+        with (
+            patch("sys.stdin", StringIO(stdin_data)),
+            patch("sys.stdout", StringIO()),
+            patch(
+                "mcp_stdio.relay._write_line",
+                side_effect=BrokenPipeError(32, "Broken pipe"),
+            ),
+        ):
+            # Must NOT raise.
+            run("https://example.com/mcp", {"Content-Type": "application/json"})
+
     def test_notification_retry_exhaustion_emits_no_error(self, httpx_mock):
         """has_id=False (a notification): retry exhaustion must NOT synthesize an
         id:null error — a notification can never receive a response."""
@@ -3514,6 +3539,48 @@ class TestPagination:
         # The real list result is still parsed correctly.
         merged = next(d for d in lines if "result" in d)
         assert [t["name"] for t in merged["result"]["tools"]] == ["a"]
+
+    def test_page_sse_skips_non_message_event(self, httpx_mock):
+        """#4(round31): a non-`message` SSE event (e.g. event: ping) on the
+        paginated POST stream is skipped and the following event: message result
+        is still parsed — pins the buffered-path non-message skip branch (the
+        streaming path covers the equivalent case, the buffered path did not)."""
+        result = '{"jsonrpc":"2.0","id":1,"result":{"tools":[{"name":"a"}]}}'
+        body = "event: ping\ndata: {}\n\n" f"event: message\ndata: {result}\n\n"
+        httpx_mock.add_response(
+            url=self.URL,
+            text=body,
+            headers={"content-type": "text/event-stream"},
+        )
+        output = self._run_with_stdin(
+            httpx_mock,
+            [json.dumps({"jsonrpc": "2.0", "id": 1, "method": "tools/list"})],
+        )
+        merged = json.loads(output.strip())
+        assert [t["name"] for t in merged["result"]["tools"]] == ["a"]
+
+    def test_page1_empty_body_falls_back_to_streamed_post(self, httpx_mock):
+        """#4(round31): a page-1 200 with an EMPTY body yields (None, 200), which
+        must trigger the plain-streamed-POST fallback (re-POST) so the client
+        still gets a response — not a silent empty emit. Pins the buffered-path
+        empty-body branch."""
+        # Page 1: empty 200 body -> (None, 200) -> fallback re-POST.
+        httpx_mock.add_response(
+            url=self.URL, text="", headers={"content-type": "application/json"}
+        )
+        # The fallback re-POST returns a normal result.
+        httpx_mock.add_response(
+            url=self.URL,
+            text='{"jsonrpc":"2.0","id":1,"result":{"tools":[{"name":"a"}]}}',
+            headers={"content-type": "application/json"},
+        )
+        output = self._run_with_stdin(
+            httpx_mock,
+            [json.dumps({"jsonrpc": "2.0", "id": 1, "method": "tools/list"})],
+        )
+        merged = json.loads(output.strip())
+        assert merged["result"]["tools"] == [{"name": "a"}]
+        assert len(httpx_mock.get_requests()) == 2  # original empty + fallback
 
 
 # --- check_connection ---


### PR DESCRIPTION
Round-31 review fixes for `relay.py` (file-grouped PR 2/3).

## Changes
- **[low] recovery write re-raises BrokenPipeError** (#3) — the outer `except` handler in `run()` / `run_sse()` names "a BrokenPipeError from `_write_line`" as a recoverable case, but when the original exception *is* that BrokenPipeError (client closed stdout), the handler's own recovery `_write_line` hits the same dead stdout and re-raises — propagating out of the loop and **crashing the gateway**, the exact case the comment claims is kept alive. Wrap the recovery write in `try/except OSError` so a second write failure is swallowed (a dead stdout can receive nothing; the stderr log already recorded it). Applied to both `run()` and `run_sse()`.

## Tests
- `test_recovery_write_brokenpipe_does_not_crash` — `run()` with `_write_line` raising BrokenPipeError exits cleanly.
- `test_page_sse_skips_non_message_event` + `test_page1_empty_body_falls_back_to_streamed_post` (#4) — close the buffered-pagination-path coverage gaps (non-`message` SSE skip; empty-body → streamed-POST fallback).

## Accepted (documented design, no change)
- **SSE reconnect-backoff `stop.wait()→True` early-return arms uncovered** (nit) — benign timing branches; the reader exits cleanly either way. Not worth the fiddly deterministic test for a shutdown-during-backoff window.

Full relay suite: 362 passed, 3 skipped. Raw separator scan clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)