### PR TITLE
docs: qualify the Token-refresh feature bullet as OAuth-mode only

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -55,7 +55,7 @@ Bearer token、カスタムヘッダー、OAuth 2.1 認証情報をリモート�
 - **キャンセル対応フィルタ** — stdin の `notifications/cancelled` でキャンセルされた id を追跡し、その id を持つ遅延レスポンスがクライアントに届く前に drop する（MCP キャンセル仕様準拠）。デフォルト有効（TTL 60 秒）、`--no-cancel-filter` で無効化
 - **セッション回復** — 404 でセッション ID をリセットして再試行
 - **プロトコルバージョンヘッダー** — `initialize` 応答から交渉済みの `protocolVersion` を捕捉し、以降の Streamable HTTP リクエストすべてに `MCP-Protocol-Version` を付与（MCP 仕様 rev 2025-06-18）。このヘッダーを強制するサーバーは未送信時に初期化後リクエストを `400 Bad Request` で拒否する
-- **401 時の自動トークンリフレッシュ** — セッション中に OAuth トークンが失効しても自動更新
+- **401 時の自動トークンリフレッシュ** — セッション中に OAuth トークンが失効しても自動更新（OAuth モード時のみ）
 - **403 時のステップアップ認可** — `Bearer error="insufficient_scope"` チャレンジを受けると、付与済みスコープと要求スコープの和集合で再認可（[RFC 9470](https://www.rfc-editor.org/rfc/rfc9470) / MCP step-up、cf. anthropics/claude-code#44652）
 - **Bearer token 認証** — `--bearer-token` フラグまたは `MCP_BEARER_TOKEN` 環境変数
 - **カスタムヘッダー** — `-H` / `--header` で任意のヘッダーを送信

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Bearer tokens, custom headers, and OAuth 2.1 credentials are forwarded to the re
 - **Cancellation-aware filtering** — tracks request ids cancelled via `notifications/cancelled` on stdin and drops any late upstream response carrying one of those ids before it reaches the client, per the MCP cancellation spec; on by default (60 s TTL), opt out with `--no-cancel-filter`
 - **Session recovery** — resets MCP session ID on 404 and retries
 - **Protocol version header** — captures the negotiated `protocolVersion` from the `initialize` response and injects `MCP-Protocol-Version` on every subsequent Streamable HTTP request (MCP spec rev 2025-06-18); servers that enforce the header would otherwise reject post-initialize requests with `400 Bad Request`
-- **Token refresh on 401** — automatically refreshes expired OAuth tokens mid-session
+- **Token refresh on 401** — automatically refreshes expired OAuth tokens mid-session (OAuth mode only)
 - **Step-up authorization on 403** — on a `Bearer error="insufficient_scope"` challenge, re-authorizes for the union of the granted and required scopes ([RFC 9470](https://www.rfc-editor.org/rfc/rfc9470) / MCP step-up; cf. anthropics/claude-code#44652)
 - **Bearer token auth** — via `--bearer-token` flag or `MCP_BEARER_TOKEN` env var
 - **Custom headers** — pass any header with `-H` / `--header`


### PR DESCRIPTION
Round-33 review fix for the docs (file-grouped PR 3/3).

## Change
- **[nit] missing mode qualifier** (#7) — the "Token refresh on 401" Features bullet read "automatically refreshes expired OAuth tokens mid-session" with no mode qualifier, so a skim could suggest a static `--bearer-token` / `-H` token is auto-refreshed too. The 401 refresh is driven by the `token_refresher` callback, only built on the OAuth path. The "How It Works" step already says "(OAuth mode only)"; add the same qualifier to the bullet in both `README.md` and `README.ja.md`.

## Accepted (documented / external, no change)
- **WORKAROUNDS.md Claude Code version refs** (nit) — issue-anchored, point-in-time upstream claims; the mcp-stdio side is verified. Leave as-is.

Raw separator scan clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)