### PR TITLE
fix(oauth): set no-store / no-referrer on the OAuth callback page

### DIFF
--- a/src/mcp_stdio/oauth.py
+++ b/src/mcp_stdio/oauth.py
@@ -876,6 +876,13 @@ def _make_callback_handler(
             if result.auth_code is not None or result.error is not None:
                 self.send_response(200)
                 self.send_header("Content-Type", "text/html")
+                # #6 (round32): the callback URL carries the auth code/state, so
+                # no-store keeps the browser from caching the response and
+                # no-referrer keeps any (future) sub-resource from leaking the
+                # URL via the Referer header. The page has no sub-resources
+                # today, so this is defense-in-depth / standard callback hygiene.
+                self.send_header("Cache-Control", "no-store")
+                self.send_header("Referrer-Policy", "no-referrer")
                 self.end_headers()
                 self.wfile.write(
                     b"<h1>Already received</h1><p>You can close this tab.</p>"
@@ -891,6 +898,8 @@ def _make_callback_handler(
 
             self.send_response(200)
             self.send_header("Content-Type", "text/html")
+            self.send_header("Cache-Control", "no-store")  # #6 (round32)
+            self.send_header("Referrer-Policy", "no-referrer")
             self.end_headers()
 
             if result.error:

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -1913,6 +1913,35 @@ class TestCallbackServer:
         assert cb_result.auth_code == "test_code_123"
         assert cb_result.state == "test_state"
 
+    def test_callback_response_has_security_headers(self):
+        """#6(round32): the callback page sets Cache-Control: no-store and
+        Referrer-Policy: no-referrer — defense-in-depth, since the callback URL
+        carries the auth code/state."""
+        cb_result = CallbackResult()
+        handler_cls = _make_callback_handler(cb_result)
+
+        from http.server import HTTPServer
+
+        server = HTTPServer(("127.0.0.1", 0), handler_cls)
+        port = server.server_address[1]
+        done = threading.Event()
+
+        def serve():
+            while not done.is_set():
+                server.handle_request()
+
+        t = threading.Thread(target=serve, daemon=True)
+        t.start()
+        time.sleep(0.3)
+
+        resp = httpx.get(f"http://127.0.0.1:{port}/callback?code=c&state=s")
+
+        done.set()
+        server.server_close()
+
+        assert resp.headers.get("cache-control") == "no-store"
+        assert resp.headers.get("referrer-policy") == "no-referrer"
+
     def test_bare_callback_hit_does_not_render_success(self):
         """#2(round21): a /callback hit carrying neither code nor error (a
         browser prefetch, a manual GET) captured nothing — the page must NOT say


### PR DESCRIPTION
Round-32 review fix for `oauth.py` (file-grouped PR 3/3). Defense-in-depth.

## Change
- **[nit] callback page lacked cache/referrer headers** (#6) — the localhost callback page was served with only `Content-Type`. Add `Cache-Control: no-store` and `Referrer-Policy: no-referrer` (both response sites) as defense-in-depth: the callback URL carries the single-use, PKCE-bound auth code/state, so `no-store` keeps the browser from caching the response and `no-referrer` keeps any future sub-resource from leaking the URL via `Referer`. Standard OAuth-callback hygiene; the page has no sub-resources today so nothing observable changes, but it closes the audit's "leaks code to other origins" dimension.

## Test
- `test_callback_response_has_security_headers` — the callback response carries both headers.

Full oauth suite: 279 passed. Raw separator scan clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)