### PR TITLE
fix(token_store): write standards-compliant JSON (allow_nan=False)

### DIFF
--- a/src/mcp_stdio/token_store.py
+++ b/src/mcp_stdio/token_store.py
@@ -519,7 +519,16 @@ def _write_store(data: dict[str, Any]) -> None:
     # sort_keys for stable, diff-friendly on-disk output (#8 round17): without it
     # the per-server key order follows dict-insertion order and churns across the
     # read-modify-write saves, complicating inspection/diffing for no benefit.
-    payload = json.dumps(data, indent=2, sort_keys=True).encode("utf-8")
+    # allow_nan=False (#7 round31): Python's default would serialise a non-finite
+    # expires_at (inf/nan) as the non-standard literal `Infinity`/`NaN`, which a
+    # strict JSON parser rejects and which only the load-side math.isfinite guard
+    # catches. Raise ValueError instead so the bad value never reaches disk — the
+    # save_token / delete_token / migration callers already catch Exception and
+    # degrade to a soft-fail warning (token simply not cached), keeping the store
+    # standards-compliant rather than relying on the read-side backstop.
+    payload = json.dumps(data, indent=2, sort_keys=True, allow_nan=False).encode(
+        "utf-8"
+    )
     # Per-write unique temp name. PID alone is not enough: when the advisory
     # lock degrades to a no-op (lock fs unavailable), two THREADS in one process
     # share the PID and would otherwise pick the same temp path and clobber each

--- a/tests/test_token_store.py
+++ b/tests/test_token_store.py
@@ -602,6 +602,26 @@ class TestLoadSaveDelete:
         # Nothing persisted (the write was aborted), so a later load re-auths.
         assert load_token("https://example.com/mcp") is None
 
+    @pytest.mark.parametrize("bad_expiry", [float("inf"), float("-inf"), float("nan")])
+    def test_save_rejects_non_finite_expiry_before_disk(
+        self, tmp_path, monkeypatch, capsys, bad_expiry
+    ):
+        """#7(round31): _write_store uses allow_nan=False, so a non-finite
+        expires_at raises ValueError before reaching disk (instead of writing the
+        non-standard `Infinity`/`NaN` literal that only the load-side guard
+        catches). save_token catches it and soft-fails — nothing is persisted and
+        the on-disk store never contains non-standard JSON."""
+        store_file = tmp_path / "tokens.json"
+        monkeypatch.setattr("mcp_stdio.token_store._STORE_DIR", tmp_path)
+        monkeypatch.setattr("mcp_stdio.token_store._STORE_FILE", store_file)
+
+        bad = TokenData(access_token="tok", expires_at=bad_expiry)
+        save_token("https://example.com/mcp", bad)  # must not raise
+
+        assert "could not write token store" in capsys.readouterr().err
+        assert not store_file.exists()  # nothing reached disk
+        assert load_token("https://example.com/mcp") is None
+
     def test_save_degrades_to_unlocked_when_lock_open_fails(
         self, tmp_path, monkeypatch
     ):


### PR DESCRIPTION
Round-31 review fix for `token_store.py` (file-grouped PR 3/3).

## Change
- **[nit] non-standard JSON on disk** (#7) — `_write_store`'s `json.dumps` used the default `allow_nan=True`, so a non-finite `expires_at` / `client_secret_expires_at` (inf/nan) would be written as the non-standard literal `Infinity`/`NaN` (rejected by strict JSON parsers), caught only by the load-side `math.isfinite` guard. Pass `allow_nan=False` so the bad value raises `ValueError` **before** reaching disk; `save_token` / `delete_token` / migration already catch `Exception` and soft-fail (token not cached), so the contract is unchanged and the on-disk store is guaranteed standards-compliant.

## Test
- `test_save_rejects_non_finite_expiry_before_disk` (inf/-inf/nan) — soft-fails, writes nothing, loads back as None.

## Accepted (documented design, no change)
- **empty-placeholder copy-through path-based re-stat** (nit) — cosmetic TOCTOU already mooted by `_write_store`'s `O_EXCL|O_NOFOLLOW` temp + `os.replace`, and bounded by the `0o700` store dir.

Full token_store suite: 79 passed. Raw separator scan clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)