### PR TITLE
fix(oauth): return None on access_token-less refresh; strip resource userinfo

### DIFF
--- a/src/mcp_stdio/oauth.py
+++ b/src/mcp_stdio/oauth.py
@@ -131,6 +131,35 @@ def _authorization_base_url(server_url: str) -> str:
     return f"{parsed.scheme}://{netloc}"
 
 
+def _resource_indicator(server_url: str) -> str:
+    """Return the RFC 8707 ``resource`` value for ``server_url``.
+
+    Strips embedded userinfo (``user:pass@``) — RFC 8707 §2 defines the resource
+    as a target-service URI and the credentials are not part of that identity;
+    leaving them in would send them verbatim in the token/authorize form body,
+    the authorize URL (and the browser address bar), and the AS's request logs.
+    Mirrors the userinfo-strip discipline of ``_authorization_base_url`` /
+    ``_build_well_known_url``. Keeps the path and query (they distinguish
+    resources) but drops any fragment (RFC 8707 §2 MUST NOT). Returns the input
+    unchanged if it does not parse as an http(s) URL with a host (#L1 round37).
+    """
+    try:
+        parsed = urlparse(server_url)
+        host = parsed.hostname
+        port = parsed.port
+    except ValueError:
+        return server_url
+    if not parsed.scheme or not host:
+        return server_url
+    if ":" in host:  # re-bracket an IPv6 literal host (urlparse strips brackets)
+        host = f"[{host}]"
+    netloc = f"{host}:{port}" if port is not None else host
+    resource = f"{parsed.scheme}://{netloc}{parsed.path}"
+    if parsed.query:
+        resource += f"?{parsed.query}"
+    return resource
+
+
 # Default ports used when normalising a parsed URL into a RFC 6454 origin
 # tuple for comparison. Any scheme outside this table falls through as None,
 # which is fine — we only reach the cross-origin check after scheme has
@@ -1255,7 +1284,7 @@ def refresh_cached_token(
             cached.client_secret,
             cached.refresh_token,
             client,
-            resource=None if no_resource_indicator else server_url,
+            resource=None if no_resource_indicator else _resource_indicator(server_url),
             auth_method=auth_method,
         )
     except Exception as e:
@@ -1279,17 +1308,29 @@ def refresh_cached_token(
         # keeps the cached flag intact for the next step-up.
         iss_parameter_supported=cached.iss_parameter_supported,
     )
-    data = _token_response_to_data(
-        raw,
-        metadata,
-        cached.client_id,
-        cached.client_secret,
-        previous_refresh_token=cached.refresh_token,
-        previous_scope=cached.scope,
-        client_secret_expires_at=cached.client_secret_expires_at,
-        auth_method=auth_method,
-        no_resource_indicator=no_resource_indicator,
-    )
+    try:
+        data = _token_response_to_data(
+            raw,
+            metadata,
+            cached.client_id,
+            cached.client_secret,
+            previous_refresh_token=cached.refresh_token,
+            previous_scope=cached.scope,
+            client_secret_expires_at=cached.client_secret_expires_at,
+            auth_method=auth_method,
+            no_resource_indicator=no_resource_indicator,
+        )
+    except Exception as e:
+        # #M2 (round37): a non-compliant 200 token response MISSING access_token
+        # (e.g. {"token_type":"Bearer"} with no `error`) slips past
+        # _parse_token_response and makes _token_response_to_data raise. This
+        # call was outside the try above, so the RuntimeError propagated out of
+        # refresh_cached_token — violating its "returns None on failure" contract
+        # and, worse, aborting ensure_token's recovery (it expects None to clear
+        # the stale token and re-auth, but the RuntimeError reached cli.py and
+        # exited 1). Degrade to None like every other refresh failure.
+        log(f"token refresh failed: {_sanitize_oauth_error(e)}")
+        return None
     save_token(server_url, data)
     log("token refreshed successfully")
     return data
@@ -1377,7 +1418,7 @@ def _run_authorization_flow(
             "code_challenge_method": "S256",
         }
         if resource_indicator:
-            params["resource"] = server_url
+            params["resource"] = _resource_indicator(server_url)
         if scope:
             params["scope"] = scope
 
@@ -1446,6 +1487,13 @@ def _run_authorization_flow(
     # false-mismatch and block a legitimate flow. A genuine mix-up always differs
     # by HOST, which rstrip does not mask, so the defence is preserved.
     #
+    # Honest deviation note (#N1 round37): RFC 9207 §2.4 specifies a SIMPLE
+    # STRING comparison (RFC 3986 §6.2.1), i.e. byte-exact. The rstrip("/")
+    # tolerance is a deliberate, security-preserving relaxation of that letter
+    # (same spirit as the RFC 9728 §3.3 / RFC 8414 §3.3 warn-and-continue
+    # relaxations) — it only collapses a trailing slash, never a host/scheme/port
+    # difference, so no mix-up the strict comparison would catch slips through.
+    #
     # §2.4 has a SECOND MUST: a client MUST reject a response that OMITS `iss`
     # from an AS that advertises iss support (the RFC 9207 §3 metadata flag) —
     # otherwise a mix-up attacker could simply strip `iss` to silence the compare
@@ -1480,7 +1528,7 @@ def _run_authorization_flow(
         code_verifier,
         redirect_uri,
         client,
-        resource=server_url if resource_indicator else None,
+        resource=_resource_indicator(server_url) if resource_indicator else None,
         auth_method=auth_method,
     )
     data = _token_response_to_data(
@@ -1555,7 +1603,7 @@ def _run_device_authorization_flow(
     # Step 1: Device Authorization Request (RFC 8628 §3.1)
     da_params: dict[str, str] = {}
     if resource_indicator:
-        da_params["resource"] = server_url
+        da_params["resource"] = _resource_indicator(server_url)
     if scope:
         da_params["scope"] = scope
     da_headers: dict[str, str] = {

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -43,6 +43,33 @@ from mcp_stdio.token_store import TokenData
 # --- _authorization_base_url ---
 
 
+class TestResourceIndicator:
+    """#L1(round37): the RFC 8707 resource value strips userinfo (it is not part
+    of the resource identity and would otherwise reach the AS / its logs / the
+    browser address bar) while keeping path+query and dropping any fragment."""
+
+    @pytest.mark.parametrize(
+        "url,expected",
+        [
+            # userinfo stripped
+            ("https://user:pass@api.example.com/mcp", "https://api.example.com/mcp"),
+            ("https://user@api.example.com/mcp", "https://api.example.com/mcp"),
+            # idempotent when there is no userinfo
+            ("https://api.example.com/mcp", "https://api.example.com/mcp"),
+            # port + query kept; userinfo stripped
+            ("https://u:p@host:8443/mcp?a=1", "https://host:8443/mcp?a=1"),
+            # fragment dropped (RFC 8707 §2 MUST NOT)
+            ("https://api.example.com/mcp#frag", "https://api.example.com/mcp"),
+            # unparseable / non-http stays unchanged
+            ("not-a-url", "not-a-url"),
+        ],
+    )
+    def test_strips_userinfo(self, url, expected):
+        from mcp_stdio.oauth import _resource_indicator
+
+        assert _resource_indicator(url) == expected
+
+
 class TestAuthorizationBaseUrl:
     def test_strips_path(self):
         assert (
@@ -1463,6 +1490,38 @@ class TestRefreshCachedToken:
         req = httpx_mock.get_requests()[0]
         assert b"resource=https%3A%2F%2Fapi.example.com%2Fmcp" in req.content
 
+    def test_refresh_200_missing_access_token_returns_none(
+        self, tmp_path, monkeypatch, httpx_mock
+    ):
+        """#M2(round37): a non-compliant 200 token response with NO access_token
+        (and no `error`) makes _token_response_to_data raise. refresh_cached_token
+        must degrade to None per its contract — not propagate a RuntimeError that
+        aborts ensure_token's clear-and-re-auth recovery (and exits cli.py with
+        1). The _token_response_to_data call was outside the refresh try/except."""
+        store_file = tmp_path / "tokens.json"
+        monkeypatch.setattr("mcp_stdio.token_store._STORE_DIR", tmp_path)
+        monkeypatch.setattr("mcp_stdio.token_store._STORE_FILE", store_file)
+
+        from mcp_stdio.token_store import save_token
+
+        save_token(
+            "https://api.example.com/mcp",
+            TokenData(
+                access_token="old_at",
+                refresh_token="rt123",
+                expires_at=time.time() - 10,
+                client_id="cid",
+                token_endpoint="https://auth.example.com/token",
+                authorization_endpoint="https://auth.example.com/authorize",
+            ),
+        )
+        # 200 but no access_token and no error → _token_response_to_data raises.
+        httpx_mock.add_response(
+            url="https://auth.example.com/token", json={"token_type": "Bearer"}
+        )
+        client = httpx.Client()
+        assert refresh_cached_token("https://api.example.com/mcp", client) is None
+
     def test_refresh_preserves_persisted_issuer(
         self, tmp_path, monkeypatch, httpx_mock
     ):
@@ -1953,6 +2012,22 @@ class TestParseTokenResponse:
         client = httpx.Client()
         resp = client.post("https://example.com/token")
         with pytest.raises(RuntimeError, match="Code expired"):
+            _parse_token_response(resp)
+
+    def test_form_urlencoded_4xx_error_body_raises_clear_error(self, httpx_mock):
+        """#L5(round37): a 4xx with a form-urlencoded RFC 6749 §5.2 error body
+        surfaces the error as a RuntimeError before raise_for_status — the
+        form-urlencoded 4xx branch, sibling of the JSON 4xx and form-urlencoded
+        200-error cases that were already covered."""
+        httpx_mock.add_response(
+            url="https://example.com/token",
+            status_code=400,
+            text="error=invalid_grant&error_description=Refresh+expired",
+            headers={"content-type": "application/x-www-form-urlencoded"},
+        )
+        client = httpx.Client()
+        resp = client.post("https://example.com/token")
+        with pytest.raises(RuntimeError, match="Refresh expired"):
             _parse_token_response(resp)
 
 


### PR DESCRIPTION
Round-37 review fixes for `oauth.py` (file-grouped PR 2/4). Includes a **MEDIUM** contract fix.

## Changes
- **[medium] refresh raises instead of returning None** (M2) — `refresh_cached_token`'s try/except wrapped only `refresh_access_token`; `_token_response_to_data` ran outside it and raises when a non-compliant AS returns a 200 token response **missing `access_token`** (and no `error`, so `_parse_token_response` doesn't catch it). That RuntimeError propagated out — violating the documented "returns None on failure" contract and aborting `ensure_token`'s recovery (which expects None to clear the stale token and re-auth, but the error reached `cli.py` and exited 1). Wrap `_token_response_to_data` → log + return None.
- **[low] RFC 8707 resource leaked userinfo** (L1) — the `resource` indicator passed `server_url` verbatim at all four sites, so a `https://user:pass@host/mcp` URL sent the embedded userinfo to the AS (form/query/authorize URL/logs/address bar). New `_resource_indicator` helper strips userinfo (keeps path+query, drops fragment per RFC 8707 §2).
- **[nit] iss comparison deviation note** (N1) — flag that `rstrip("/")` is a deliberate relaxation of RFC 9207 §2.4's simple-string (RFC 3986 §6.2.1) comparison.

## Tests
- a 200 refresh missing `access_token` returns None (M2); `_resource_indicator` strip/keep/drop cases (L1); a form-urlencoded 4xx error body raises an actionable RuntimeError (L5, the previously-uncovered branch).

Full oauth suite: 293 passed, no teardown errors. Raw separator scan clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)