### PR TITLE
fix(relay): keep reading the --check SSE stream past interleaved frames

### DIFF
--- a/src/mcp_stdio/relay.py
+++ b/src/mcp_stdio/relay.py
@@ -177,14 +177,6 @@ def _write_line(line: str) -> None:
         sys.stdout.flush()
 
 
-def _extract_id(line: str) -> Any:
-    """Extract JSON-RPC id from request line."""
-    try:
-        return json.loads(line).get("id")
-    except (json.JSONDecodeError, AttributeError):
-        return None
-
-
 def _extract_id_and_presence(line: str) -> tuple[Any, bool]:
     """Return ``(id_value, has_id)`` from a SINGLE JSON parse of a line.
 
@@ -1578,10 +1570,21 @@ def check_connection(
                 if event_type != "message":
                     continue
                 try:
-                    result_data = json.loads(payload)
-                    break
+                    parsed = json.loads(payload)
                 except json.JSONDecodeError:
                     continue
+                # A compliant server MAY interleave notifications / server-
+                # initiated requests on the POST's SSE stream BEFORE the JSON-RPC
+                # response, so keep reading until a message carries result/error —
+                # matching the keep-reading gate in _post_parsed /
+                # _check_connection_sse. Breaking on the first message would
+                # mis-report a server that sends a notification frame first as
+                # "could not parse initialize result". (#1 round36)
+                if isinstance(parsed, dict) and (
+                    "result" in parsed or "error" in parsed
+                ):
+                    result_data = parsed
+                    break
         else:
             try:
                 result_data = json.loads(resp.text)

--- a/tests/test_relay.py
+++ b/tests/test_relay.py
@@ -25,7 +25,7 @@ from mcp_stdio.relay import (
     _error_response,
     _escape_js_line_separators,
     _extract_cancel_id,
-    _extract_id,
+    _extract_id_and_presence,
     _extract_protocol_version,
     _handle_rate_limit,
     _iter_sse_events,
@@ -182,40 +182,45 @@ class TestEnforceLfStdio:
         assert stdin_stream.checked and stdout_stream.checked
 
 
-# --- _extract_id ---
+# --- _extract_id_and_presence ---
 
 
-class TestExtractId:
+class TestExtractIdAndPresence:
+    """The hot-path helper returns (id_value, has_id) from one parse, crucially
+    distinguishing a PRESENT id:null (a request) from an ABSENT id (a
+    notification) — the distinction req_has_id gating relies on."""
+
     def test_numeric_id(self):
         line = json.dumps({"jsonrpc": "2.0", "method": "init", "id": 1})
-        assert _extract_id(line) == 1
+        assert _extract_id_and_presence(line) == (1, True)
 
     def test_string_id(self):
         line = json.dumps({"jsonrpc": "2.0", "method": "init", "id": "abc"})
-        assert _extract_id(line) == "abc"
+        assert _extract_id_and_presence(line) == ("abc", True)
 
     def test_zero_id(self):
-        # id 0 is a VALID JSON-RPC id but falsy — the helper must return the int
-        # 0, not None, so the falsy-id regression class stays pinned at the leaf.
+        # id 0 is a VALID JSON-RPC id but falsy — the helper must return int 0
+        # with has_id True, not collapse it to a notification.
         line = json.dumps({"jsonrpc": "2.0", "method": "init", "id": 0})
-        assert _extract_id(line) == 0
+        assert _extract_id_and_presence(line) == (0, True)
 
-    def test_null_id(self):
+    def test_null_id_is_present(self):
+        # A present id:null IS a request → (None, True), NOT a notification.
         line = json.dumps({"jsonrpc": "2.0", "method": "init", "id": None})
-        assert _extract_id(line) is None
+        assert _extract_id_and_presence(line) == (None, True)
 
-    def test_missing_id(self):
+    def test_missing_id_is_notification(self):
         line = json.dumps({"jsonrpc": "2.0", "method": "notify"})
-        assert _extract_id(line) is None
+        assert _extract_id_and_presence(line) == (None, False)
 
     def test_invalid_json(self):
-        assert _extract_id("not json") is None
+        assert _extract_id_and_presence("not json") == (None, False)
 
     def test_empty_string(self):
-        assert _extract_id("") is None
+        assert _extract_id_and_presence("") == (None, False)
 
     def test_json_array(self):
-        assert _extract_id("[1, 2, 3]") is None
+        assert _extract_id_and_presence("[1, 2, 3]") == (None, False)
 
 
 # --- _error_response ---
@@ -3861,6 +3866,26 @@ class TestCheckConnection:
         )
         assert check_connection(self.URL, dict(self.HEADERS)) is True
 
+    def test_sse_skips_leading_notification_and_captures_result(
+        self, httpx_mock, capsys
+    ):
+        """#1(round36): a compliant server MAY interleave a notification on the
+        POST's SSE stream BEFORE the initialize result. --check must keep reading
+        until a message carries result/error, not break on the first message —
+        otherwise it mis-reports a valid server as 'could not parse initialize
+        result' and loses the server/protocol/capabilities lines."""
+        body = (
+            'data: {"jsonrpc":"2.0","method":"notifications/progress","params":{}}\n\n'
+            'data: {"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2024-11-05",'
+            '"serverInfo":{"name":"demo","version":"1"}}}\n\n'
+        )
+        httpx_mock.add_response(
+            text=body, headers={"content-type": "text/event-stream"}
+        )
+        assert check_connection(self.URL, dict(self.HEADERS)) is True
+        # The REAL initialize result was captured (not the leading notification).
+        assert "server=demo" in capsys.readouterr().err
+
     def test_non_200_returns_false(self, httpx_mock):
         httpx_mock.add_response(status_code=500, text="oops")
         assert check_connection(self.URL, dict(self.HEADERS)) is False
@@ -5964,24 +5989,29 @@ class TestCancelTracker:
         assert not t.contains(None)
 
     def test_gc_bounds_memory(self):
+        """#5(round36): pin the production GC bound AND prove GC actually prunes
+        the internal map. The old version hardcoded 200/256/300 and asserted only
+        via contains() (which lazy-expires), so it passed even if the threshold
+        were widened. Derive counts from _CANCEL_GC_THRESHOLD and assert the
+        internal _seen map shrank, so a silent widening is caught."""
+        from mcp_stdio.relay import _CANCEL_GC_THRESHOLD
+
+        assert _CANCEL_GC_THRESHOLD == 256  # pin the documented bound
         clock = _FakeClock()
         t = _CancelTracker(ttl=10.0, now=clock)
-        # Insert 200 ids at t=0, all will have expired by t=20
-        for i in range(200):
+        # Fill PAST the threshold with ids that all expire by t=20.
+        n_old = _CANCEL_GC_THRESHOLD + 1
+        for i in range(n_old):
             t.add(i)
         clock.advance(20)
-        # Trigger GC by pushing past threshold with fresh entries
-        # (threshold is 256; we add 100 more at t=20 → _seen briefly holds
-        # 300 before _gc_locked prunes the 200 expired ones.)
-        for i in range(200, 300):
-            t.add(i)
-        # Access internals to verify GC ran (all old ids should be gone)
-        # We can only check indirectly via contains(): old ids must not
-        # be tracked any more.
-        for i in range(200):
+        # One more add crosses the threshold again, now with expired entries →
+        # _gc_locked sweeps them. _seen must shrink to just the fresh id, proving
+        # GC ran (not merely contains()'s lazy per-key expiry).
+        t.add(n_old)
+        assert len(t._seen) == 1, "GC did not prune the internal map"
+        assert t.contains(n_old)
+        for i in range(n_old):
             assert not t.contains(i), f"old id {i} still tracked after GC"
-        for i in range(200, 300):
-            assert t.contains(i), f"fresh id {i} lost to GC"
 
     def test_thread_safety(self):
         t = _CancelTracker()
@@ -6058,6 +6088,19 @@ class TestExtractCancelId:
             '"params":{"requestId":"req-42"}}'
         )
         assert _extract_cancel_id(line) == "req-42"
+
+    def test_ignores_batched_cancel(self):
+        """#6(round36): a notifications/cancelled buried in a JSON-RPC BATCH array
+        is intentionally NOT extracted (the regex pre-check matches the substring,
+        but the isinstance(msg, dict) gate fails on a list → None). Pins the
+        documented batch exclusion so a future refactor that iterates batch
+        elements before the dict check cannot start tracking batched cancel ids
+        and collateral-drop batch responses. Symmetric with test_forwards_json_batch."""
+        line = (
+            '[{"jsonrpc":"2.0","method":"notifications/cancelled",'
+            '"params":{"requestId":7}}]'
+        )
+        assert _extract_cancel_id(line) is None
 
     def test_ignores_other_notifications(self):
         line = '{"jsonrpc":"2.0","method":"notifications/initialized","params":{}}'


### PR DESCRIPTION
Round-36 review fixes for `relay.py` (file-grouped PR 1/3). Includes the round's main LOW + dead-code removal + test pins.

## Changes
- **[low] --check broke on the first SSE message** (#1) — `check_connection`'s Streamable-HTTP SSE branch broke on the first decodable `message` event, but the MCP spec lets a server interleave notifications before the response. The relay hot path already keeps reading until result/error; this diagnostic path didn't, so a compliant server sending a notification frame first was mis-reported as "could not parse initialize result". Apply the same keep-reading gate. (capture-init in `_post_and_stream` is already correct — it emits every frame and captures the version from whichever message carries it.)
- **[nit] dead `_extract_id`** (#4) — removed (no production caller; the hot path uses `_extract_id_and_presence`, which distinguishes a present `id:null` from an absent one). Replaced `TestExtractId` with `TestExtractIdAndPresence`, directly unit-testing the helper actually used (previously only covered via run()).

## Tests
- `test_sse_skips_leading_notification_and_captures_result` (#1).
- `test_gc_bounds_memory` now derives counts from `_CANCEL_GC_THRESHOLD`, pins it (256), and asserts the internal `_seen` map actually shrank — the old version passed even if the bound were widened (#5).
- `test_ignores_batched_cancel` pins the documented batch-cancel exclusion (#6).

## Accepted (documented non-bug)
- **stdin framing via text-mode newline** (#9) — correct for NDJSON; the only edge (an illegal embedded raw newline in a JSON string) comes from a hostile client only and is not dropped at the relay.

Full relay suite: 371 passed, 3 skipped. Raw separator scan clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)