### PR TITLE
fix(cli): freeze base headers in OAuth callbacks instead of aliasing the live dict

### DIFF
--- a/src/mcp_stdio/cli.py
+++ b/src/mcp_stdio/cli.py
@@ -121,6 +121,16 @@ def _build_token_refresher(
     Returns a callable that attempts to refresh the OAuth token
     and returns updated headers on success, or None on failure.
     """
+    # Freeze a private copy of the operator-supplied base headers at build time
+    # (#L3 round39). The relay passes the SAME live `headers` dict to both this
+    # callback and the SSE reader thread; closing over the live object and
+    # iterating it via dict(headers) would read it UNLOCKED, racing any future
+    # reader-thread mutation (today none exists, so it is safe, but the relay's
+    # own comment claims every cross-thread access is serialised). The callbacks
+    # only ever layer a fresh Authorization onto the static base headers, so a
+    # frozen snapshot is behaviourally identical AND removes the shared-object
+    # aliasing entirely — no lock needed, no fragile invariant to preserve.
+    base_headers = dict(headers)
 
     def refresher() -> dict[str, str] | None:
         from .oauth import refresh_cached_token
@@ -140,7 +150,7 @@ def _build_token_refresher(
             data = refresh_cached_token(server_url, client)
             if data is None:
                 return None
-            new_headers = dict(headers)
+            new_headers = dict(base_headers)
             new_headers["Authorization"] = _bearer_header_value(data.access_token)
             return new_headers
         except Exception as e:
@@ -173,6 +183,9 @@ def _build_scope_upgrader(
     cold-start ``ensure_token`` does, so ``--oauth-timeout`` applies to a
     mid-session step-up too, not just the initial authorization.
     """
+    # Freeze the operator-supplied base headers at build time (#L3 round39); see
+    # _build_token_refresher for why the live shared dict is not closed over.
+    base_headers = dict(headers)
 
     def upgrader(required_scope: str) -> dict[str, str] | None:
         from .oauth import step_up_authorize
@@ -192,7 +205,7 @@ def _build_scope_upgrader(
             data = step_up_authorize(
                 server_url, client, required_scope, timeout=oauth_timeout
             )
-            new_headers = dict(headers)
+            new_headers = dict(base_headers)
             new_headers["Authorization"] = _bearer_header_value(data.access_token)
         except Exception as e:
             print(f"error: step-up authorization failed: {e}", file=sys.stderr)

--- a/src/mcp_stdio/relay.py
+++ b/src/mcp_stdio/relay.py
@@ -821,6 +821,14 @@ def _post_and_stream(
                             continue
                         if capture_init and pv is None:
                             pv = _extract_protocol_version(payload)
+                        # _emit -> _write_line can raise BrokenPipeError (an
+                        # OSError, not an httpx.HTTPError) mid-stream if the
+                        # downstream reader closed stdout. That intentionally
+                        # bypasses the httpx.HTTPError handler below and unwinds
+                        # to run()/run_sse()'s outer `except Exception` safety
+                        # net, which swallows the re-raised write error: a dead
+                        # reader cannot observe the truncated body anyway (#L2
+                        # round39).
                         _emit(payload, tracker)
                         emitted = True
                 else:
@@ -2370,8 +2378,12 @@ def run_sse(
         """Take a consistent copy of ``headers`` under the lock for a POST.
 
         Symmetric with the reader thread's snapshot and the 401/403 mutations
-        so every cross-thread access to ``headers`` is serialised — no POST
-        ever iterates the dict while a refresh is updating it.
+        so every cross-thread access to the shared ``headers`` object is
+        serialised — no POST ever iterates the dict while a refresh is updating
+        it. The token_refresher / scope_upgrader callbacks do NOT count as a
+        cross-thread access: they layer a fresh Authorization onto a build-time
+        frozen copy of the base headers (see cli.py _build_token_refresher),
+        never touching this live object, so the serialisation claim holds.
         """
         with headers_lock:
             return dict(headers)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1031,6 +1031,30 @@ class TestBuildTokenRefresher:
         assert refresher() is None
         assert _SpyClient.instances[-1].closed
 
+    def test_does_not_alias_live_headers_dict(self, monkeypatch):
+        """#L3(round39): the callback layers Authorization onto a build-time
+        FROZEN copy of the base headers, not the live shared dict the SSE reader
+        thread also holds. Mutating the caller's dict after build must not affect
+        the callback's output — proving the live object is never iterated
+        unlocked from the callback (no cross-thread aliasing)."""
+        _SpyClient.instances.clear()
+        monkeypatch.setattr("mcp_stdio.cli.httpx.Client", _SpyClient)
+        monkeypatch.setattr(
+            "mcp_stdio.oauth.refresh_cached_token",
+            lambda url, client: TokenData(access_token="fresh"),
+        )
+        live = {"X-Base": "1"}
+        refresher = _build_token_refresher("https://example.com/mcp", live, 10, 120)
+        # Mutate the live dict AFTER build, as the relay main loop's
+        # headers.update would (concurrently with the reader thread).
+        live["X-Base"] = "MUTATED"
+        live["X-New"] = "added"
+        out = refresher()
+        # Output reflects the frozen build-time snapshot, not the mutation.
+        assert out["X-Base"] == "1"
+        assert "X-New" not in out
+        assert out["Authorization"] == "Bearer fresh"
+
     def test_returns_none_when_refresh_raises_and_closes(self, monkeypatch, capsys):
         """A refresh that RAISES (e.g. save_token re-raising OSError on a
         read-only disk) must degrade to None — not crash the relay mid-session
@@ -1078,6 +1102,25 @@ class TestBuildScopeUpgrader:
         # (an AS-controlled token endpoint could otherwise 302 the credential POST
         # to a cleartext / cross-origin host). Symmetric with the refresher test.
         assert _SpyClient.instances[-1].kwargs.get("follow_redirects") is False
+
+    def test_does_not_alias_live_headers_dict(self, monkeypatch):
+        """#L3(round39): like the refresher, the upgrader layers Authorization
+        onto a build-time frozen copy of the base headers, not the live shared
+        dict. Mutating the caller's dict after build must not affect output."""
+        _SpyClient.instances.clear()
+        monkeypatch.setattr("mcp_stdio.cli.httpx.Client", _SpyClient)
+        monkeypatch.setattr(
+            "mcp_stdio.oauth.step_up_authorize",
+            lambda url, client, scope, *, timeout: TokenData(access_token="upgraded"),
+        )
+        live = {"X-Base": "1"}
+        upgrader = _build_scope_upgrader("https://example.com/mcp", live, 10, 120, 90)
+        live["X-Base"] = "MUTATED"
+        live["X-New"] = "added"
+        out = upgrader("hr:read")
+        assert out["X-Base"] == "1"
+        assert "X-New" not in out
+        assert out["Authorization"] == "Bearer upgraded"
 
     def test_returns_none_when_step_up_raises_and_closes(self, monkeypatch, capsys):
         _SpyClient.instances.clear()


### PR DESCRIPTION
## Summary

Round-39 review fixes in `cli.py` / `relay.py`.

### Unlocked shared-headers read in callbacks (#L3, low)
The relay passes one live `headers` dict to both the `token_refresher` / `scope_upgrader` callbacks and the SSE reader thread. The callbacks closed over that live object and iterated it via `dict(headers)` with **no** `headers_lock` held. It is race-free today only by a fragile invariant (the main loop is the sole mutator and updates `headers` only **after** the callback returns), yet `relay.py`'s own comment claimed *"every cross-thread access to headers is serialised"*.

The callbacks only ever layer a fresh `Authorization` onto the static operator-supplied base headers, so freeze a private copy at build time (`base_headers = dict(headers)`) and build from it. This removes the shared-object aliasing entirely — behaviourally identical, no lock, no fragile invariant. The `_snapshot_headers` docstring is corrected to note the callbacks no longer touch the live object, so the claim now holds.

### BrokenPipe cross-function contract (#L2, nit)
A one-line comment at the SSE `_emit` site documents that a stdout write failure (`BrokenPipeError`, not an `httpx.HTTPError`) intentionally unwinds past the local `httpx.HTTPError` handler to `run()`/`run_sse()`'s outer safety net — a dead reader cannot observe the truncation. No behaviour change.

## Tests

- refresher and upgrader both ignore a post-build mutation of the caller's dict (proving the frozen snapshot, no live aliasing)

Full suite: **884 passed, 3 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)