### PR TITLE
fix(relay): gate protocol-version capture on parse-authoritative initialize check

### DIFF
--- a/src/mcp_stdio/relay.py
+++ b/src/mcp_stdio/relay.py
@@ -417,7 +417,17 @@ def _extract_cancel_id(line: str) -> Any:
     params = msg.get("params")
     if not isinstance(params, dict):
         return None
-    return params.get("requestId")
+    rid = params.get("requestId")
+    # A JSON-RPC id is a String or Number (or null). A NON-SCALAR requestId
+    # (object / array) is malformed AND unhashable, so the caller's
+    # ``tracker.add(rid)`` would raise ``TypeError: unhashable type`` on the
+    # stdin hot path — and such an id can never match a real response id anyway.
+    # Drop it (return None) so a malformed cancellation is a clean no-op rather
+    # than an exception. ``null`` already returns None here and is filtered by
+    # the caller's ``cid is not None`` guard. (#9 round42)
+    if rid is not None and not isinstance(rid, (str, int, float)):
+        return None
+    return rid
 
 
 def _error_response(message: str, req_id: Any = None, data: Any = None) -> str:
@@ -1236,7 +1246,13 @@ def _paginate_and_stream(
 
     merged_response: dict[str, Any] = {
         "jsonrpc": request.get("jsonrpc", "2.0"),
-        "id": request.get("id"),
+        # Reuse the id run() already parsed (and tracks/discards in the cancel
+        # filter) rather than re-deriving it from this second parse (#1 round42).
+        # They are provably identical today, but keying the emitted id off req_id
+        # removes a latent divergence point — _emit's cancel filter matches on the
+        # BODY id, so any future drift would both mis-correlate the response and
+        # defeat cancellation filtering for paginated responses.
+        "id": req_id,
         "result": merged_result,
     }
     _emit(json.dumps(merged_response), tracker)
@@ -1786,20 +1802,27 @@ def run(
                     # different version is adopted so the injected
                     # MCP-Protocol-Version header stays equal to the version in
                     # force (the 2025-06-18 spec requires the header to match the
-                    # negotiated version). The added per-line cost is one cheap
-                    # `_looks_like_initialize` regex; the heavier
-                    # `_extract_protocol_version` still runs only inside
-                    # `_post_and_stream` for lines that are actually initializes.
+                    # negotiated version). The heavier `_extract_protocol_version`
+                    # still runs only inside `_post_and_stream` for lines that are
+                    # actually initializes.
                     #
                     # Response-only: the version comes from the server's
                     # InitializeResult, not the client's requested version. If a
                     # (non-compliant) server omits result.protocolVersion, no
                     # header is sent rather than guessing — a server that both
                     # omits it and enforces the header would be self-contradictory.
-                    capture_init = _looks_like_initialize(content)
-                    if protocol_version is not None and _is_initialize_request(
-                        content
-                    ):
+                    #
+                    # Classify the line ONCE, PARSE-authoritatively. Gating the
+                    # protocol-version CAPTURE on _is_initialize_request (not the
+                    # _looks_like_initialize substring) stops a tools/call whose
+                    # `arguments` merely contains a "method":"initialize" key from
+                    # capturing a spurious result.protocolVersion out of its tool
+                    # response and then injecting a never-negotiated version on
+                    # every later request (#3 round42). The cheap
+                    # _INITIALIZE_METHOD_RE inside _is_initialize_request still
+                    # short-circuits the common non-matching line without a parse.
+                    capture_init = _is_initialize_request(content)
+                    if protocol_version is not None and capture_init:
                         # An initialize request IS the (re)negotiation and predates a
                         # known version, so it must not advertise the prior one
                         # (2025-06-18: the header carries the negotiated version and
@@ -1808,10 +1831,10 @@ def run(
                         # on ``protocol_version is not None`` means we only drop the
                         # relay's OWN injected header — on a cold-start initialize
                         # (no version yet) a user-pinned ``-H MCP-Protocol-Version``
-                        # is left intact. Mcp-Session-Id is untouched. The strip is
-                        # gated on the PARSE-authoritative check (not the regex
-                        # capture_init) so a tools/call whose arguments contains a
-                        # "method":"initialize" key keeps its header. See #3 (round18).
+                        # is left intact. Mcp-Session-Id is untouched. Both capture
+                        # and strip now share the parse-authoritative gate, so a
+                        # tools/call whose arguments contains a "method":"initialize"
+                        # key keeps its header. See #3 (round18), #3 (round42).
                         h = {
                             k: v
                             for k, v in h.items()

--- a/tests/test_relay.py
+++ b/tests/test_relay.py
@@ -2394,6 +2394,37 @@ class TestProtocolVersionHeader:
         # The tools/call is a post-init request → carries the negotiated header.
         assert reqs[1].headers["mcp-protocol-version"] == "2025-06-18"
 
+    def test_tools_call_with_nested_method_initialize_does_not_capture_version(
+        self, httpx_mock
+    ):
+        """#3(round42): the CAPTURE counterpart of the strip test above. A
+        tools/call whose nested ``arguments`` contains a ``"method":"initialize"``
+        key must NOT capture ``result.protocolVersion`` from its tool response —
+        capture is now gated on the parse-authoritative check, not the substring
+        regex. Otherwise a never-negotiated version would be injected as
+        MCP-Protocol-Version on every later request."""
+        # The tool response happens to carry a string protocolVersion in its
+        # result (e.g. a tool that proxies an MCP server / returns version info).
+        httpx_mock.add_response(
+            text='{"jsonrpc":"2.0","result":{"protocolVersion":"9999-spoof"},"id":1}',
+            headers={"content-type": "application/json"},
+        )
+        httpx_mock.add_response(
+            text='{"jsonrpc":"2.0","result":{},"id":2}',
+            headers={"content-type": "application/json"},
+        )
+        # No real initialize precedes this; both lines are top-level tools/call.
+        self._run_with_stdin(
+            [
+                '{"jsonrpc":"2.0","method":"tools/call","id":1,"params":'
+                '{"name":"http","arguments":{"method":"initialize"}}}',
+                '{"jsonrpc":"2.0","method":"tools/call","id":2}',
+            ]
+        )
+        reqs = httpx_mock.get_requests()
+        # The spurious protocolVersion was NOT captured → no injected header.
+        assert "mcp-protocol-version" not in reqs[1].headers
+
     def test_initialized_notification_carries_header(self, httpx_mock):
         """notifications/initialized is the first subsequent request — must carry it."""
         httpx_mock.add_response(
@@ -6192,6 +6223,53 @@ class TestExtractCancelId:
             '"params":["requestId",1]}'
         )
         assert _extract_cancel_id(line) is None
+
+    def test_null_request_id_returns_none(self):
+        """An explicit requestId:null yields None — the caller's `cid is not None`
+        guard then skips tracking, a clean no-op."""
+        line = (
+            '{"jsonrpc":"2.0","method":"notifications/cancelled",'
+            '"params":{"requestId":null}}'
+        )
+        assert _extract_cancel_id(line) is None
+
+    @pytest.mark.parametrize(
+        "request_id", ['{"a":1}', "[1,2]", "{}", "[]"]
+    )
+    def test_non_scalar_request_id_returns_none_not_unhashable_crash(
+        self, request_id
+    ):
+        """#9(round42): a non-scalar requestId (object/array) is malformed AND
+        unhashable, so returning it verbatim would make the caller's
+        tracker.add(rid) raise TypeError on the stdin hot path. _extract_cancel_id
+        must drop it (return None) so a malformed cancellation is a clean no-op.
+        Guard the full path: the extracted value must be safe to add to a tracker."""
+        line = (
+            '{"jsonrpc":"2.0","method":"notifications/cancelled",'
+            f'"params":{{"requestId":{request_id}}}}}'
+        )
+        cid = _extract_cancel_id(line)
+        assert cid is None
+        # End-to-end: the value (None → skipped) never reaches an unhashable add.
+        tracker = _CancelTracker()
+        if cid is not None:  # mirrors the relay's guard
+            tracker.add(cid)  # would raise TypeError if a dict/list slipped through
+
+    def test_scalar_request_ids_pass_through(self):
+        """A valid scalar requestId (int / float / string) is returned verbatim
+        and is hashable, so the tracker accepts it."""
+        for body, expected in [
+            ('"requestId":5', 5),
+            ('"requestId":1.5', 1.5),
+            ('"requestId":"r-1"', "r-1"),
+        ]:
+            line = (
+                '{"jsonrpc":"2.0","method":"notifications/cancelled",'
+                f'"params":{{{body}}}}}'
+            )
+            cid = _extract_cancel_id(line)
+            assert cid == expected
+            _CancelTracker().add(cid)  # hashable → no crash
 
     def test_substring_false_positive_guard(self):
         # The regex matches on any '"method":"notifications/cancelled"'


### PR DESCRIPTION
## Summary

Round-42 review fixes in `relay.py`.

### Spurious protocol-version capture (#3, low)
`_dispatch` set `capture_init` via the `_looks_like_initialize` **substring** regex, which over-triggers on any line containing `"method":"initialize"` — including a `tools/call` whose nested `arguments` carries that key. If such a tool's response `result` happened to hold a string `protocolVersion`, it was captured and then injected as `MCP-Protocol-Version` on **every subsequent request** — a version never negotiated via a real initialize handshake. Gate the **capture** on the parse-authoritative `_is_initialize_request` (already used for the request-header strip), classifying the line once and sharing the gate. The cheap `_INITIALIZE_METHOD_RE` still short-circuits the common non-matching line without a parse.

### Unhashable cancel requestId (#9, was flagged as coverage-gap — upgraded)
`_extract_cancel_id` returned `params.requestId` verbatim, so a `notifications/cancelled` with a **non-scalar** `requestId` (object / array) returned an unhashable dict/list. The caller's `tracker.add(rid)` then raised `TypeError: unhashable type` on the stdin hot path (**empirically confirmed**). A JSON-RPC id is a String or Number (or null); drop a non-scalar `requestId` (return `None`) so a malformed cancellation is a clean no-op rather than an exception.

### Pagination merged id (#1, nit)
The merged list response re-derived `"id"` from a **second** `json.loads` of the line instead of the `req_id` `run()` already parsed and tracks in the cancel filter. Provably identical today, but reuse `req_id` to remove a latent divergence point (the cancel filter keys off the body id, so any future drift would defeat cancellation filtering for paginated responses).

## Tests

- `tools/call`-with-nested-initialize does not capture a version
- non-scalar / null cancel `requestId` returns `None` (no unhashable crash); scalar ids pass through

Full suite: **900 passed, 3 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)