### PR TITLE
fix(token_store): warn on a valid-but-non-object JSON store, matching corrupt-JSON

### DIFF
--- a/src/mcp_stdio/token_store.py
+++ b/src/mcp_stdio/token_store.py
@@ -459,6 +459,27 @@ class _StoreUnreadable(Exception):
     """
 
 
+def _warn_unusable_store_once(detail: str) -> None:
+    """Emit a one-shot stderr warning that the token store is unusable.
+
+    Covers both genuinely corrupt JSON and a valid-but-non-object top level
+    (e.g. ``[]`` / ``42`` / ``null``) — both are equally unusable as a token
+    store and overwrite-safe (the next save replaces them), so they must surface
+    the SAME operator signal instead of one silently degrading to ``{}`` (#L3
+    round40). The ``_warned_corrupt_store`` flag keeps it to one line per process
+    across repeated reads; ``detail`` names the specific cause.
+    """
+    global _warned_corrupt_store
+    if not _warned_corrupt_store:
+        _warned_corrupt_store = True
+        print(
+            f"mcp-stdio: warning: token store {_STORE_FILE} {detail}; treating "
+            f"it as empty (cached tokens, if any, are unrecoverable and need "
+            f"re-auth). It is replaced on the next save.",
+            file=sys.stderr,
+        )
+
+
 def _read_store(*, for_write: bool = False) -> dict[str, Any]:
     """Read the token store file.
 
@@ -551,21 +572,21 @@ def _read_store(*, for_write: bool = False) -> dict[str, Any]:
         # Fire on BOTH paths now (#L8 round39): a read-only invocation
         # (load_token -> _read_store with for_write=False) otherwise gives the
         # operator zero signal — just an unexplained re-auth — until some later
-        # save happens to reach the write path. The one-shot _warned_corrupt_store
-        # flag keeps it to a single line per process, and the wording covers both
-        # outcomes (read-as-empty now, replaced on the next save).
-        global _warned_corrupt_store
-        if not _warned_corrupt_store:
-            _warned_corrupt_store = True
-            print(
-                f"mcp-stdio: warning: token store {_STORE_FILE} contains "
-                f"corrupt JSON; treating it as empty (cached tokens, if any, were "
-                f"already unparseable and need re-auth). It is replaced on the "
-                f"next save.",
-                file=sys.stderr,
-            )
+        # save happens to reach the write path.
+        _warn_unusable_store_once("contains corrupt JSON")
         return {}
-    return data if isinstance(data, dict) else {}
+    if not isinstance(data, dict):
+        # Valid JSON but NOT an object (e.g. a bare array / number / string /
+        # null) is just as unusable as a token store as corrupt JSON, and the
+        # next save clobbers it the same overwrite-safe way — so surface it with
+        # the SAME one-shot warning instead of the silent {} that left the
+        # operator with only an unexplained re-auth (#L3 round40, completing the
+        # read-path visibility of #L8 round39).
+        _warn_unusable_store_once(
+            f"holds a non-object JSON top level ({type(data).__name__})"
+        )
+        return {}
+    return data
 
 
 def _write_store(data: dict[str, Any]) -> None:

--- a/tests/test_relay.py
+++ b/tests/test_relay.py
@@ -2261,6 +2261,30 @@ class TestRun:
         assert result["error"]["message"] == "HTTP 401"
         assert result["id"] == 1
 
+    def test_explicit_null_id_request_error_is_emitted_not_suppressed(
+        self, httpx_mock
+    ):
+        """#L4(round40): a request with an EXPLICIT "id": null is a request, not a
+        notification, so an unhandled non-2xx must still synthesize an error
+        echoing "id": null — never silently drop it as if it were a notification.
+        The contract was asserted only at the helper level (TestErrorResponse),
+        never end-to-end through run()'s id extraction from a real stdin line."""
+        httpx_mock.add_response(
+            status_code=401,
+            text="",
+            headers={"content-type": "application/json"},
+        )
+        output = self._run_with_stdin(
+            httpx_mock,
+            ['{"jsonrpc":"2.0","method":"init","id":null}'],
+        )
+        line = output.strip()
+        assert line, "an explicit-null-id request must get a response, not silence"
+        result = json.loads(line)
+        # "id": null is echoed (key present, value None), not dropped.
+        assert "id" in result and result["id"] is None
+        assert result["error"]["message"] == "HTTP 401"
+
 
 # --- MCP-Protocol-Version header (spec rev 2025-06-18, issue #69) ---
 

--- a/tests/test_token_store.py
+++ b/tests/test_token_store.py
@@ -238,6 +238,23 @@ class TestLoadSaveDelete:
         # One-shot: the warning line appears exactly once across both reads.
         assert err.count("corrupt JSON") == 1
 
+    @pytest.mark.parametrize("body", ["[]", "42", '"foo"', "null", "[1, 2, 3]"])
+    def test_non_object_store_warns_and_degrades_to_empty(
+        self, tmp_path, monkeypatch, capsys, body
+    ):
+        """#L3(round40): a token store whose top-level JSON is valid but NOT an
+        object (a bare array / number / string / null) is unusable as a store and
+        overwrite-safe — it must surface the SAME one-shot warning as corrupt
+        JSON, not silently degrade to {} with only an unexplained re-auth."""
+        store_file = tmp_path / "tokens.json"
+        monkeypatch.setattr("mcp_stdio.token_store._STORE_DIR", tmp_path)
+        monkeypatch.setattr("mcp_stdio.token_store._STORE_FILE", store_file)
+        monkeypatch.setattr("mcp_stdio.token_store._warned_corrupt_store", False)
+
+        store_file.write_text(body)
+        assert load_token("https://example.com/mcp") is None
+        assert "non-object JSON top level" in capsys.readouterr().err
+
     @pytest.mark.skipif(
         sys.platform == "win32" or not hasattr(os, "mkfifo"),
         reason="os.mkfifo is POSIX-only",


### PR DESCRIPTION
## Summary

Round-40 review fixes.

### Non-object store visibility (#L3, low)
`_read_store` warned (one-shot) when the token store was corrupt JSON, but a store whose top-level JSON is **valid yet not an object** (a bare array / number / string / null) bypassed the `JSONDecodeError` branch and silently degraded to `{}` with no signal — the operator saw only an unexplained re-auth, the exact gap #L8 round39 closed for corrupt JSON. Both cases are equally unusable as a token store and overwrite-safe, so they now share one `_warn_unusable_store_once(detail)` helper: *"contains corrupt JSON"* vs *"holds a non-object JSON top level ( & lt; type & gt; )"*. Recovery behaviour is unchanged (still `{}` / replaced on next save); only the missing diagnostic line is added.

### Coverage (#L4, low)
Added an end-to-end `run()` test that an explicit `"id": null` request receiving an unhandled non-2xx synthesizes an error echoing `"id": null` (a request, not a notification) — previously asserted only at the helper level (`TestErrorResponse`), never through `run()`'s stdin id extraction, so a regression mis-classifying explicit-null-id as a notification (suppressing the response) was uncaught.

## Tests

- non-object stores (`[]`, `42`, `"foo"`, `null`, `[1,2,3]`) warn and degrade to empty
- explicit-null-id request error is emitted, not suppressed

Full suite: **892 passed, 3 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)