### PR TITLE
fix(token_store): warn when a corrupt store is replaced on save

### DIFF
--- a/src/mcp_stdio/token_store.py
+++ b/src/mcp_stdio/token_store.py
@@ -60,6 +60,10 @@ _warned_userinfo_key = False
 # cross-process serialization, so the operator gets one warning per process.
 _warned_lock_symlink = False
 
+# Set once if a save encountered a corrupt-JSON store and replaced it, so the
+# operator is told their token store was corrupt (and replaced) just once.
+_warned_corrupt_store = False
+
 
 def _normalize_key(server_url: str) -> str:
     """Normalise a server URL into a stable token-store key.
@@ -421,9 +425,9 @@ def _migrate_legacy_store() -> None:
 class _StoreUnreadable(Exception):
     """The store file exists but could not be READ (permission / symlink /
     I/O error) — distinct from 'absent' (→ {}) and 'corrupt JSON' (which is
-    overwrite-safe). A writer must ABORT on this rather than clobber a store
-    whose real contents it never saw, which would destroy every other
-    server's tokens.
+    overwrite-safe, since corrupt bytes are already unrecoverable). A writer
+    must ABORT on this rather than clobber a store whose real contents it never
+    saw, which would destroy every other server's tokens.
     """
 
 
@@ -437,7 +441,8 @@ def _read_store(*, for_write: bool = False) -> dict[str, Any]:
     transient EACCES, an ELOOP from a swapped-in symlink, or a backup-restore
     race would otherwise let the next save persist ONLY its one key and wipe
     every other server's cached token. A corrupt-JSON store stays overwrite-safe
-    (``{}``), preserving the intentional corrupt-store-replacement behaviour.
+    (``{}``) — its bytes are already unrecoverable — but the WRITE path warns once
+    so the replacement is visible to the operator (#L2 round37).
     """
     _migrate_legacy_store()
     if not _STORE_FILE.exists():
@@ -506,8 +511,25 @@ def _read_store(*, for_write: bool = False) -> dict[str, Any]:
     try:
         data = json.loads(text)
     except json.JSONDecodeError:
-        # Genuinely corrupt JSON is overwrite-safe (the contents are unusable);
-        # both read and write paths treat it as an empty store.
+        # Genuinely corrupt JSON is overwrite-safe: the bytes are UNPARSEABLE, so
+        # every server's token in it is already unrecoverable — replacing it on
+        # the next save loses nothing recoverable and restores a usable store
+        # (aborting would leave it broken AND fail to cache the new token). Both
+        # paths therefore treat it as an empty store. But the silent replacement
+        # previously hid a real event from the operator (a 3rd-party tool / disk
+        # corrupting tokens.json), so the WRITE path warns ONCE that the corrupt
+        # store is being replaced — visibility without changing the recovery
+        # behaviour (#L2 round37).
+        if for_write:
+            global _warned_corrupt_store
+            if not _warned_corrupt_store:
+                _warned_corrupt_store = True
+                print(
+                    f"mcp-stdio: warning: token store {_STORE_FILE} contains "
+                    f"corrupt JSON; replacing it (other servers' cached tokens, "
+                    f"if any, were already unparseable and need re-auth).",
+                    file=sys.stderr,
+                )
         return {}
     return data if isinstance(data, dict) else {}
 

--- a/tests/test_token_store.py
+++ b/tests/test_token_store.py
@@ -413,16 +413,23 @@ class TestLoadSaveDelete:
         loaded = load_token("https://example.com/mcp")
         assert loaded is not None and loaded.iss_parameter_supported is True
 
-    def test_save_over_corrupt_store_succeeds(self, tmp_path, monkeypatch):
-        """A corrupt store file is replaced (not appended to) on the next save."""
+    def test_save_over_corrupt_store_succeeds_with_warning(
+        self, tmp_path, monkeypatch, capsys
+    ):
+        """A corrupt store file is replaced (not appended to) on the next save —
+        its unparseable bytes are already unrecoverable. #L2(round37): the
+        previously-silent replacement now emits a one-time stderr warning so the
+        operator learns their token store was corrupt."""
         store_file = tmp_path / "tokens.json"
         monkeypatch.setattr("mcp_stdio.token_store._STORE_DIR", tmp_path)
         monkeypatch.setattr("mcp_stdio.token_store._STORE_FILE", store_file)
+        monkeypatch.setattr("mcp_stdio.token_store._warned_corrupt_store", False)
 
         store_file.write_text("not json")
         save_token("https://example.com/mcp", TokenData(access_token="fresh"))
         loaded = load_token("https://example.com/mcp")
         assert loaded is not None and loaded.access_token == "fresh"
+        assert "corrupt JSON" in capsys.readouterr().err
 
     def test_save_aborts_when_store_unreadable(self, tmp_path, monkeypatch, capsys):
         """#3: if the store EXISTS but cannot be read (e.g. transient EACCES),


### PR DESCRIPTION
Round-37 review fix for `token_store.py` (file-grouped PR 3/4).

## Change
- **[low] silent corrupt-store replacement** (L2) — a save over a corrupt-JSON store silently replaced it, hiding a real event (a 3rd-party tool / disk corrupting `tokens.json`) from the operator. The overwrite itself is kept deliberate and correct: corrupt JSON is **unparseable**, so any other server's token in it is **already unrecoverable** — replacing it loses nothing recoverable and restores a usable store (aborting would leave it broken **and** fail to cache the new token, and could race a concurrent writer). Add a one-time stderr warning on the write path so the replacement is visible, without changing the recovery behaviour.

> Note: the reviewer suggested abort-on-corrupt for consistency with the read-failure guards, but those failures (EACCES/ELOOP) are transient with recoverable data behind them, whereas corrupt JSON is already lost — so warn-and-recover is the better fit here. The fallback "make it visible" recommendation is what's implemented.

## Test
- `test_save_over_corrupt_store_succeeds_with_warning` — the save still succeeds and now emits the warning.

Full token_store suite: 80 passed. Raw separator scan clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)