### PR TITLE
fix(oauth): preserve cached refresh_token across a step-up re-authorization

### DIFF
--- a/src/mcp_stdio/oauth.py
+++ b/src/mcp_stdio/oauth.py
@@ -1256,8 +1256,9 @@ def _token_response_to_data(
 ) -> TokenData:
     """Convert a raw token response to TokenData.
 
-    If the response omits refresh_token (allowed per RFC 6749 Section 6),
-    the previous_refresh_token is preserved so subsequent refreshes work.
+    If the response omits refresh_token (it is OPTIONAL per RFC 6749 §5.1;
+    §6 only covers how an issued refresh_token is later used), the
+    previous_refresh_token is preserved so subsequent refreshes work.
     Likewise ``scope`` is OPTIONAL in a token response (RFC 6749 §5.1: it
     may be omitted when identical to the requested scope, which refreshes
     routinely do), so ``previous_scope`` is preserved — otherwise a refresh
@@ -1623,6 +1624,15 @@ def _run_authorization_flow(
         metadata,
         cid,
         csecret,
+        # RFC 6749 §5.1 makes refresh_token OPTIONAL in a token response, so a
+        # step-up (which reuses this auth-code path for a full re-authorization)
+        # against an AS that omits it would otherwise overwrite the cached
+        # TokenData's still-valid refresh_token with None — breaking every future
+        # silent refresh until the next interactive flow. Carry the cached token
+        # through, mirroring the refresh path (refresh_cached_token). Harmless on
+        # initial auth, where `cached` is None or carries no refresh_token. (#L2
+        # round41)
+        previous_refresh_token=cached.refresh_token if cached else None,
         # RFC 6749 §5.1 lets the AS omit `scope` when it equals the requested
         # scope — exactly what a step-up does (requested == merged union). Fall
         # back to the requested `scope` so the stored TokenData.scope is not

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -4619,6 +4619,48 @@ class TestRfc9207IssValidation:
         )
         assert data.scope == "read write admin"
 
+    def test_stepup_preserves_cached_refresh_token_when_response_omits_it(
+        self, httpx_mock, tmp_path, monkeypatch
+    ):
+        """#L2(round41): a step-up token response that OMITS refresh_token (RFC
+        6749 §5.1, OPTIONAL) must keep the CACHED refresh_token in the stored
+        TokenData — not overwrite it with None, which would break every future
+        silent refresh until the next interactive flow. Mirrors the scope
+        preservation above and the refresh path."""
+        store_file = tmp_path / "tokens.json"
+        monkeypatch.setattr("mcp_stdio.token_store._STORE_DIR", tmp_path)
+        monkeypatch.setattr("mcp_stdio.token_store._STORE_FILE", store_file)
+        # Token response deliberately omits "refresh_token".
+        httpx_mock.add_response(
+            url="https://ex.com/token",
+            json={"access_token": "new_at", "token_type": "Bearer"},
+        )
+        monkeypatch.setattr(
+            "mcp_stdio.oauth.webbrowser.open", self._driver("iss=https://ex.com")
+        )
+        cached = TokenData(
+            access_token="old_at",
+            refresh_token="cached_rt",
+            client_id="cid",  # reused → no DCR
+            token_endpoint="https://ex.com/token",
+            authorization_endpoint="https://ex.com/authorize",
+        )
+        client = httpx.Client()
+        data = _run_authorization_flow(
+            "https://ex.com/mcp",
+            client,
+            metadata=self.META,
+            cached=cached,
+            scope="read write",
+            timeout=5,
+        )
+        assert data.access_token == "new_at"
+        assert data.refresh_token == "cached_rt"  # preserved, not wiped to None
+        # And it survives the round-trip to disk.
+        from mcp_stdio.token_store import load_token
+
+        assert load_token("https://ex.com/mcp").refresh_token == "cached_rt"
+
     def test_no_iss_skips_validation(self, httpx_mock, tmp_path, monkeypatch):
         store_file = tmp_path / "tokens.json"
         monkeypatch.setattr("mcp_stdio.token_store._STORE_DIR", tmp_path)


### PR DESCRIPTION
## Summary

Round-41 review fixes in `oauth.py`.

### Step-up refresh_token drop (#L2, low)
`_run_authorization_flow` passed `previous_scope` to `_token_response_to_data` but **not** `previous_refresh_token` (it defaulted to `None`). `step_up_authorize` reuses this same auth-code path for a full re-authorization, so an AS that omits `refresh_token` on the step-up token response — permitted, **RFC 6749 §5.1** makes it OPTIONAL — would overwrite the cached `TokenData`'s still-valid `refresh_token` with `None`, breaking every future silent refresh until the next interactive flow.

Carry the cached token through (`previous_refresh_token=cached.refresh_token if cached else None`), mirroring the refresh path (`refresh_cached_token`) and the `previous_scope` preservation two lines down. Harmless on initial auth (`cached` is `None` / carries no refresh_token). This was the only credential-flow path that did not preserve a prior refresh token across a token response. Degrades gracefully today (it forces one extra interactive prompt), so low severity.

### RFC citation (#N3, nit)
The `_token_response_to_data` docstring cited *"RFC 6749 Section 6"* for `refresh_token` being omittable; the OPTIONAL designation is actually **§5.1** (*"refresh_token: OPTIONAL"*, verified against the RFC), while §6 only covers how an issued refresh_token is later *used*. Corrected to §5.1, matching the scope citation already used in the same docstring.

## Tests

- a step-up token response omitting `refresh_token` keeps the cached one (in the returned `TokenData` and on disk)

Full suite: **893 passed, 3 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)