### PR TITLE
fix(token_store): add O_NONBLOCK to the lock-file open so a FIFO can't hang it

### DIFF
--- a/src/mcp_stdio/token_store.py
+++ b/src/mcp_stdio/token_store.py
@@ -583,26 +583,34 @@ def _store_lock() -> Iterator[None]:
     # so test monkeypatching of _STORE_DIR redirects the lock file too.
     lock_path = _STORE_DIR / "tokens.json.lock"
     try:
+        # _O_NONBLOCK (#1 round32): without it, an O_WRONLY open of a writer-less
+        # FIFO planted at the lock path BLOCKS forever, hanging every
+        # save_token/delete_token instead of degrading to an unlocked write.
+        # Matches every other os.open in this file (read / legacy / migration),
+        # which all add O_NONBLOCK for exactly this reason. A no-op for the
+        # regular lock file; on a FIFO the open returns ENXIO immediately.
         fd = os.open(
             lock_path,
-            os.O_WRONLY | os.O_CREAT | _O_NOFOLLOW,
+            os.O_WRONLY | os.O_CREAT | _O_NOFOLLOW | _O_NONBLOCK,
             stat.S_IRUSR | stat.S_IWUSR,
         )
     except OSError as e:
-        # A symlink planted at the lock path (O_NOFOLLOW -> ELOOP) silently
-        # disables cross-process serialization — distinct from a benign
-        # read-only / missing-dir failure that just degrades to a no-op lock.
-        # Warn ONCE so the operator can notice the advisory-lock DoS, then
-        # proceed unlocked (a lock failure must never block the save). The dir's
-        # 0o700 mode is the primary guard against another user planting it.
-        if e.errno == errno.ELOOP:
+        # A symlink (O_NOFOLLOW -> ELOOP) or a FIFO (O_NONBLOCK -> ENXIO) planted
+        # at the lock path silently disables cross-process serialization —
+        # distinct from a benign read-only / missing-dir failure that just
+        # degrades to a no-op lock. Warn ONCE so the operator can notice the
+        # advisory-lock DoS, then proceed unlocked (a lock failure must never
+        # block the save). The dir's 0o700 mode is the primary guard against
+        # another user planting it.
+        if e.errno in (errno.ELOOP, errno.ENXIO):
             global _warned_lock_symlink
             if not _warned_lock_symlink:
                 _warned_lock_symlink = True
                 print(
-                    f"warning: token store lock path {lock_path} is a symlink "
-                    f"(refused via O_NOFOLLOW); proceeding without cross-process "
-                    f"locking — concurrent saves may last-writer-wins",
+                    f"warning: token store lock path {lock_path} is a special "
+                    f"file (symlink/FIFO, refused via O_NOFOLLOW/O_NONBLOCK); "
+                    f"proceeding without cross-process locking — concurrent "
+                    f"saves may last-writer-wins",
                     file=sys.stderr,
                 )
         yield

--- a/tests/test_token_store.py
+++ b/tests/test_token_store.py
@@ -582,6 +582,31 @@ class TestLoadSaveDelete:
         err = capsys.readouterr().err
         assert "lock path" in err and "symlink" in err
 
+    @pytest.mark.skipif(
+        sys.platform == "win32" or not hasattr(os, "mkfifo"),
+        reason="os.mkfifo is POSIX-only",
+    )
+    def test_lock_fifo_does_not_hang_and_proceeds(
+        self, tmp_path, monkeypatch, capsys
+    ):
+        """#1(round32): a FIFO planted at the lock path must NOT hang the save —
+        an O_WRONLY open of a writer-less FIFO blocks forever WITHOUT O_NONBLOCK.
+        With O_NONBLOCK the open returns ENXIO and the save degrades to an
+        unlocked write (and warns once), instead of stalling every save/delete."""
+        store_file = tmp_path / "tokens.json"
+        lock_path = tmp_path / "tokens.json.lock"
+        monkeypatch.setattr("mcp_stdio.token_store._STORE_DIR", tmp_path)
+        monkeypatch.setattr("mcp_stdio.token_store._STORE_FILE", store_file)
+        monkeypatch.setattr("mcp_stdio.token_store._warned_lock_symlink", False)
+
+        os.mkfifo(lock_path)
+        # If the O_NONBLOCK guard regressed, this would hang the test forever.
+        save_token("https://example.com/mcp", TokenData(access_token="tok"))
+
+        assert load_token("https://example.com/mcp").access_token == "tok"
+        err = capsys.readouterr().err
+        assert "lock path" in err and "FIFO" in err
+
     def test_save_soft_fails_on_non_serializable_value(
         self, tmp_path, monkeypatch, capsys
     ):


### PR DESCRIPTION
Round-32 review fix for `token_store.py` (file-grouped PR 1/3). The round's only behavior-changing finding.

## Change
- **[low] lock open could hang on a FIFO** (#1) — the advisory-lock `os.open` was the single `os.open` in this file missing `_O_NONBLOCK`. An `O_WRONLY` open of a writer-less FIFO blocks **forever**, so a FIFO planted at `~/.config/mcp-stdio/tokens.json.lock` would hang `_store_lock()` and thus every `save_token` / `delete_token` (and the relay's in-session token refresh) — turning the documented "degrade to an unlocked write on lock trouble" contract into a hard hang. Add `_O_NONBLOCK` (no-op on the regular lock file; returns `ENXIO` on a FIFO) so the existing `except` branch degrades to an unlocked write, matching the read / legacy / migration opens. Broaden the one-time warning to cover FIFO (`ENXIO`) alongside symlink (`ELOOP`). The `0o700` dir is the primary guard.

## Test
- `test_lock_fifo_does_not_hang_and_proceeds` — a FIFO at the lock path no longer hangs; the save proceeds unlocked and warns once.

Full token_store suite: 80 passed. Raw separator scan clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)