### PR TITLE
fix(oauth): surface RFC 6749 §5.2 token-error bodies; validate DCR credentials

### DIFF
--- a/src/mcp_stdio/oauth.py
+++ b/src/mcp_stdio/oauth.py
@@ -640,9 +640,10 @@ def discover_oauth_metadata(
 
     # Path-scoped issuers (Keycloak realm URLs, AWS Cognito user pools, etc.)
     # publish metadata at /.well-known/oauth-authorization-server/<path> per
-    # RFC 8414 §3.1 (the well-known string is inserted between the host and the
-    # issuer's path component). Try the original server_url when it has a path
-    # component that neither the PRM-discovered AS nor the base URL tried.
+    # RFC 8414 §3 (the well-known string is inserted between the host and the
+    # issuer's path component; §3.1 illustrates it for the metadata request).
+    # Try the original server_url when it has a path component that neither the
+    # PRM-discovered AS nor the base URL tried.
     if server_url not in (auth_server_url, base):
         meta = _fetch_authorization_server_metadata(server_url, client)
         if meta:
@@ -802,9 +803,25 @@ def register_client(
         raise ValueError(
             "Client registration response is missing client_id (RFC 7591 §3.2.1)."
         )
+    # Type-validate the AS-supplied credentials (#A-1 round34). A non-conformant
+    # AS returning a non-string client_id / client_secret would otherwise be
+    # str()-coerced into the authorize URL or raise an OPAQUE TypeError deep in
+    # quote() during HTTP Basic auth. Convert it to an actionable RFC 7591 error
+    # here, matching the missing-client_id guard above and the str validation
+    # load_token / _parse_token_response already apply to AS-supplied values.
+    client_secret = data.get("client_secret")
+    if not isinstance(client_id, str):
+        raise ValueError(
+            "Client registration response client_id is not a string (RFC 7591 §3.2.1)."
+        )
+    if client_secret is not None and not isinstance(client_secret, str):
+        raise ValueError(
+            "Client registration response client_secret is not a string "
+            "(RFC 7591 §3.2.1)."
+        )
     return ClientRegistration(
         client_id=client_id,
-        client_secret=data.get("client_secret"),
+        client_secret=client_secret,
         client_secret_expires_at=expiry,
         auth_method=auth_method,
     )
@@ -945,6 +962,31 @@ def _parse_token_response(resp: httpx.Response) -> dict[str, Any]:
     GitHub OAuth (and some others) may return application/x-www-form-urlencoded.
     Some servers return HTTP 200 with an error in the body (GitHub legacy).
     """
+    # #1 (round34): RFC 6749 §5.2 — a token error is a 4xx carrying
+    # ``{"error": ..., "error_description": ...}``. Surface that actionable
+    # description BEFORE raise_for_status() collapses it into an opaque
+    # ``HTTPStatusError`` (which omits the body), mirroring the 200-with-error
+    # handling in _raise_for_body_error. Best-effort: an unparseable / error-less
+    # 4xx body falls through to raise_for_status (an honest but generic HTTP
+    # error). On the refresh path the resulting RuntimeError degrades to None
+    # exactly as the HTTPStatusError did, so only the interactive auth-code
+    # exchange gains the better message.
+    if resp.status_code >= 400:
+        body: dict[str, Any] | None = None
+        try:
+            if "application/x-www-form-urlencoded" in resp.headers.get(
+                "content-type", ""
+            ):
+                _qs = dict(parse_qs(resp.text, keep_blank_values=True))
+                body = {k: (v[0] if v else "") for k, v in _qs.items()}
+            else:
+                body = resp.json()
+        except Exception:
+            body = None
+        if isinstance(body, dict) and "error" in body:
+            desc = body.get("error_description", body["error"])
+            raise RuntimeError(f"OAuth token error: {_sanitize_oauth_error(desc)}")
+
     resp.raise_for_status()
 
     content_type = resp.headers.get("content-type", "")

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -983,6 +983,35 @@ class TestRegisterClient:
         with pytest.raises(ValueError, match="client_id"):
             register_client(meta, "http://127.0.0.1:9999/callback", client)
 
+    @pytest.mark.parametrize(
+        "reg,match",
+        [
+            ({"client_id": 12345}, "client_id is not a string"),
+            (
+                {"client_id": "cid", "client_secret": {"x": 1}},
+                "client_secret is not a string",
+            ),
+        ],
+    )
+    def test_non_string_dcr_credentials_raise_clear_error(
+        self, httpx_mock, reg, match
+    ):
+        """#A-1(round34): a non-conformant AS returning a non-string client_id /
+        client_secret must raise an actionable RFC 7591 ValueError here, not an
+        opaque TypeError deep in quote() during HTTP Basic auth (or a silently
+        str-coerced client_id in the authorize URL)."""
+        httpx_mock.add_response(
+            url="https://api.example.com/register", json=reg
+        )
+        meta = OAuthMetadata(
+            authorization_endpoint="https://api.example.com/authorize",
+            token_endpoint="https://api.example.com/token",
+            registration_endpoint="https://api.example.com/register",
+        )
+        client = httpx.Client()
+        with pytest.raises(ValueError, match=match):
+            register_client(meta, "http://127.0.0.1:9999/callback", client)
+
     def test_no_registration_endpoint(self):
         meta = OAuthMetadata(
             authorization_endpoint="https://api.example.com/authorize",
@@ -1242,10 +1271,40 @@ class TestExchangeCode:
         assert b"resource=https" in req.content
 
     def test_token_exchange_failure(self, httpx_mock):
+        """#1(round34): a standard RFC 6749 §5.2 token error (4xx + error /
+        error_description) surfaces the actionable error_description as a
+        RuntimeError, not an opaque HTTPStatusError that drops the body."""
         httpx_mock.add_response(
             url="https://api.example.com/token",
             status_code=400,
             json={"error": "invalid_grant", "error_description": "Code expired"},
+        )
+        meta = OAuthMetadata(
+            authorization_endpoint="https://api.example.com/authorize",
+            token_endpoint="https://api.example.com/token",
+        )
+        client = httpx.Client()
+        with pytest.raises(RuntimeError, match="Code expired"):
+            exchange_code(
+                meta,
+                "cid",
+                None,
+                "bad-code",
+                "verifier",
+                "http://127.0.0.1:9999/callback",
+                client,
+            )
+
+    def test_token_exchange_4xx_without_error_body_raises_http_error(
+        self, httpx_mock
+    ):
+        """A 4xx whose body is NOT an RFC 6749 §5.2 error (no `error` key) falls
+        through to raise_for_status — an honest, generic HTTP error."""
+        httpx_mock.add_response(
+            url="https://api.example.com/token",
+            status_code=400,
+            text="upstream rejected",
+            headers={"content-type": "text/plain"},
         )
         meta = OAuthMetadata(
             authorization_endpoint="https://api.example.com/authorize",
@@ -1305,14 +1364,17 @@ class TestRefreshToken:
         assert result["refresh_token"] == "new_rt"
 
     def test_invalid_grant(self, httpx_mock):
-        """Refresh token expired or revoked."""
+        """Refresh token expired or revoked — an RFC 6749 §5.2 error body (here
+        with no error_description) surfaces the `error` code as a RuntimeError
+        (#1 round34). On the refresh path refresh_cached_token catches it and
+        degrades to None, exactly as it did for the prior HTTPStatusError."""
         httpx_mock.add_response(
             url="https://api.example.com/token",
             status_code=400,
             json={"error": "invalid_grant"},
         )
         client = httpx.Client()
-        with pytest.raises(httpx.HTTPStatusError):
+        with pytest.raises(RuntimeError, match="invalid_grant"):
             refresh_access_token(
                 "https://api.example.com/token", "cid", None, "bad_rt", client
             )
@@ -1852,11 +1914,27 @@ class TestParseTokenResponse:
         with pytest.raises(RuntimeError, match="Code expired"):
             _parse_token_response(resp)
 
-    def test_http_400_raises(self, httpx_mock):
+    def test_http_400_with_error_body_raises_runtime_error(self, httpx_mock):
+        """#1(round34): a 4xx whose body is an RFC 6749 §5.2 error surfaces the
+        `error` code as a RuntimeError (actionable), not the opaque
+        HTTPStatusError that drops the body."""
         httpx_mock.add_response(
             url="https://example.com/token",
             status_code=400,
             json={"error": "invalid_grant"},
+        )
+        client = httpx.Client()
+        resp = client.post("https://example.com/token")
+        with pytest.raises(RuntimeError, match="invalid_grant"):
+            _parse_token_response(resp)
+
+    def test_http_400_without_error_body_raises_http_error(self, httpx_mock):
+        """A 4xx whose body has no `error` key falls through to raise_for_status."""
+        httpx_mock.add_response(
+            url="https://example.com/token",
+            status_code=400,
+            text="plain rejection",
+            headers={"content-type": "text/plain"},
         )
         client = httpx.Client()
         resp = client.post("https://example.com/token")


### PR DESCRIPTION
Round-34 review fixes for `oauth.py` (file-grouped PR 1/3). Includes the round's only behavior-changing finding.

## Changes
- **[low] §5.2 token-error bodies discarded** (#1) — `_parse_token_response` called `raise_for_status()` before reading the body, so a standard RFC 6749 §5.2 error (4xx + `{"error", "error_description"}`) collapsed into an opaque `HTTPStatusError` that drops the body; the interactive auth-code exchange showed a generic "400 Bad Request" instead of the actionable `error_description`. Parse the error body first (best-effort) and raise `RuntimeError("OAuth token error: <description>")`, mirroring the 200-with-error handling. A 4xx without an `error` key still falls through to `raise_for_status`. On refresh it degrades to None exactly as before.
- **[nit] DCR credential type validation** (#A-1) — `register_client` validates the AS-supplied `client_id` / `client_secret` as strings, converting an otherwise-opaque `TypeError` deep in `quote()` (or a silently str-coerced `client_id`) into an actionable RFC 7591 `ValueError`.
- **[nit] RFC 8414 citation** (#A-3) — `§3.1` → `§3` for the well-known-insertion rule (verified against the RFC; the normative rule is in §3's lead paragraph).

## Tests
- `test_token_exchange_failure` / `test_invalid_grant` / `test_http_400_with_error_body_raises_runtime_error` updated to the new actionable-error behavior; added 4xx-without-error-body fallthrough + non-string-DCR-credential cases.

## Accepted (documented, recurring)
- **Basic-auth `%20` vs §2.3.1 `+`** (nit) — already documented as a deliberate, spec-aware choice; byte-identical for real (space-free) credentials.

Full oauth suite: 283 passed, no teardown errors. Raw separator scan clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)