### PR TITLE
chore(token_store): add O_NONBLOCK to the directory-fsync open for consistency

### DIFF
--- a/src/mcp_stdio/token_store.py
+++ b/src/mcp_stdio/token_store.py
@@ -559,7 +559,11 @@ def _write_store(data: dict[str, Any]) -> None:
     # directory fsync, and opening a directory fails on Windows — neither should
     # fail the write.
     try:
-        dir_fd = os.open(str(_STORE_DIR), os.O_RDONLY | _O_NOFOLLOW)
+        # _O_NONBLOCK for consistency with every other os.open in this file
+        # (#5 round33). Harmless on a directory (a dir open never blocks), but
+        # it keeps the defensive open discipline uniform so a future copy of
+        # this pattern does not omit it where it DOES matter (FIFO at a path).
+        dir_fd = os.open(str(_STORE_DIR), os.O_RDONLY | _O_NOFOLLOW | _O_NONBLOCK)
         try:
             os.fsync(dir_fd)
         finally:


### PR DESCRIPTION
Round-33 review fix for `token_store.py` (file-grouped PR 2/3). Consistency nit.

## Change
- **[nit] uniform open discipline** (#5) — the post-`os.replace` directory-fsync open was the only `os.open` in this file using `_O_NOFOLLOW` without `_O_NONBLOCK`. A directory open never blocks, so this is harmless and behavior-preserving — but adding the flag keeps the defensive open discipline uniform so a future copy of the pattern doesn't omit it where a FIFO *could* block.

Full token_store suite: 80 passed. Raw separator scan clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)