### PR TITLE
fix(oauth): honour AS-assigned token_endpoint_auth_method from DCR response

### DIFF
--- a/src/mcp_stdio/oauth.py
+++ b/src/mcp_stdio/oauth.py
@@ -772,6 +772,24 @@ def _pick_token_endpoint_auth_method(supported: list[str] | None) -> str:
     return "none"
 
 
+def _warn_if_basic_auth_lacks_secret(
+    auth_method: str, client_secret: str | None
+) -> None:
+    """Warn when client_secret_basic is selected but no client_secret is present.
+
+    The callers then fall back to sending only client_id in the request body,
+    which an AS expecting HTTP Basic credentials for a confidential client
+    rejects. Surfacing the inconsistency turns an opaque AS 401 into an
+    actionable message (#L5 round39).
+    """
+    if auth_method == "client_secret_basic" and not client_secret:
+        log(
+            "warning: token_endpoint_auth_method is 'client_secret_basic' but no "
+            "client_secret is available — sending client_id only; the AS will "
+            "likely reject this. Re-registration (RFC 7591) may be needed."
+        )
+
+
 @dataclass
 class ClientRegistration:
     """Result of dynamic client registration."""
@@ -869,6 +887,34 @@ def register_client(
             "Client registration response client_secret is not a string "
             "(RFC 7591 §3.2.1)."
         )
+    # RFC 7591 §3.2.1: "The authorization server MAY reject or replace any of the
+    # client's requested metadata values ... and substitute them with suitable
+    # values", and MUST return all registered metadata about the client. So the
+    # token_endpoint_auth_method the AS records in the registration RESPONSE is
+    # authoritative and may differ from the one we requested (L812). Honour the
+    # AS-assigned value when we implement it, so the subsequent token exchange
+    # frames credentials the way the AS expects (Basic header vs request body)
+    # instead of the way we asked — otherwise the exchange fails with an opaque
+    # AS rejection. (#L4 round39)
+    assigned_method = data.get("token_endpoint_auth_method")
+    if isinstance(assigned_method, str) and assigned_method != auth_method:
+        if assigned_method in _SUPPORTED_AUTH_METHODS:
+            log(
+                f"AS assigned token_endpoint_auth_method {assigned_method!r} "
+                f"(requested {auth_method!r}); using the AS-assigned value per "
+                f"RFC 7591 §3.2.1"
+            )
+            auth_method = assigned_method
+        else:
+            # The AS recorded a method we do not implement (e.g. private_key_jwt).
+            # We cannot frame credentials that way, so keep our requested method
+            # as the best-effort fallback but surface the mismatch — otherwise the
+            # ensuing exchange failure looks like a generic auth error.
+            log(
+                f"warning: AS assigned unsupported token_endpoint_auth_method "
+                f"{assigned_method!r} (requested {auth_method!r}); mcp-stdio "
+                f"cannot honour it and the token exchange may fail"
+            )
     return ClientRegistration(
         client_id=client_id,
         client_secret=client_secret,
@@ -1119,6 +1165,7 @@ def exchange_code(
         "Content-Type": "application/x-www-form-urlencoded",
         "Accept": "application/json",
     }
+    _warn_if_basic_auth_lacks_secret(auth_method, client_secret)
     if auth_method == "client_secret_basic" and client_secret:
         # URL-encode client_id and client_secret before base64-encoding for HTTP
         # Basic auth. RFC 6749 §2.3.1 specifies the form-urlencoded algorithm
@@ -1169,6 +1216,7 @@ def refresh_access_token(
         "Content-Type": "application/x-www-form-urlencoded",
         "Accept": "application/json",
     }
+    _warn_if_basic_auth_lacks_secret(auth_method, client_secret)
     if auth_method == "client_secret_basic" and client_secret:
         creds = base64.b64encode(
             f"{quote(client_id, safe='')}:{quote(client_secret, safe='')}".encode()
@@ -1649,6 +1697,9 @@ def _run_device_authorization_flow(
         "Content-Type": "application/x-www-form-urlencoded",
         "Accept": "application/json",
     }
+    # Covers both this device-authorization request and the token poll below:
+    # both reuse this auth_method/csecret, so one warning here suffices.
+    _warn_if_basic_auth_lacks_secret(auth_method, csecret)
     if auth_method == "client_secret_basic" and csecret:
         creds = base64.b64encode(
             f"{quote(cid, safe='')}:{quote(csecret, safe='')}".encode()

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -1127,6 +1127,79 @@ class TestRegisterClient:
         with pytest.raises(ValueError, match=match):
             register_client(meta, "http://127.0.0.1:9999/callback", client)
 
+    def test_honours_as_assigned_auth_method(self, httpx_mock):
+        """#L4(round39): RFC 7591 §3.2.1 — the AS MAY replace the requested
+        token_endpoint_auth_method and MUST return the registered value. When the
+        AS assigns a method we support that differs from the one we requested, the
+        returned ClientRegistration adopts the AS-assigned value so the later
+        token exchange frames credentials the way the AS expects."""
+        httpx_mock.add_response(
+            url="https://api.example.com/register",
+            json={
+                "client_id": "cid",
+                "client_secret": "sec",
+                "token_endpoint_auth_method": "client_secret_post",  # AS-assigned
+            },
+        )
+        meta = OAuthMetadata(
+            authorization_endpoint="https://api.example.com/authorize",
+            token_endpoint="https://api.example.com/token",
+            registration_endpoint="https://api.example.com/register",
+            # We request client_secret_basic (first supported match)...
+            token_endpoint_auth_methods_supported=["client_secret_basic"],
+        )
+        client = httpx.Client()
+        reg = register_client(meta, "http://127.0.0.1:9999/callback", client)
+        # ...but the AS recorded client_secret_post — that value wins.
+        assert reg.auth_method == "client_secret_post"
+        body = json.loads(httpx_mock.get_requests()[0].content)
+        assert body["token_endpoint_auth_method"] == "client_secret_basic"
+
+    def test_unsupported_as_assigned_auth_method_keeps_requested(
+        self, httpx_mock, capsys
+    ):
+        """#L4(round39): if the AS assigns a method mcp-stdio does not implement
+        (e.g. private_key_jwt), keep the requested method as the best-effort
+        fallback and warn so the ensuing exchange failure is not opaque."""
+        httpx_mock.add_response(
+            url="https://api.example.com/register",
+            json={
+                "client_id": "cid",
+                "client_secret": "sec",
+                "token_endpoint_auth_method": "private_key_jwt",  # unsupported here
+            },
+        )
+        meta = OAuthMetadata(
+            authorization_endpoint="https://api.example.com/authorize",
+            token_endpoint="https://api.example.com/token",
+            registration_endpoint="https://api.example.com/register",
+            token_endpoint_auth_methods_supported=["client_secret_basic"],
+        )
+        client = httpx.Client()
+        reg = register_client(meta, "http://127.0.0.1:9999/callback", client)
+        assert reg.auth_method == "client_secret_basic"  # requested, unchanged
+        assert "unsupported token_endpoint_auth_method" in capsys.readouterr().err
+
+    def test_non_string_as_assigned_auth_method_ignored(self, httpx_mock):
+        """A non-string token_endpoint_auth_method in the registration response is
+        ignored (isinstance guard) — the requested method is kept, no crash."""
+        httpx_mock.add_response(
+            url="https://api.example.com/register",
+            json={
+                "client_id": "cid",
+                "token_endpoint_auth_method": 123,  # non-string
+            },
+        )
+        meta = OAuthMetadata(
+            authorization_endpoint="https://api.example.com/authorize",
+            token_endpoint="https://api.example.com/token",
+            registration_endpoint="https://api.example.com/register",
+            token_endpoint_auth_methods_supported=["client_secret_post"],
+        )
+        client = httpx.Client()
+        reg = register_client(meta, "http://127.0.0.1:9999/callback", client)
+        assert reg.auth_method == "client_secret_post"
+
     def test_no_registration_endpoint(self):
         meta = OAuthMetadata(
             authorization_endpoint="https://api.example.com/authorize",
@@ -5839,6 +5912,34 @@ class TestExchangeCodeBasicAuth:
         assert b"client_id=cid" in req.content
         assert b"client_secret=csec" in req.content
         assert "authorization" not in req.headers
+
+    def test_basic_auth_without_secret_warns_and_falls_back_to_body(
+        self, httpx_mock, capsys
+    ):
+        """#L5(round39): client_secret_basic selected but no client_secret present
+        (a confidential client that lost its secret / a registration race). The
+        code degrades safely to body auth (client_id only) but now logs an
+        actionable warning so the operator sees WHY the AS rejects it, instead of
+        an opaque 401."""
+        httpx_mock.add_response(
+            url="https://as.example.com/token",
+            json={"access_token": "at"},
+        )
+        client = httpx.Client()
+        exchange_code(
+            self.META,
+            "cid",
+            None,  # no secret despite client_secret_basic
+            "code",
+            "v",
+            "http://127.0.0.1:9/cb",
+            client,
+            auth_method="client_secret_basic",
+        )
+        req = httpx_mock.get_requests()[0]
+        assert "authorization" not in req.headers  # no Basic header without a secret
+        assert b"client_id=cid" in req.content  # fell back to body
+        assert "client_secret_basic" in capsys.readouterr().err
 
 
 # --- client_secret_basic in refresh_access_token ---


### PR DESCRIPTION
## Summary

Round-39 review fixes in `oauth.py`.

### DCR auth-method readback (#L4, low)
`register_client` picked an auth method from the AS-advertised list and sent it in the registration request, but never read `token_endpoint_auth_method` back from the registration **response**. RFC 7591 §3.2.1 states the AS *"MAY reject or replace any of the client's requested metadata values ... and substitute them with suitable values"* and MUST return all registered metadata — so the response value is authoritative.

If the AS assigns a different (supported) method, the subsequent token exchange would frame credentials the way we **requested** (Basic header vs request body) rather than the way the AS **expects**, and fail with an opaque rejection. Now:
- adopt the AS-assigned method when we implement it (`none` / `client_secret_post` / `client_secret_basic`);
- if the AS assigns one we do not implement (e.g. `private_key_jwt`), keep the requested method and **warn** so the ensuing failure is actionable;
- ignore non-string values (`isinstance` guard).

### client_secret_basic without a secret (#L5, nit)
When `auth_method` is `client_secret_basic` but no `client_secret` is available (a confidential client that lost its secret, a registration race), the four credential-framing sites silently fell back to body auth (`client_id` only), which the AS rejects with an opaque 401. A shared `_warn_if_basic_auth_lacks_secret` helper now logs an actionable warning at the exchange / refresh / device-flow sites before the fallback. Recovery behaviour is unchanged (still degrades safely).

## Tests

- AS-assigned method adopted / unsupported assigned kept + warned / non-string ignored
- basic-auth-without-secret warns and falls back to body

Full suite: **879 passed, 3 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)