### PR TITLE
docs(relay): note cross-origin guard snapshot freshness; assert win32 branch ran

### DIFF
--- a/src/mcp_stdio/relay.py
+++ b/src/mcp_stdio/relay.py
@@ -2111,6 +2111,14 @@ def _sse_reader_loop(
     window where a server keeps the GET alive on an expired token would be
     over-engineering for no observed failure mode.
 
+    The cross-origin credential guard on the endpoint event (#D-1 round34)
+    evaluates ``has_auth`` against this SAME per-connect snapshot, so it is only
+    as fresh as the current GET connection — acceptable because Authorization is
+    established at startup, not introduced mid-session: a refresh that ADDED an
+    Authorization header where none existed would not reach an already-open
+    stream's snapshot until reconnect, but that flow does not occur (auth is set
+    once at startup), so the guard never evaluates a stale has_auth=False.
+
     Reconnects automatically on disconnect.
     """
     # Whether a usable endpoint was EVER established. A non-200 on the very

--- a/tests/test_relay.py
+++ b/tests/test_relay.py
@@ -156,18 +156,30 @@ class TestEnforceLfStdio:
         assert calls == [{"newline": ""}, {"newline": ""}]
 
     def test_windows_without_reconfigure_is_tolerated(self):
-        """Some redirected streams lack reconfigure(); must not raise."""
+        """Some redirected streams lack reconfigure(); must not raise — AND the
+        win32 branch must actually run the hasattr guard (#C-1 round34). The
+        stream records the `reconfigure` lookup, so `checked` is True only if the
+        win32 path was taken; on a non-win32 early-return it would stay False."""
 
-        class BareStream:
-            # Intentionally no reconfigure attribute
-            pass
+        class TrackingStream:
+            def __init__(self):
+                self.checked = False
 
+            def __getattr__(self, name):
+                # Only `reconfigure` is missing; hasattr() probes it here.
+                if name == "reconfigure":
+                    self.checked = True
+                raise AttributeError(name)
+
+        stdin_stream, stdout_stream = TrackingStream(), TrackingStream()
         with (
             patch("mcp_stdio.relay.sys.platform", "win32"),
-            patch("mcp_stdio.relay.sys.stdin", BareStream()),
-            patch("mcp_stdio.relay.sys.stdout", BareStream()),
+            patch("mcp_stdio.relay.sys.stdin", stdin_stream),
+            patch("mcp_stdio.relay.sys.stdout", stdout_stream),
         ):
-            _enforce_lf_stdio()  # should not raise
+            _enforce_lf_stdio()  # must not raise
+        # The win32 branch ran the hasattr guard on both streams.
+        assert stdin_stream.checked and stdout_stream.checked
 
 
 # --- _extract_id ---


### PR DESCRIPTION
Round-34 review fixes for `relay.py` (file-grouped PR 3/3). Doc clarity + a test assertion.

## Changes
- **[nit] cross-origin guard snapshot note** (#D-1) — extend the SSE refresh-propagation note to call out that the cross-origin credential guard evaluates `has_auth` against the same per-connect snapshot (only as fresh as the current GET connection), acceptable because Authorization is established at startup, not introduced mid-session.
- **[nit] vacuous test** (#C-1) — `test_windows_without_reconfigure_is_tolerated` asserted nothing. Use a stream that records the `reconfigure` `hasattr` lookup so the test proves the win32 branch actually ran the guard (not a non-win32 early-return silently no-op'ing).

## Accepted (documented, no change)
- **reader-thread cross-origin auth uses the locked snapshot** (nit) — correct as-is; the only ask was the doc note now added above.

Full relay suite: 368 passed, 3 skipped. Raw separator scan clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)