### PR TITLE
fix(oauth): honour --oauth-timeout for the device-code wait

### DIFF
--- a/src/mcp_stdio/oauth.py
+++ b/src/mcp_stdio/oauth.py
@@ -1647,12 +1647,18 @@ def _run_device_authorization_flow(
     client_id_override: str | None = None,
     scope: str | None = None,
     resource_indicator: bool = True,
+    timeout: float | None = None,
 ) -> TokenData:
     """Run RFC 8628 Device Authorization Grant flow.
 
     Displays a ``verification_uri`` + ``user_code`` on stderr so the user can
     authorize on a separate device, then polls the token endpoint until the
     device code expires or the user grants access.
+
+    ``timeout`` (when not ``None``) is the operator's ``--oauth-timeout`` and
+    bounds how long this waits for the user to confirm the device code — the
+    effective poll lifetime is ``min(timeout, server-advertised expires_in)``.
+    A direct caller passing ``None`` keeps the full RFC 8628 server lifetime.
     """
     if not metadata.device_authorization_endpoint:
         raise ValueError(
@@ -1767,6 +1773,17 @@ def _run_device_authorization_flow(
     expires_in = max(
         1, min(_safe_int(da.get("expires_in"), 1800), _DEVICE_FLOW_MAX_LIFETIME_SECS)
     )
+    # Honour the operator's --oauth-timeout as an UPPER bound on the human wait
+    # (#L9 round39). The CLI help promises --oauth-timeout covers "device-code
+    # confirmation", but it was never plumbed here, so the device flow silently
+    # ran on the server-advertised lifetime alone. Clamp the effective poll
+    # lifetime to min(timeout, expires_in) so the documented contract holds; a
+    # longer device window simply needs a larger --oauth-timeout. timeout=None
+    # (a direct caller) keeps the full RFC 8628 lifetime. floor at 1 s so a tiny
+    # timeout still allows the immediate first poll.
+    effective_lifetime = expires_in
+    if timeout is not None:
+        effective_lifetime = max(1, min(expires_in, int(timeout)))
     # Clamp the AS-supplied polling interval to a sane window so a hostile or
     # misconfigured AS cannot make a single time.sleep block for hours (or
     # raise on a negative value), mirroring the cap-gated Retry-After sleep in
@@ -1785,11 +1802,14 @@ def _run_device_authorization_flow(
     # mitigation (§5.4). So show it unconditionally, not only on the no-complete
     # branch. See #5 (round18).
     print(f"  Code (verify it matches): {user_code}", file=sys.stderr)
-    print(f"\nWaiting for authorization (expires in {expires_in}s)...", file=sys.stderr)
+    print(
+        f"\nWaiting for authorization (giving up in {effective_lifetime}s)...",
+        file=sys.stderr,
+    )
 
     # Step 2: Poll token endpoint (RFC 8628 §3.4 request / §3.5 response)
     # Sleep is at the end of each iteration so the first poll is immediate.
-    deadline = time.monotonic() + expires_in
+    deadline = time.monotonic() + effective_lifetime
 
     def _poll_sleep() -> None:
         # Never sleep past the deadline — a slow_down-inflated interval must not
@@ -1982,6 +2002,9 @@ def ensure_token(
             client_id_override=client_id,
             scope=scope,
             resource_indicator=resource_indicator,
+            # #L9 round39: honour --oauth-timeout for the device-code wait too,
+            # matching the auth-code branch below and the CLI help text.
+            timeout=timeout,
         )
     return _run_authorization_flow(
         server_url,

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -5225,7 +5225,9 @@ class TestDeviceAuthorizationFlow:
             MCP_URL, client, metadata=_device_meta(), cached=None
         )
         err = capsys.readouterr().err
-        assert f"expires in {_DEVICE_FLOW_MAX_LIFETIME_SECS}s" in err
+        # No --oauth-timeout here, so the effective wait equals the clamped
+        # server lifetime (#L9 round39 reworded the message to "giving up in").
+        assert f"giving up in {_DEVICE_FLOW_MAX_LIFETIME_SECS}s" in err
         assert "999999999" not in err
 
     def test_verification_uri_complete_printed(self, httpx_mock, tmp_path, monkeypatch, capsys):
@@ -5637,6 +5639,69 @@ class TestDeviceAuthorizationFlow:
         with pytest.raises(TimeoutError, match="timed out"):
             _run_device_authorization_flow(
                 MCP_URL, client, metadata=_device_meta(), cached=None
+            )
+
+    def test_oauth_timeout_clamps_device_poll_lifetime(
+        self, httpx_mock, tmp_path, monkeypatch
+    ):
+        """#L9(round39): --oauth-timeout bounds the device-code wait. With a
+        timeout (5s) far below the server-advertised expires_in (1800s), the poll
+        deadline is clamped to the timeout: a clock jump of 6s — past the 5s
+        timeout but nowhere near the 1800s server lifetime — ends the flow with
+        TimeoutError, proving the deadline was the clamped value, not 1800."""
+        self._patch_store(tmp_path, monkeypatch)
+        httpx_mock.add_response(url=REG_URL, json={"client_id": "cid"})
+        httpx_mock.add_response(url=DEVICE_AUTH_URL, json=_da_response(expires_in=1800))
+        httpx_mock.add_response(
+            url=TOKEN_URL,
+            json={"error": "authorization_pending"},
+            status_code=400,
+            is_reusable=True,
+        )
+        clock = {"t": 0.0}
+        monkeypatch.setattr(time, "monotonic", lambda: clock["t"])
+
+        def jump_sleep(_secs: float) -> None:
+            clock["t"] += 6  # past the 5s timeout, far below the 1800s expires_in
+
+        monkeypatch.setattr(time, "sleep", jump_sleep)
+        client = httpx.Client()
+        with pytest.raises(TimeoutError, match="timed out"):
+            _run_device_authorization_flow(
+                MCP_URL, client, metadata=_device_meta(), cached=None, timeout=5
+            )
+        # Exactly one token poll fired before the clamped 5s deadline was crossed;
+        # without the clamp the 1800s deadline would have driven ~300 polls.
+        polls = [r for r in httpx_mock.get_requests() if str(r.url) == TOKEN_URL]
+        assert len(polls) == 1
+
+    def test_oauth_timeout_does_not_extend_beyond_server_lifetime(
+        self, httpx_mock, tmp_path, monkeypatch
+    ):
+        """#L9(round39): the clamp is min(timeout, expires_in) — a timeout LARGER
+        than the server lifetime must not extend the wait. expires_in=10, a huge
+        timeout, and a 11s clock jump (past expires_in, below timeout) still ends
+        with TimeoutError: the deadline stayed at the 10s server lifetime."""
+        self._patch_store(tmp_path, monkeypatch)
+        httpx_mock.add_response(url=REG_URL, json={"client_id": "cid"})
+        httpx_mock.add_response(url=DEVICE_AUTH_URL, json=_da_response(expires_in=10))
+        httpx_mock.add_response(
+            url=TOKEN_URL,
+            json={"error": "authorization_pending"},
+            status_code=400,
+            is_reusable=True,
+        )
+        clock = {"t": 0.0}
+        monkeypatch.setattr(time, "monotonic", lambda: clock["t"])
+
+        def jump_sleep(_secs: float) -> None:
+            clock["t"] += 11  # past the 10s server lifetime, below the huge timeout
+
+        monkeypatch.setattr(time, "sleep", jump_sleep)
+        client = httpx.Client()
+        with pytest.raises(TimeoutError, match="timed out"):
+            _run_device_authorization_flow(
+                MCP_URL, client, metadata=_device_meta(), cached=None, timeout=99999
             )
 
     def test_poll_network_error_is_retried(


### PR DESCRIPTION
## Summary

Round-39 review (#L9, low).

The `--oauth-timeout` help text promises it bounds *"the interactive OAuth flow (browser callback / device-code confirmation)"*, and the round-25 rationale explicitly exposed the flag so a user with slow device-code entry *"is not cut off"*. But the timeout was only ever forwarded to the auth-code branch: `ensure_token` dispatched the device path via `_run_device_authorization_flow` **without** passing `timeout`, and the function did not accept one — so with `--oauth-device` the operator-supplied `--oauth-timeout` had **zero effect**, the device flow running solely on its RFC 8628 server-advertised lifetime.

Plumb it through: `_run_device_authorization_flow` now takes an optional `timeout` and clamps the effective poll lifetime to `min(timeout, server expires_in)`, so the documented contract holds. A direct caller passing `None` keeps the full RFC 8628 lifetime (unchanged). The stderr wait line is reworded to "giving up in Ns" to reflect the client-side deadline.

## Tests

- a timeout below `expires_in` clamps the deadline (one poll, then `TimeoutError`)
- a timeout above `expires_in` does **not** extend past the server lifetime

Full suite: **884 passed, 3 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)