### PR TITLE
fix(oauth): harden the OAuth callback handler and reject non-finite expires_in

### DIFF
--- a/src/mcp_stdio/oauth.py
+++ b/src/mcp_stdio/oauth.py
@@ -6,6 +6,7 @@ import base64
 import hashlib
 import html
 import ipaddress
+import math
 import re
 import secrets
 import sys
@@ -980,6 +981,25 @@ def _make_callback_handler(
                 self.end_headers()
                 return
 
+            # Reject a Host header that is not the loopback callback (#5 round42):
+            # DNS-rebinding defense-in-depth (RFC 8252 §8.x native-app guidance).
+            # The server binds 127.0.0.1, so a legitimate browser redirect carries
+            # ``Host: 127.0.0.1:<port>`` (or localhost). A hostile page that rebound
+            # a hostname it controls to 127.0.0.1 to reach this callback would carry
+            # that hostname in Host; refuse it. The captured code is single-use and
+            # useless without the in-process PKCE verifier, so this only closes the
+            # class at negligible cost. Parse via urlparse("//host") so an IPv6
+            # ``[::1]:port`` / a portless Host / case are handled uniformly.
+            host_header = self.headers.get("Host", "")
+            try:
+                host_only = urlparse(f"//{host_header}").hostname
+            except ValueError:
+                host_only = None
+            if host_only not in ("127.0.0.1", "localhost", "::1"):
+                self.send_response(404)
+                self.end_headers()
+                return
+
             params = parse_qs(parsed.query)
 
             # Single-shot capture: once the first authorization response is
@@ -1002,18 +1022,27 @@ def _make_callback_handler(
                 )
                 return
 
+            # Write ordering matters (#4 round42): the main loop gates on
+            # ``cb_result.auth_code or cb_result.error`` and, the instant it
+            # observes either, breaks out and reads ``cb_result.state`` for the
+            # CSRF compare. CallbackResult is lock-free, so the CSRF-relevant
+            # fields (state / iss) MUST be stored BEFORE the gating field —
+            # otherwise a GIL switch between two separate attribute stores lets
+            # the main thread observe auth_code set while state is still None and
+            # spuriously fail the state compare (fails closed, but wrongly). Set
+            # the gating field LAST in each branch.
             if "error" in params:
-                result.error = params["error"][0]
                 # Capture state on the error branch too (#1 round35) so the flow
                 # can bind an error response to the CSRF state before acting on
                 # it. RFC 6749 §4.1.2.1 requires a compliant AS to echo `state`
                 # on error responses; an error callback WITHOUT the matching
                 # state is an unauthenticated abort attempt, not a real AS error.
                 result.state = params.get("state", [None])[0]
+                result.error = params["error"][0]  # gating field — set LAST
             elif "code" in params:
-                result.auth_code = params["code"][0]
                 result.state = params.get("state", [None])[0]
                 result.iss = params.get("iss", [None])[0]
+                result.auth_code = params["code"][0]  # gating field — set LAST
 
             self.send_response(200)
             self.send_header("Content-Type", "text/html")
@@ -1284,12 +1313,22 @@ def _token_response_to_data(
         # FRESHLY obtained token as already expired and immediately re-refresh /
         # re-run the whole flow instead of using it once. Treat it as "no expiry
         # advertised" (expires_at = None) and warn, rather than burning the token.
-        if expires_in is not None and expires_in > 0:
+        # #6 (round42): also reject a NON-FINITE expires_in. json.loads parses the
+        # non-standard literals Infinity / NaN by default, and `float("inf") > 0`
+        # is True — so without isfinite a hostile/buggy AS sending
+        # `"expires_in": Infinity` would set expires_at = now + inf = inf, and
+        # ensure_token's `expires_at > now + leeway` would then ALWAYS be True,
+        # pinning the token as eternally fresh and suppressing every future
+        # refresh. Mirrors _safe_int's finiteness defence on the device-flow path
+        # (which catches the OverflowError int(inf) raises) and token_store's
+        # cached-expiry isfinite check.
+        if expires_in is not None and math.isfinite(expires_in) and expires_in > 0:
             expires_at = time.time() + expires_in
         elif expires_in is not None:
             log(
-                f"warning: ignoring non-positive expires_in ({expires_in!r}); "
-                f"treating the token as having no advertised expiry"
+                f"warning: ignoring non-finite/non-positive expires_in "
+                f"({expires_in!r}); treating the token as having no advertised "
+                f"expiry"
             )
 
     # `.get(default)` only substitutes when the key is ABSENT; a provider that

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -2044,6 +2044,22 @@ class TestTokenResponseToData:
         data = _token_response_to_data(raw, meta, "cid", None)
         assert data.expires_at is None
 
+    @pytest.mark.parametrize(
+        "bad", [float("inf"), float("-inf"), float("nan"), "Infinity", "NaN"]
+    )
+    def test_non_finite_expires_in_degrades_to_none(self, bad):
+        """#6(round42): a non-finite expires_in (json.loads parses Infinity/NaN by
+        default) must be treated as 'no expiry advertised', NOT set expires_at to
+        inf/nan. float('inf') > 0 is True, so without the isfinite guard a hostile
+        AS could pin a token as eternally fresh and suppress every future refresh."""
+        raw = {"access_token": "at", "expires_in": bad}
+        meta = OAuthMetadata(
+            authorization_endpoint="https://ex.com/auth",
+            token_endpoint="https://ex.com/token",
+        )
+        data = _token_response_to_data(raw, meta, "cid", None)
+        assert data.expires_at is None
+
     def test_non_bearer_token_type_warns(self, capsys):
         """A non-Bearer token_type (DPoP/mac) is stored but warned about, since
         mcp-stdio always presents it as a Bearer credential."""
@@ -2477,6 +2493,86 @@ class TestCallbackServer:
         # The bogus codes must not have been captured
         assert cb_result.auth_code == "good_code"
         assert cb_result.state == "good_state"
+
+    def test_rejects_non_loopback_host_header(self):
+        """#5(round42): a request carrying a non-loopback Host header (a DNS-
+        rebinding attempt) is rejected 404 and captures nothing, even though it
+        reaches the loopback-bound server with a valid-looking code+state."""
+        cb_result = CallbackResult()
+        handler_cls = _make_callback_handler(cb_result)
+
+        from http.server import HTTPServer
+
+        server = HTTPServer(("127.0.0.1", 0), handler_cls)
+        port = server.server_address[1]
+        done = threading.Event()
+
+        def serve():
+            while not done.is_set():
+                server.handle_request()
+
+        t = threading.Thread(target=serve, daemon=True)
+        t.start()
+        time.sleep(0.3)
+
+        try:
+            resp = httpx.get(
+                f"http://127.0.0.1:{port}/callback?code=c&state=s",
+                headers={"Host": "evil.example.com"},
+            )
+            assert resp.status_code == 404
+            # A loopback Host is still accepted (allowlist includes localhost).
+            ok = httpx.get(
+                f"http://127.0.0.1:{port}/callback?code=good&state=s",
+                headers={"Host": f"localhost:{port}"},
+            )
+            assert ok.status_code == 200
+        finally:
+            done.set()
+            server.server_close()
+
+        # The rebinding attempt captured nothing; only the loopback hit did.
+        assert cb_result.auth_code == "good"
+
+    def test_callback_sets_csrf_fields_before_gating_auth_code(self):
+        """#4(round42): the handler must assign the CSRF fields (state/iss) BEFORE
+        the gating auth_code so the lock-free main loop never observes auth_code
+        set while state is still None — which would spuriously fail the constant-
+        time state compare. Verified by recording attribute-assignment order."""
+        order: list[str] = []
+
+        class RecordingResult(CallbackResult):
+            def __setattr__(self, name, value):
+                if name in ("state", "iss", "auth_code", "error"):
+                    order.append(name)
+                object.__setattr__(self, name, value)
+
+        cb_result = RecordingResult()
+        order.clear()  # ignore the dataclass __init__ default assignments
+        handler_cls = _make_callback_handler(cb_result)
+
+        from http.server import HTTPServer
+
+        server = HTTPServer(("127.0.0.1", 0), handler_cls)
+        port = server.server_address[1]
+        done = threading.Event()
+
+        def serve():
+            while not done.is_set():
+                server.handle_request()
+
+        t = threading.Thread(target=serve, daemon=True)
+        t.start()
+        time.sleep(0.3)
+
+        try:
+            httpx.get(f"http://127.0.0.1:{port}/callback?code=c&state=s&iss=https://x")
+        finally:
+            done.set()
+            server.server_close()
+
+        # The gating field (auth_code) is assigned LAST, after state and iss.
+        assert order == ["state", "iss", "auth_code"]
 
     def test_concurrent_flows_isolated(self):
         """Two callback handlers with separate result objects don't interfere."""


### PR DESCRIPTION
## Summary

Round-42 review fixes in `oauth.py`.

### CSRF write-ordering race (#4, low)
The lock-free callback handler set the gating field (`auth_code` / `error`) **before** the CSRF-relevant fields (`state` / `iss`). The main loop gates on `cb_result.auth_code or cb_result.error` and reads `cb_result.state` the instant it observes the gate, so a GIL switch between the two separate attribute stores could let it see `auth_code` set while `state` was still `None` — spuriously failing the constant-time state compare (fails closed, but wrongly aborts a valid flow). Assign `state`/`iss` **first**, the gating field **last** in each branch.

### DNS-rebinding defense-in-depth (#5, nit)
The loopback callback handler validated only the request **path**, never the `Host` header. The server binds `127.0.0.1`, so a legitimate browser redirect carries `Host: 127.0.0.1:<port>` (or `localhost`); reject any other Host (a hostile page that rebound a hostname to `127.0.0.1`) with 404 before recording anything. Negligible cost; the code is single-use and useless without the in-process PKCE verifier, so this just closes the class (RFC 8252 native-app guidance).

### Non-finite expires_in (#6, nit)
`_token_response_to_data` coerced `expires_in` with `float(...)` guarded only by `> 0`. `json.loads` parses `Infinity`/`NaN` by default and `float("inf") > 0` is True, so a hostile AS sending `"expires_in": Infinity` set `expires_at = now + inf = inf`, after which `expires_at > now + leeway` is **always** true — pinning the token as eternally fresh and suppressing every future refresh. Add a `math.isfinite` guard, mirroring `_safe_int`'s device-flow defence and `token_store`'s cached-expiry check.

## Tests

- callback assigns `state`/`iss` before `auth_code` (recorded assignment order)
- non-loopback `Host` is rejected 404, loopback accepted
- non-finite `expires_in` (`inf`/`-inf`/`nan`/`"Infinity"`/`"NaN"`) degrades to no-expiry

Full suite: **900 passed, 3 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)