### PR TITLE
fix(oauth): validate CSRF state before acting on an error callback

### DIFF
--- a/src/mcp_stdio/oauth.py
+++ b/src/mcp_stdio/oauth.py
@@ -908,6 +908,12 @@ def _make_callback_handler(
 
             if "error" in params:
                 result.error = params["error"][0]
+                # Capture state on the error branch too (#1 round35) so the flow
+                # can bind an error response to the CSRF state before acting on
+                # it. RFC 6749 §4.1.2.1 requires a compliant AS to echo `state`
+                # on error responses; an error callback WITHOUT the matching
+                # state is an unauthenticated abort attempt, not a real AS error.
+                result.state = params.get("state", [None])[0]
             elif "code" in params:
                 result.auth_code = params["code"][0]
                 result.state = params.get("state", [None])[0]
@@ -1406,16 +1412,23 @@ def _run_authorization_flow(
         done.set()
         callback_server.server_close()
 
-    if cb_result.error:
-        raise RuntimeError(f"OAuth error: {_sanitize_oauth_error(cb_result.error)}")
-
+    # Validate state BEFORE acting on EITHER a code or an error (#1 round35).
     # Use a constant-time comparison so the rejection path does not leak the
-    # common-prefix length of the two state tokens via timing. Over a
-    # loopback callback the attack is theoretical, but every mainstream
-    # OAuth client does this and the line carries a CSRF-facing comment —
-    # we want it to hold up to scrutiny without caveats. See #26.
+    # common-prefix length of the two state tokens via timing. Over a loopback
+    # callback the attack is theoretical, but every mainstream OAuth client does
+    # this and the line carries a CSRF-facing comment — we want it to hold up to
+    # scrutiny without caveats. See #26. Checking state FIRST also binds the
+    # ERROR path: an unauthenticated local process (or a port-guessing page) that
+    # hits /callback?error=... during the auth window to GRIEF the flow does not
+    # carry the matching state, so it is rejected here as a CSRF mismatch instead
+    # of aborting the flow with an attacker-chosen error. A compliant AS echoes
+    # `state` on error responses (RFC 6749 §4.1.2.1), so a legitimate error still
+    # passes this and surfaces just below.
     if not secrets.compare_digest(cb_result.state or "", state):
         raise RuntimeError("OAuth state mismatch — possible CSRF attack")
+
+    if cb_result.error:
+        raise RuntimeError(f"OAuth error: {_sanitize_oauth_error(cb_result.error)}")
 
     # RFC 9207 §2.4: if the authorization response carries an `iss` parameter,
     # the client MUST validate it against the issuer the metadata was fetched

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -4015,17 +4015,26 @@ class TestAuthorizationFlowFailurePaths:
         assert "state=%3Credacted%3E" in err
         assert real_state not in err
 
-    def test_callback_error_raises_runtime_error(self, monkeypatch):
-        """A callback carrying ?error=... → RuntimeError, no code exchange."""
+    def test_callback_error_with_matching_state_raises_oauth_error(
+        self, monkeypatch
+    ):
+        """A LEGITIMATE error callback echoes `state` (RFC 6749 §4.1.2.1) →
+        surfaces the OAuth error, no code exchange. (#1 round35: state is now
+        validated before the error is acted on.)"""
         from urllib.parse import parse_qs, urlparse
         from urllib.request import urlopen
 
         def fake_open(auth_url: str) -> bool:
-            redirect_uri = parse_qs(urlparse(auth_url).query)["redirect_uri"][0]
+            q = parse_qs(urlparse(auth_url).query)
+            redirect_uri = q["redirect_uri"][0]
+            sent_state = q["state"][0]
 
             def hit() -> None:
                 try:
-                    urlopen(f"{redirect_uri}?error=access_denied", timeout=5).read()
+                    urlopen(
+                        f"{redirect_uri}?error=access_denied&state={sent_state}",
+                        timeout=5,
+                    ).read()
                 except Exception:
                     pass
 
@@ -4035,6 +4044,40 @@ class TestAuthorizationFlowFailurePaths:
         monkeypatch.setattr("mcp_stdio.oauth.webbrowser.open", fake_open)
         client = httpx.Client()
         with pytest.raises(RuntimeError, match="OAuth error"):
+            _run_authorization_flow(
+                "https://ex.com/mcp",
+                client,
+                metadata=self.META,
+                cached=None,
+                client_id_override="cid",
+                timeout=5,
+            )
+
+    def test_callback_error_without_state_rejected_as_csrf(self, monkeypatch):
+        """#1(round35): an error callback that does NOT carry the matching state
+        is an unauthenticated abort attempt (a local process / port-guessing page
+        hitting /callback?error=... during the auth window), not a real AS error.
+        State is validated first, so it is rejected as a CSRF mismatch — it
+        cannot grief the flow with an attacker-chosen error."""
+        from urllib.parse import parse_qs, urlparse
+        from urllib.request import urlopen
+
+        def fake_open(auth_url: str) -> bool:
+            redirect_uri = parse_qs(urlparse(auth_url).query)["redirect_uri"][0]
+
+            def hit() -> None:
+                try:
+                    # No state -> unauthenticated abort.
+                    urlopen(f"{redirect_uri}?error=access_denied", timeout=5).read()
+                except Exception:
+                    pass
+
+            threading.Thread(target=hit, daemon=True).start()
+            return True
+
+        monkeypatch.setattr("mcp_stdio.oauth.webbrowser.open", fake_open)
+        client = httpx.Client()
+        with pytest.raises(RuntimeError, match="state mismatch"):
             _run_authorization_flow(
                 "https://ex.com/mcp",
                 client,


### PR DESCRIPTION
Round-35 review fix for `oauth.py` (file-grouped PR 1/3). The round's security-relevant LOW.

## Change
- **[low] error path bypassed CSRF state binding** (#1) — `_run_authorization_flow` raised on a callback `error` parameter **before** validating `state`, and the handler recorded `result.error` from any `/callback?error=...` hit without binding it to state. So an unauthenticated local process (or a port-guessing page reaching the loopback callback during the auth window) could pre-empt the single-shot capture and **abort the flow** with an attacker-chosen error — a retriable DoS / flow-griefing (no token is issued; the success path is already state- and iss-validated). Now: capture `state` on the error branch and move the constant-time state comparison **above** the error short-circuit, so an error callback without the matching state is rejected as a CSRF mismatch. A compliant AS echoes `state` on error responses (RFC 6749 §4.1.2.1), so a legitimate error still surfaces.

## Tests
- `test_callback_error_with_matching_state_raises_oauth_error` — legitimate error surfaces.
- `test_callback_error_without_state_rejected_as_csrf` — unauthenticated abort rejected.

Full oauth suite: 284 passed. Raw separator scan clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)