### PR TITLE
refactor(relay): drop dead _has_id; cover nextCursor/_same_origin/HTTP-date edges

### DIFF
--- a/src/mcp_stdio/relay.py
+++ b/src/mcp_stdio/relay.py
@@ -185,28 +185,16 @@ def _extract_id(line: str) -> Any:
         return None
 
 
-def _has_id(line: str) -> bool:
-    """Return True if the line is a JSON-RPC request (carries an ``id`` key).
-
-    A notification has no ``id`` and must never receive a response, so the relay
-    suppresses synthesized error responses for it. Distinguishes a present
-    ``id:null`` (a request) from an absent id (a notification). Unparseable input
-    is treated as id-less (no response synthesized).
-    """
-    try:
-        msg = json.loads(line)
-    except (json.JSONDecodeError, TypeError):
-        return False
-    return isinstance(msg, dict) and "id" in msg
-
-
 def _extract_id_and_presence(line: str) -> tuple[Any, bool]:
     """Return ``(id_value, has_id)`` from a SINGLE JSON parse of a line.
 
-    Equivalent to ``(_extract_id(line), _has_id(line))`` but parses once — the
-    relay's per-stdin-line hot path needs both facts, and re-walking the JSON
-    twice is wasteful under load. A notification (no id) → ``(None, False)``; a
-    request → ``(id, True)``; a non-object / malformed line → ``(None, False)``.
+    The relay's per-stdin-line hot path needs both the id value AND whether an
+    ``id`` key is present (a notification has none and must never receive a
+    response), so this parses once rather than re-walking the JSON twice under
+    load. A present ``id:null`` (a request) is distinguished from an absent id
+    (a notification). A notification (no id) → ``(None, False)``; a request →
+    ``(id, True)``; a non-object / unparseable line → ``(None, False)`` (no
+    response synthesized).
     """
     try:
         msg = json.loads(line)

--- a/tests/test_relay.py
+++ b/tests/test_relay.py
@@ -674,6 +674,17 @@ class TestSameOrigin:
     def test_different_explicit_port_is_cross_origin(self):
         assert not _same_origin("https://h.example:8443/x", "https://h.example/x")
 
+    def test_malformed_url_returns_not_same_origin(self):
+        """#4(round32): a malformed URL (urlsplit/.port raises ValueError, e.g. a
+        non-numeric port) must be treated as NOT same-origin — the conservative,
+        fail-closed answer for the SSE cross-origin credential guard."""
+        assert not _same_origin(
+            "https://h.example:notaport/a", "https://h.example/b"
+        )
+        assert not _same_origin(
+            "https://h.example/a", "https://h.example:99999/b"
+        )
+
 
 class TestExtractProtocolVersion:
     """_extract_protocol_version reads result.protocolVersion from an
@@ -3448,6 +3459,31 @@ class TestPagination:
         )
         merged = json.loads(output.strip())
         assert [t["name"] for t in merged["result"]["tools"]] == ["a"]
+
+    def test_empty_string_next_cursor_is_terminal(self, httpx_mock):
+        """#2(round32): an empty-string nextCursor is treated as terminal (like
+        null / absent) — an empty cursor cannot be round-tripped, so it is a
+        degenerate end, not another page. Exactly one upstream POST, and the
+        merged result carries no nextCursor. Pins the documented `if not
+        next_cursor` contract distinctly from the null/absent case."""
+        page1 = {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "result": {"tools": [{"name": "a"}], "nextCursor": ""},
+        }
+        httpx_mock.add_response(
+            url=self.URL,
+            text=json.dumps(page1),
+            headers={"content-type": "application/json"},
+        )
+        output = self._run_with_stdin(
+            httpx_mock,
+            [json.dumps({"jsonrpc": "2.0", "id": 1, "method": "tools/list"})],
+        )
+        merged = json.loads(output.strip())
+        assert merged["result"]["tools"] == [{"name": "a"}]
+        assert "nextCursor" not in merged["result"]  # empty cursor not re-exposed
+        assert len(httpx_mock.get_requests()) == 1  # no second-page fetch
 
     def test_page2_nonlist_result_key_keeps_page1_and_merges_late_field(
         self, httpx_mock
@@ -6590,6 +6626,35 @@ class TestRun429Retry:
         )
         assert '"ok":true' in output
         assert 2.0 in slept, f"expected a 2.0-second sleep, got {slept!r}"
+
+    def test_429_http_date_retry_after_then_200(self, httpx_mock, monkeypatch):
+        """#5(round32): an HTTP-date Retry-After flows end-to-end through
+        _handle_rate_limit into the run() retry sleep — the integration analogue
+        of the parser unit test. The date->delta conversion is exercised on the
+        real path, not just in isolation."""
+        slept: list[float] = []
+        monkeypatch.setattr("mcp_stdio.relay.time.sleep", lambda s: slept.append(s))
+
+        # Retry-After as an HTTP-date 10 s in the future (RFC 9110 §10.2.3).
+        future = datetime.now(timezone.utc) + timedelta(seconds=10)
+        http_date = email.utils.format_datetime(future, usegmt=True)
+        httpx_mock.add_response(
+            status_code=429, headers={"retry-after": http_date}, text=""
+        )
+        httpx_mock.add_response(
+            text='{"jsonrpc":"2.0","result":{"ok":true},"id":1}',
+            headers={"content-type": "application/json"},
+        )
+
+        output = self._run_with_stdin(
+            httpx_mock,
+            ['{"jsonrpc":"2.0","method":"tools/call","id":1}'],
+        )
+        assert '"ok":true' in output
+        # The date was parsed to a ~10 s delta and slept on, NOT the 1 s
+        # no-hint backoff fallback (which would be the value if parsing failed).
+        assert slept, "expected a retry sleep"
+        assert max(slept) >= 5.0, f"expected a date-derived sleep, got {slept!r}"
 
     def test_429_without_retry_after_uses_backoff_then_200(
         self, httpx_mock, monkeypatch


### PR DESCRIPTION
Round-32 review fixes for `relay.py` (file-grouped PR 2/3). Dead-code removal + coverage.

## Changes
- **[nit] dead code** (#3) — `_has_id` had no production caller (the hot path uses `_extract_id_and_presence`, a single-parse superset, everywhere) and no test, so it was dead code carrying an uncovered branch. Remove it; reword the `_extract_id_and_presence` docstring that referenced it.

## Tests (coverage gaps; behavior already correct)
- `test_empty_string_next_cursor_is_terminal` (#2) — an empty-string `nextCursor` is terminal (one POST, no `nextCursor` re-exposed), distinct from null/absent.
- `test_malformed_url_returns_not_same_origin` (#4) — `_same_origin` fail-closes on a malformed URL (urlsplit/`.port` ValueError).
- `test_429_http_date_retry_after_then_200` (#5) — an HTTP-date `Retry-After` flows end-to-end into the run() retry sleep (~10 s), not just the parser unit test.

Full suite: 823 passed, 3 skipped. Raw separator scan clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)