### PR TITLE
fix(relay): validate server protocolVersion before injecting it as a header

### DIFF
--- a/src/mcp_stdio/relay.py
+++ b/src/mcp_stdio/relay.py
@@ -277,7 +277,19 @@ def _extract_protocol_version(payload: str) -> str | None:
     if not isinstance(result, dict):
         return None
     pv = result.get("protocolVersion")
-    return pv if isinstance(pv, str) else None
+    # Validate before this value can be injected as the MCP-Protocol-Version
+    # request header on every subsequent request (#M1 round37). Unlike
+    # Mcp-Session-Id (an HTTP RESPONSE header h11 already vets for CR/LF), this
+    # comes from the JSON BODY and bypasses all header validation — a malicious /
+    # buggy server returning "2025-06-18\r\nEvil: 1" (or a NUL) would otherwise
+    # poison the header, and httpx's send-time LocalProtocolError would brick the
+    # session permanently, breaking the #11 never-crash invariant. Restrict to a
+    # non-empty visible-ASCII token (0x21-0x7E: no control / CR / LF / NUL /
+    # space), which every real date-form protocolVersion satisfies; anything else
+    # degrades to None so the header is simply omitted (server assumes default).
+    if isinstance(pv, str) and pv and all(0x21 <= ord(c) <= 0x7E for c in pv):
+        return pv
+    return None
 
 
 # Cancel-aware response filter (MCP cancellation spec SHOULDs).
@@ -1200,6 +1212,11 @@ def _paginate_and_stream(
             f"truncating results"
         )
 
+    # Defensive only / unreachable in practice (#N6 round37): the loop always
+    # runs page 1, and every path that reaches here either early-returned or
+    # merged page 1's dict into merged_result first, so it is never None. Kept as
+    # a belt-and-suspenders guard; intentionally not covered by a test (the state
+    # cannot be constructed).
     if merged_result is None:
         merged_result = {result_key: []}
 

--- a/tests/test_relay.py
+++ b/tests/test_relay.py
@@ -729,6 +729,31 @@ class TestExtractProtocolVersion:
     def test_non_string_protocol_version_returns_none(self):
         assert _extract_protocol_version('{"result":{"protocolVersion":123}}') is None
 
+    @pytest.mark.parametrize(
+        "pv",
+        [
+            "2025-06-18\r\nEvil: 1",  # CRLF header injection
+            "2025-06-18\nEvil: 1",  # bare LF
+            "2025-06-18\rEvil",  # bare CR
+            "2025-06-18\x00",  # NUL
+            "2025 06 18",  # space (not a visible-ASCII token)
+            "ver\x7fsion",  # DEL control char
+            "",  # empty
+        ],
+    )
+    def test_malformed_protocol_version_rejected(self, pv):
+        """#M1(round37): protocolVersion comes from the JSON body and is injected
+        as the MCP-Protocol-Version request header, so a value carrying CR/LF/NUL
+        (or any non-visible-ASCII) must be rejected to None — otherwise it poisons
+        the header and httpx's send-time LocalProtocolError bricks the session."""
+        payload = json.dumps({"result": {"protocolVersion": pv}})
+        assert _extract_protocol_version(payload) is None
+
+    def test_valid_date_form_protocol_version_accepted(self):
+        # The canonical date-form version is visible ASCII → accepted.
+        payload = '{"result":{"protocolVersion":"2024-11-05"}}'
+        assert _extract_protocol_version(payload) == "2024-11-05"
+
 
 class TestIterSseEvents:
     """WHATWG Server-Sent Events line decoder shared by all SSE-decode sites."""
@@ -4962,6 +4987,24 @@ class TestRunSse:
             RuntimeError("boom"),
         )
         assert out.strip() == ""
+
+    def test_recovery_write_brokenpipe_does_not_crash(self, httpx_mock):
+        """#L4(round37): when the client closed stdout, the recovery write in
+        run_sse's outer handler raises BrokenPipeError too. It must be swallowed
+        (mirroring run()'s guard) so the SSE loop exits cleanly instead of
+        crashing the gateway — the SSE analogue of the run() BrokenPipe test."""
+        with patch(
+            "mcp_stdio.relay._write_line",
+            side_effect=BrokenPipeError(32, "Broken pipe"),
+        ):
+            # The POST raises a non-httpx exception → the outer handler's recovery
+            # write also raises BrokenPipeError → must be swallowed, not propagate.
+            self._sse_post_raises(
+                httpx_mock,
+                '{"jsonrpc":"2.0","method":"tools/call","id":99}',
+                RuntimeError("boom"),
+            )
+        # Reaching here = run_sse returned without propagating the BrokenPipeError.
 
     def test_cross_origin_endpoint_refused_end_to_end(self, httpx_mock):
         """#7(round21): an SSE endpoint event pointing cross-origin while an


### PR DESCRIPTION
Round-37 review fixes for `relay.py` (file-grouped PR 1/4). Includes a **MEDIUM** DoS fix.

## Changes
- **[medium] unvalidated protocolVersion bricks the session** (M1) — `_extract_protocol_version` returned `result.protocolVersion` (a JSON **body** value) with only an `isinstance(str)` check; it is then injected as the `MCP-Protocol-Version` request header on every subsequent request. Unlike `Mcp-Session-Id` (an HTTP *response* header h11 vets for CR/LF), this bypasses all header validation — a server returning `"2025-06-18\r\nEvil: 1"` (or a NUL) poisons the header, and httpx's send-time `LocalProtocolError` is caught + retried with the same value and surfaced as an error **without clearing** `protocol_version`, **permanently bricking** the session (breaking the `#11` never-crash invariant). A single malformed `InitializeResult` was a permanent DoS. Restrict the captured value to a non-empty visible-ASCII token (`0x21-0x7E`); anything else degrades to None so the header is omitted.

## Tests
- malformed protocolVersion (CR/LF/NUL/space/DEL/empty) rejected; valid date-form accepted.
- `test_recovery_write_brokenpipe_does_not_crash` for **run_sse()** (#L4) — the SSE analogue of run()'s BrokenPipe guard, previously untested.
- comment the unreachable `merged_result is None` pagination fallback as defensive dead code (#N6).

## Accepted (documented, recurring)
- duplicate `_parse_www_authenticate_scope` walk (N2), `is not None` vs truthiness (N3), legacy-SSE async-reply de-dup (N4), rate-limit `time.sleep` on stdin thread (N5) — all cosmetic or documented minimalism tradeoffs, behavior-identical / bounded.

Full relay suite: 380 passed, 3 skipped. Raw separator scan clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)