### PR TITLE
fix(cli): exit cleanly on Ctrl-C during the pre-relay OAuth flow

### DIFF
--- a/src/mcp_stdio/cli.py
+++ b/src/mcp_stdio/cli.py
@@ -204,8 +204,8 @@ def _build_scope_upgrader(
     return upgrader
 
 
-def main() -> None:
-    """Entry point for mcp-stdio CLI."""
+def _main() -> None:
+    """CLI body. Wrapped by ``main`` for top-level interrupt handling."""
     parser = argparse.ArgumentParser(
         prog="mcp-stdio",
         description="Stdio-to-HTTP gateway for MCP servers. "
@@ -656,3 +656,20 @@ def main() -> None:
             token_refresher=token_refresher,
             scope_upgrader=scope_upgrader,
         )
+
+
+def main() -> None:
+    """Entry point for mcp-stdio CLI.
+
+    #2 (round35): run() / run_sse() install their own SIGINT/SIGTERM handlers,
+    but the pre-relay work — argument parsing and especially the blocking
+    interactive OAuth flow (browser callback / device-code wait, up to
+    --oauth-timeout) — runs before that. A Ctrl-C there would otherwise dump a
+    raw KeyboardInterrupt traceback (BaseException, so the OAuth block's
+    `except Exception` does not catch it). Exit cleanly with 130 instead.
+    """
+    try:
+        _main()
+    except KeyboardInterrupt:
+        print("\nmcp-stdio: interrupted", file=sys.stderr)
+        sys.exit(130)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1108,6 +1108,24 @@ class TestOAuthFailureExit:
             assert exc_info.value.code == 1
         assert "OAuth authentication failed" in capsys.readouterr().err
 
+    def test_keyboard_interrupt_during_oauth_exits_130(self, capsys):
+        """#2(round35): Ctrl-C during the pre-relay OAuth flow (before run()
+        installs signal handlers) exits cleanly with 130, not a raw
+        KeyboardInterrupt traceback. KeyboardInterrupt is a BaseException, so the
+        OAuth block's `except Exception` does not catch it — main()'s top-level
+        handler must."""
+        with (
+            patch("sys.argv", ["mcp-stdio", "--oauth", "https://example.com/mcp"]),
+            patch(
+                "mcp_stdio.oauth.ensure_token",
+                side_effect=KeyboardInterrupt(),
+            ),
+        ):
+            with pytest.raises(SystemExit) as exc_info:
+                main()
+            assert exc_info.value.code == 130
+        assert "interrupted" in capsys.readouterr().err
+
 
 class TestOAuthClientHardening:
     def test_oauth_client_disables_redirects(self, monkeypatch):


### PR DESCRIPTION
Round-35 review fix for `cli.py` (file-grouped PR 2/3).

## Change
- **[low] no top-level interrupt handler** (#2) — `run()` / `run_sse()` install SIGINT/SIGTERM handlers, but the pre-relay work (argument parsing and the **blocking interactive OAuth flow** — browser callback / device-code wait, up to `--oauth-timeout`) runs before that. A Ctrl-C there dumped a raw `KeyboardInterrupt` traceback (a `BaseException`, so the OAuth block's `except Exception` doesn't catch it) and a nondeterministic exit status. Rename the CLI body to `_main` and wrap it in `main()` with `except KeyboardInterrupt: sys.exit(130)`. The relay steady-state loop is already covered by its own signal handlers.

## Test
- `test_keyboard_interrupt_during_oauth_exits_130`.

Full cli suite: 102 passed. Raw separator scan clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)