### PR TITLE
test(relay): cover cancel x pagination end-to-end through _paginate_and_stream

### DIFF
--- a/tests/test_relay.py
+++ b/tests/test_relay.py
@@ -6298,6 +6298,48 @@ class TestRunCancelFilter:
         )
         assert '"keep":true' in output
 
+    def test_cancel_then_paginated_request_merged_result_is_forwarded(
+        self, httpx_mock
+    ):
+        """#9(round35): closes the cancel x pagination coverage matrix end-to-end.
+        A cancelled id reused by a paginated tools/list is a brand-new call: the
+        request discards the tracked cancel before dispatch, so the MERGED
+        multi-page result is FORWARDED, not dropped. (The drop case is not
+        reproducible here — pagination is synchronous, so no late cancel can
+        pre-empt the emit, unlike the async SSE path; the _emit drop seam itself
+        is unit-covered by test_drops_merged_paginated_result.)"""
+        httpx_mock.add_response(status_code=202, text="")  # cancel ACK
+        httpx_mock.add_response(
+            url="https://example.com/mcp",
+            text=json.dumps(
+                {
+                    "jsonrpc": "2.0",
+                    "id": 7,
+                    "result": {"tools": [{"name": "a"}], "nextCursor": "p2"},
+                }
+            ),
+            headers={"content-type": "application/json"},
+        )
+        httpx_mock.add_response(
+            url="https://example.com/mcp",
+            text=json.dumps(
+                {"jsonrpc": "2.0", "id": 7, "result": {"tools": [{"name": "b"}]}}
+            ),
+            headers={"content-type": "application/json"},
+        )
+        output = self._run_with_stdin(
+            httpx_mock,
+            [
+                (
+                    '{"jsonrpc":"2.0","method":"notifications/cancelled",'
+                    '"params":{"requestId":7}}'
+                ),
+                '{"jsonrpc":"2.0","id":7,"method":"tools/list"}',
+            ],
+        )
+        merged = json.loads(output.strip())
+        assert [t["name"] for t in merged["result"]["tools"]] == ["a", "b"]
+
     def test_cancel_is_forwarded_upstream(self, httpx_mock):
         httpx_mock.add_response(status_code=202, text="")
         self._run_with_stdin(


### PR DESCRIPTION
Round-35 review fix for `relay.py` tests (file-grouped PR 3/3). Test-only.

## Change
- **[nit] cancel × pagination coverage** (#9) — the interaction was only covered at the `_emit` unit seam (`test_drops_merged_paginated_result`); the run()-level path wasn't. Investigating it showed the **drop** case is **not reproducible e2e** for pagination: the path is synchronous (no async window like SSE), and a request reusing a cancelled id `discard`s the tracked cancel before dispatch, so the merged multi-page result is always **forwarded**. Added the reproducible, meaningful e2e test for that — a cancel followed by a paginated `tools/list` reusing the id delivers the merged result — closing the coverage matrix symmetric with the streamable/SSE/TTL e2e cancel tests.

Full relay suite: 369 passed, 3 skipped. Raw separator scan clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)