### PR TITLE
fix(oauth): fast-fail the device-flow poll on a non-compliant status

### DIFF
--- a/src/mcp_stdio/oauth.py
+++ b/src/mcp_stdio/oauth.py
@@ -1316,6 +1316,10 @@ def _run_authorization_flow(
     cb_result = CallbackResult()
     handler_cls = _make_callback_handler(cb_result)
 
+    # Bind 127.0.0.1 (NOT "" / "0.0.0.0"): the callback carries the auth code and
+    # state, so only the LOCAL browser may reach /callback. This loopback-only
+    # bind is the premise the single-shot + state-binding CSRF model rests on —
+    # do not widen it. The ephemeral port (0) further narrows the attack window.
     callback_server = HTTPServer(("127.0.0.1", 0), handler_cls)
     # #4 (round18): bound handle_request()'s block so the serve() daemon below
     # re-checks ``done`` between requests instead of parking forever in
@@ -1721,9 +1725,15 @@ def _run_device_authorization_flow(
         try:
             err = tok_resp.json().get("error", "")
         except Exception:
+            # Non-JSON body. raise_for_status fails a 4xx/5xx; a non-compliant
+            # 2xx-non-200 / 3xx (which raise_for_status would NOT catch, being
+            # <400) would otherwise spin to the device-code deadline — fast-fail
+            # it by name instead of wasting the code's whole lifetime (#2 round36).
             tok_resp.raise_for_status()
-            _poll_sleep()
-            continue
+            raise RuntimeError(
+                f"Device flow failed: unexpected non-JSON HTTP "
+                f"{tok_resp.status_code} from the token endpoint"
+            )
 
         if err == "authorization_pending":
             pass
@@ -1733,7 +1743,29 @@ def _run_device_authorization_flow(
         elif err in ("expired_token", "access_denied"):
             raise RuntimeError(f"Device flow failed: {err}")
         else:
-            tok_resp.raise_for_status()
+            # An unknown error code, or a non-200 status with no recognized
+            # error. FAST-FAIL with an actionable message — never spin to the
+            # device-code deadline on a status retrying cannot resolve (RFC 8628
+            # §3.5 mandates 200 or 400+error; a non-compliant 2xx-non-200 / 3xx
+            # would otherwise no-op raise_for_status and loop) (#2 round36).
+            # Surface the AS error_description when present, mirroring the
+            # _parse_token_response extraction the auth-code / refresh paths use.
+            desc = ""
+            try:
+                body = tok_resp.json()
+                if isinstance(body, dict):
+                    desc = body.get("error_description") or body.get("error") or ""
+            except Exception:
+                pass
+            if desc:
+                raise RuntimeError(
+                    f"Device flow failed: {_sanitize_oauth_error(desc)}"
+                )
+            tok_resp.raise_for_status()  # 4xx/5xx with no body → honest HTTP error
+            raise RuntimeError(
+                f"Device flow failed: unexpected HTTP {tok_resp.status_code} "
+                f"from the token endpoint"
+            )
 
         _poll_sleep()
 

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -4744,36 +4744,49 @@ class TestDeviceAuthorizationFlow:
                 MCP_URL, client, metadata=_device_meta(), cached=None
             )
 
-    def test_poll_2xx_non_json_body_sleeps_and_continues(
+    def test_poll_2xx_non_json_body_fast_fails(
         self, httpx_mock, tmp_path, monkeypatch
     ):
-        """#F-4(round28): a non-200 2xx poll response (e.g. 202) with a non-JSON
-        body does not raise — raise_for_status only fires on 4xx/5xx, and .json()
-        raises but is caught — so the loop sleeps-and-continues rather than
-        crashing. A subsequent 200 then succeeds. Complements the 400 non-JSON
-        test (which exercises the raise side)."""
+        """#2(round36): a non-200 2xx poll response (e.g. 202) with a non-JSON
+        body is non-compliant (RFC 8628 §3.5 mandates 200 or 400+error) and
+        retrying it never resolves — so the loop FAST-FAILS by name instead of
+        spinning to the device-code deadline (the prior round28 behavior was to
+        sleep-and-continue, which wasted the whole code lifetime)."""
         self._patch_store(tmp_path, monkeypatch)
         monkeypatch.setattr(time, "sleep", lambda _s: None)
         httpx_mock.add_response(url=REG_URL, json={"client_id": "cid"})
         httpx_mock.add_response(url=DEVICE_AUTH_URL, json=_da_response())
-        # Poll #1: 202 (2xx but not 200) with a non-JSON body. json() raises,
-        # raise_for_status() does not (2xx) → sleep-and-continue.
+        # Poll: 202 (2xx but not 200) with a non-JSON body → fast-fail, not retry.
         httpx_mock.add_response(
             url=TOKEN_URL,
             status_code=202,
             headers={"content-type": "text/html"},
             text="<html>processing</html>",
         )
-        # Poll #2: 200 success.
-        httpx_mock.add_response(
-            url=TOKEN_URL, json={"access_token": "acc", "token_type": "Bearer"}
-        )
 
         client = httpx.Client()
-        data = _run_device_authorization_flow(
-            MCP_URL, client, metadata=_device_meta(), cached=None
-        )
-        assert data.access_token == "acc"
+        with pytest.raises(RuntimeError, match="unexpected non-JSON HTTP 202"):
+            _run_device_authorization_flow(
+                MCP_URL, client, metadata=_device_meta(), cached=None
+            )
+
+    def test_poll_2xx_valid_json_no_error_fast_fails(
+        self, httpx_mock, tmp_path, monkeypatch
+    ):
+        """#2(round36): a non-200 2xx with VALID JSON but no `error` key is the
+        other spin path raise_for_status would no-op — it must also fast-fail by
+        status, not loop to the deadline."""
+        self._patch_store(tmp_path, monkeypatch)
+        monkeypatch.setattr(time, "sleep", lambda _s: None)
+        httpx_mock.add_response(url=REG_URL, json={"client_id": "cid"})
+        httpx_mock.add_response(url=DEVICE_AUTH_URL, json=_da_response())
+        httpx_mock.add_response(url=TOKEN_URL, status_code=202, json={})
+
+        client = httpx.Client()
+        with pytest.raises(RuntimeError, match="unexpected HTTP 202"):
+            _run_device_authorization_flow(
+                MCP_URL, client, metadata=_device_meta(), cached=None
+            )
 
     def test_explicit_client_id_skips_dcr(self, httpx_mock, tmp_path, monkeypatch):
         """#7(round14): with an explicit --client-id (client_id_override) the
@@ -5275,20 +5288,27 @@ class TestDeviceAuthorizationFlow:
         )
         assert data.access_token == "acc"
 
-    def test_poll_unknown_error_surfaces_http_error(
+    def test_poll_unknown_error_surfaces_actionable_runtime_error(
         self, httpx_mock, tmp_path, monkeypatch
     ):
-        """A non-spec error code (e.g. invalid_client) falls through to
-        raise_for_status and surfaces as HTTPStatusError."""
+        """#2(round36): a non-spec error code (e.g. invalid_client) now fast-fails
+        with an actionable RuntimeError that names the AS error, instead of an
+        opaque HTTPStatusError that drops the body — mirroring the
+        error_description extraction the auth-code / refresh paths use."""
         self._patch_store(tmp_path, monkeypatch)
         httpx_mock.add_response(url=REG_URL, json={"client_id": "cid"})
         httpx_mock.add_response(url=DEVICE_AUTH_URL, json=_da_response())
         httpx_mock.add_response(
-            url=TOKEN_URL, json={"error": "invalid_client"}, status_code=400
+            url=TOKEN_URL,
+            json={
+                "error": "invalid_client",
+                "error_description": "client authentication failed",
+            },
+            status_code=400,
         )
         monkeypatch.setattr(time, "sleep", lambda _s: None)
         client = httpx.Client()
-        with pytest.raises(httpx.HTTPStatusError):
+        with pytest.raises(RuntimeError, match="client authentication failed"):
             _run_device_authorization_flow(
                 MCP_URL, client, metadata=_device_meta(), cached=None
             )


### PR DESCRIPTION
Round-36 review fixes for `oauth.py` (file-grouped PR 2/3).

## Changes
- **[low] device-flow poll could spin to the deadline** (#2) — the poll loop only special-cased 200; for any other status it read `error` and on an unknown/empty error called `raise_for_status()`, a **no-op for status < 400**. So a non-compliant 2xx-non-200 / 3xx (RFC 8628 §3.5 mandates 200 or 400+error) made the loop sleep-and-continue and spin to the device-code deadline before a generic `TimeoutError` — wasting the whole code lifetime. It also dropped any `error_description` on a 4xx. Now: fast-fail a non-compliant status by name, and surface the AS `error_description` (sanitized) when present so an unknown 4xx is actionable. Supersedes the round-28 sleep-and-continue behavior.
- **[nit] loopback-bind comment** (#7) — document the `("127.0.0.1", …)` callback bind (not `""`/`"0.0.0.0"`); the single-shot + state-binding CSRF model rests on only the local browser reaching `/callback`.

## Tests
- 202 non-JSON / 202 valid-JSON-no-error fast-fail by status; an unknown 4xx error surfaces its `error_description` as an actionable RuntimeError (replacing the prior sleep-and-continue / opaque HTTPStatusError assertions).

Full oauth suite: 285 passed, no teardown errors. Raw separator scan clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)