### PR TITLE
fix(token_store): treat an empty-dict XDG store as no-data during legacy migration

### DIFF
--- a/src/mcp_stdio/token_store.py
+++ b/src/mcp_stdio/token_store.py
@@ -216,23 +216,25 @@ def _ensure_store_dir() -> None:
                 pass
 
 
-def _read_legacy_data() -> dict[str, Any] | None:
-    """Read the legacy token file via ``O_NOFOLLOW``.
+def _read_json_object_file(path: Path) -> dict[str, Any] | None:
+    """Read a JSON-object file via ``O_NOFOLLOW``, with no side effects.
 
     Returns the parsed dict, or ``None`` if the file is absent, unreadable,
-    not valid JSON, or not a JSON object — so callers never write garbage (or
-    an attacker-redirected symlink target) over the XDG store.
+    not valid JSON, or not a JSON object. Shared by the legacy reader and the
+    migration's XDG-store probe so neither re-enters ``_read_store`` (which would
+    recurse through ``_migrate_legacy_store``). Unlike ``_read_store`` this does
+    NOT chmod the fd or emit the corrupt-store warning — it is a pure probe.
     """
     try:
-        fd = os.open(_LEGACY_STORE_FILE, os.O_RDONLY | _O_NOFOLLOW | _O_NONBLOCK)
+        fd = os.open(path, os.O_RDONLY | _O_NOFOLLOW | _O_NONBLOCK)
     except OSError:
         return None
-    # Refuse a non-regular legacy file the same way _read_store does (#2
-    # round27): O_NOFOLLOW blocks a symlink, but an O_RDONLY read of a
-    # writer-less FIFO planted at the legacy path would block forever and hang
-    # every token load / relay startup. O_NONBLOCK makes the open return at
-    # once (a no-op for the regular file we expect); fstat then rejects the
-    # special file before f.read() can hang on it.
+    # Refuse a non-regular file the same way _read_store does (#2 round27):
+    # O_NOFOLLOW blocks a symlink, but an O_RDONLY read of a writer-less FIFO
+    # planted at the path would block forever and hang every token load / relay
+    # startup. O_NONBLOCK makes the open return at once (a no-op for the regular
+    # file we expect); fstat then rejects the special file before f.read() can
+    # hang on it.
     try:
         if not stat.S_ISREG(os.fstat(fd).st_mode):
             os.close(fd)
@@ -246,6 +248,16 @@ def _read_legacy_data() -> dict[str, Any] | None:
     except (json.JSONDecodeError, OSError):
         return None
     return data if isinstance(data, dict) else None
+
+
+def _read_legacy_data() -> dict[str, Any] | None:
+    """Read the legacy token file via ``O_NOFOLLOW``.
+
+    Returns the parsed dict, or ``None`` if the file is absent, unreadable,
+    not valid JSON, or not a JSON object — so callers never write garbage (or
+    an attacker-redirected symlink target) over the XDG store.
+    """
+    return _read_json_object_file(_LEGACY_STORE_FILE)
 
 
 def _migrate_legacy_store() -> None:
@@ -269,10 +281,24 @@ def _migrate_legacy_store() -> None:
         # interrupted external write, a stray `touch`, a backup restore that
         # left an empty placeholder) is NOT proof the migration completed;
         # unlinking the legacy file then would silently lose still-real tokens.
-        try:
-            xdg_has_data = _STORE_FILE.stat().st_size > 0
-        except OSError:
-            xdg_has_data = False
+        #
+        # Probe the CONTENT, not the byte size (#L7 round39): an empty-dict store
+        # (`{}`, 2 bytes — all tokens were deleted) has st_size > 0 yet holds NO
+        # tokens, so the old size test wrongly treated it as "migration complete"
+        # and unlinked still-real legacy tokens. Mirror the empty-placeholder
+        # branch below, which already uses dict truthiness. Use the side-effect-
+        # free probe (NOT _read_store, which re-enters this function). A genuinely
+        # corrupt / unreadable store returns None — there fall back to the byte-
+        # size heuristic, since an unparseable non-empty file is still evidence
+        # the migration likely ran and must not loop re-copying over it.
+        xdg_data = _read_json_object_file(_STORE_FILE)
+        if xdg_data is None:
+            try:
+                xdg_has_data = _STORE_FILE.stat().st_size > 0
+            except OSError:
+                xdg_has_data = False
+        else:
+            xdg_has_data = bool(xdg_data)
         if xdg_has_data:
             # Best-effort removal of the now-redundant legacy file. This runs
             # UNLOCKED from load_token, so the unlink can lose a TOCTOU race
@@ -285,17 +311,19 @@ def _migrate_legacy_store() -> None:
                 pass
         else:
             # #8 (round16): the XDG store is an EMPTY placeholder (a stray
-            # `touch`, an interrupted external write, a backup restore) that
-            # otherwise shadows still-valid legacy tokens forever — _read_store
-            # would read {} and load_token would force a needless re-auth. Copy
+            # `touch`, an interrupted external write, a backup restore) OR an
+            # empty-dict `{}` store with all tokens deleted (#L7 round39) — both
+            # otherwise shadow still-valid legacy tokens forever (_read_store
+            # would read {} and load_token would force a needless re-auth). Copy
             # the legacy data through into the placeholder instead of stranding
-            # it. Re-stat under the same call so a placeholder that CONCURRENTLY
+            # it. Re-PROBE the content under the same call (not just st_size==0,
+            # so the `{}` case is covered too) so a placeholder that CONCURRENTLY
             # gained real data (a locked save_token) is never clobbered; the
             # residual TOCTOU is the documented one-time migration race above.
             data = _read_legacy_data()
             if data:
                 try:
-                    if _STORE_FILE.stat().st_size == 0:
+                    if not _read_json_object_file(_STORE_FILE):
                         _write_store(data)
                         try:
                             _LEGACY_STORE_FILE.unlink()
@@ -517,19 +545,25 @@ def _read_store(*, for_write: bool = False) -> dict[str, Any]:
         # (aborting would leave it broken AND fail to cache the new token). Both
         # paths therefore treat it as an empty store. But the silent replacement
         # previously hid a real event from the operator (a 3rd-party tool / disk
-        # corrupting tokens.json), so the WRITE path warns ONCE that the corrupt
-        # store is being replaced — visibility without changing the recovery
-        # behaviour (#L2 round37).
-        if for_write:
-            global _warned_corrupt_store
-            if not _warned_corrupt_store:
-                _warned_corrupt_store = True
-                print(
-                    f"mcp-stdio: warning: token store {_STORE_FILE} contains "
-                    f"corrupt JSON; replacing it (other servers' cached tokens, "
-                    f"if any, were already unparseable and need re-auth).",
-                    file=sys.stderr,
-                )
+        # corrupting tokens.json), so warn ONCE that the store is corrupt —
+        # visibility without changing the recovery behaviour (#L2 round37).
+        #
+        # Fire on BOTH paths now (#L8 round39): a read-only invocation
+        # (load_token -> _read_store with for_write=False) otherwise gives the
+        # operator zero signal — just an unexplained re-auth — until some later
+        # save happens to reach the write path. The one-shot _warned_corrupt_store
+        # flag keeps it to a single line per process, and the wording covers both
+        # outcomes (read-as-empty now, replaced on the next save).
+        global _warned_corrupt_store
+        if not _warned_corrupt_store:
+            _warned_corrupt_store = True
+            print(
+                f"mcp-stdio: warning: token store {_STORE_FILE} contains "
+                f"corrupt JSON; treating it as empty (cached tokens, if any, were "
+                f"already unparseable and need re-auth). It is replaced on the "
+                f"next save.",
+                file=sys.stderr,
+            )
         return {}
     return data if isinstance(data, dict) else {}
 

--- a/tests/test_token_store.py
+++ b/tests/test_token_store.py
@@ -210,9 +210,33 @@ class TestLoadSaveDelete:
         store_file = tmp_path / "tokens.json"
         monkeypatch.setattr("mcp_stdio.token_store._STORE_DIR", tmp_path)
         monkeypatch.setattr("mcp_stdio.token_store._STORE_FILE", store_file)
+        # Reset the one-shot flag so this test does not depend on / leak the
+        # cross-process warning state (load now warns on the read path too).
+        monkeypatch.setattr("mcp_stdio.token_store._warned_corrupt_store", False)
 
         store_file.write_text("not json")
         assert load_token("https://example.com/mcp") is None
+
+    def test_corrupt_file_warns_once_on_read_path(
+        self, tmp_path, monkeypatch, capsys
+    ):
+        """#L8(round39): a corrupt store surfaces a one-time stderr warning on the
+        pure READ path too (load_token), not only when a later save reaches the
+        write path — otherwise a read-only invocation gives the operator zero
+        signal beyond an unexplained re-auth. The one-shot flag keeps it to a
+        single line even across repeated loads."""
+        store_file = tmp_path / "tokens.json"
+        monkeypatch.setattr("mcp_stdio.token_store._STORE_DIR", tmp_path)
+        monkeypatch.setattr("mcp_stdio.token_store._STORE_FILE", store_file)
+        monkeypatch.setattr("mcp_stdio.token_store._warned_corrupt_store", False)
+
+        store_file.write_text("not json")
+        assert load_token("https://example.com/mcp") is None
+        assert load_token("https://example.com/other") is None  # second read
+        err = capsys.readouterr().err
+        assert "corrupt JSON" in err
+        # One-shot: the warning line appears exactly once across both reads.
+        assert err.count("corrupt JSON") == 1
 
     @pytest.mark.skipif(
         sys.platform == "win32" or not hasattr(os, "mkfifo"),
@@ -1274,6 +1298,68 @@ class TestLegacyMigration:
         assert "old" in new_file.read_text()
         # The legacy file is unlinked only because its data was safely migrated.
         assert not legacy_file.exists()
+
+    def test_empty_dict_xdg_store_does_not_strand_or_lose_legacy(
+        self, tmp_path, monkeypatch
+    ):
+        """#L7(round39): an XDG store of `{}` (2 bytes — all tokens were deleted)
+        is NOT proof the migration completed. The old `st_size > 0` test treated
+        it as "has data" and unlinked still-real legacy tokens (data loss). The
+        content-based probe routes `{}` into the copy-through branch instead: the
+        legacy tokens are merged in (reachable via load_token) and the redundant
+        legacy file is then removed — never stranded, never lost."""
+        legacy_dir = tmp_path / "legacy"
+        legacy_file = legacy_dir / "tokens.json"
+        new_dir = tmp_path / "new"
+        new_file = new_dir / "tokens.json"
+
+        legacy_dir.mkdir()
+        legacy_file.write_text('{"https://example.com/mcp": {"access_token": "old"}}')
+        new_dir.mkdir()
+        new_file.write_text("{}")  # empty-dict store, size 2 — NOT a completed migration
+
+        monkeypatch.setattr("mcp_stdio.token_store._STORE_DIR", new_dir)
+        monkeypatch.setattr("mcp_stdio.token_store._STORE_FILE", new_file)
+        monkeypatch.setattr("mcp_stdio.token_store._LEGACY_STORE_DIR", legacy_dir)
+        monkeypatch.setattr("mcp_stdio.token_store._LEGACY_STORE_FILE", legacy_file)
+
+        loaded = load_token("https://example.com/mcp")
+        # Legacy token is merged through, not lost behind the `{}` placeholder.
+        assert loaded is not None and loaded.access_token == "old"
+        assert "old" in new_file.read_text()
+        # Legacy file unlinked only because its data was safely migrated.
+        assert not legacy_file.exists()
+
+    def test_empty_dict_xdg_preserves_legacy_when_copy_through_fails(
+        self, tmp_path, monkeypatch
+    ):
+        """#L7(round39): the data-loss guard — if the copy-through write fails for
+        a `{}` XDG store, the legacy file must be PRESERVED (not unlinked), so a
+        later run can retry. The old size-based path would have unlinked it."""
+        legacy_dir = tmp_path / "legacy"
+        legacy_file = legacy_dir / "tokens.json"
+        new_dir = tmp_path / "new"
+        new_file = new_dir / "tokens.json"
+
+        legacy_dir.mkdir()
+        legacy_file.write_text('{"https://example.com/mcp": {"access_token": "old"}}')
+        new_dir.mkdir()
+        new_file.write_text("{}")
+
+        monkeypatch.setattr("mcp_stdio.token_store._STORE_DIR", new_dir)
+        monkeypatch.setattr("mcp_stdio.token_store._STORE_FILE", new_file)
+        monkeypatch.setattr("mcp_stdio.token_store._LEGACY_STORE_DIR", legacy_dir)
+        monkeypatch.setattr("mcp_stdio.token_store._LEGACY_STORE_FILE", legacy_file)
+
+        def failing_write(_data):
+            raise OSError(28, "No space left on device")
+
+        monkeypatch.setattr("mcp_stdio.token_store._write_store", failing_write)
+
+        loaded = load_token("https://example.com/mcp")  # must not raise
+        assert loaded is None  # `{}` still shadows → no token this run
+        assert legacy_file.exists()  # but legacy is preserved for a retry
+        assert "old" in legacy_file.read_text()
 
     def test_empty_xdg_copy_through_write_failure_preserves_legacy(
         self, tmp_path, monkeypatch


### PR DESCRIPTION
## Summary

Round-39 review fixes in `token_store.py`.

### `{}` XDG store data-loss during migration (#L7, low)
`_migrate_legacy_store` decided whether the XDG store "has data" via `_STORE_FILE.stat().st_size > 0`. An empty-dict store (`{}`, 2 bytes — produced when all tokens are deleted) has `size > 0` yet holds **no** tokens, so the legacy file was treated as redundant and **unlinked**, silently losing still-real legacy tokens.

Probe the **content** instead (dict truthiness), mirroring the empty-placeholder branch which already used `if data:`. A `{}` store now routes into the copy-through branch: legacy tokens are merged in and the redundant legacy file removed — never stranded, never lost. A corrupt / unreadable store (probe returns `None`) falls back to the byte-size heuristic so an unparseable non-empty file is not re-copied over in a loop.

Factored the side-effect-free `O_NOFOLLOW` reader out of `_read_legacy_data` into `_read_json_object_file(path)` so the migration can probe the XDG store **without** re-entering `_read_store` (which recurses through migration).

### Corrupt-store read-path visibility (#L8, nit)
`_read_store` warned about a corrupt-JSON store only on the **write** path. A read-only invocation (`load_token`) gave the operator zero signal beyond an unexplained re-auth. Now the same one-shot warning fires on the read path too (guarded by `_warned_corrupt_store`). Recovery behaviour is unchanged (still treated as empty / replaced on next save).

## Tests

- `{}` XDG store merges legacy through and removes the legacy file
- `{}` XDG store preserves legacy when the copy-through write fails (no data loss)
- corrupt-store read-path warning fires exactly once across repeated loads

Full suite: **878 passed, 3 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)