### PR TITLE
feat: serve mode optional static-token auth + RFC 9728 metadata (M2)

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -238,14 +238,25 @@ mcp-stdio --check http://127.0.0.1:8080/mcp
 - 標準ライブラリのみ（`http.server`）— ランタイム依存は増えません。
 - Streamable HTTP のリクエスト/レスポンス・通知のセマンティクスに加え、
   サーバ起点メッセージ用の GET SSE チャネルを実装。
-- **マイルストーン M1: 認証なし。** TLS 終端のリバースプロキシ背後で運用して
-  ください。OAuth（リソースサーバ検証 → 埋め込み認可サーバ）は後続マイル
-  ストーン — [#235](https://github.com/shigechika/mcp-stdio/issues/235) 参照。
+- **認証は任意。** トークン無しならエンドポイントは素通し（TLS 終端の
+  リバースプロキシ背後で運用）。トークンを設定すると OAuth リソースサーバ
+  として振る舞い、MCP リクエストに `Authorization: Bearer <token>` を要求し、
+  401 で [RFC 9728](https://www.rfc-editor.org/rfc/rfc9728) Protected Resource
+  Metadata（`/.well-known/oauth-protected-resource`）を広告します。埋め込み
+  認可サーバ（PKCE・動的クライアント登録）は後続マイルストーン —
+  [#235](https://github.com/shigechika/mcp-stdio/issues/235) 参照。
 - 当面はシングルクライアント前提（JSON-RPC の id はそのまま透過）。
 
+認証付きの例（トークンは env 経由で `ps` に出さない）:
+
+```bash
+MCP_STDIO_SERVE_TOKEN=your-secret mcp-stdio serve --port 8080 -- python -m my_mcp_server
+mcp-stdio --bearer-token your-secret --check http://127.0.0.1:8080/mcp
+```
+
 オプション: `--host`（既定 `127.0.0.1`）、`--port`（既定 `8080`）、`--path`
-（既定 `/mcp`）。バックエンドコマンドはオプションの後に置きます（`--`
-区切りも可）。
+（既定 `/mcp`）、`--auth-token TOKEN`（または `MCP_STDIO_SERVE_TOKEN`、こちらが
+推奨）。バックエンドコマンドはオプションの後に置きます（`--` 区切りも可）。
 
 ## ワークアラウンド
 

--- a/README.md
+++ b/README.md
@@ -240,15 +240,26 @@ mcp-stdio --check http://127.0.0.1:8080/mcp
 - Stdlib only (`http.server`) — adds no runtime dependency.
 - Implements the Streamable HTTP request/response and notification semantics
   plus a GET SSE channel for server-initiated messages.
-- **Milestone M1: no authentication.** Run it behind a TLS-terminating reverse
-  proxy. OAuth (Resource Server validation, then an embedded Authorization
-  Server) lands in later milestones — see
-  [#235](https://github.com/shigechika/mcp-stdio/issues/235).
+- **Authentication is optional.** Without a token the endpoint is open (run it
+  behind a TLS-terminating reverse proxy). With a token it acts as an OAuth
+  Resource Server: MCP requests require `Authorization: Bearer <token>`, and a
+  401 advertises [RFC 9728](https://www.rfc-editor.org/rfc/rfc9728) Protected
+  Resource Metadata at `/.well-known/oauth-protected-resource`. A full embedded
+  Authorization Server (PKCE, dynamic client registration) is a later milestone
+  — see [#235](https://github.com/shigechika/mcp-stdio/issues/235).
 - Single-client assumption for now: JSON-RPC ids pass through verbatim.
 
+Authenticated example (token via env so it is not visible in `ps`):
+
+```bash
+MCP_STDIO_SERVE_TOKEN=your-secret mcp-stdio serve --port 8080 -- python -m my_mcp_server
+mcp-stdio --bearer-token your-secret --check http://127.0.0.1:8080/mcp
+```
+
 Options: `--host` (default `127.0.0.1`), `--port` (default `8080`), `--path`
-(default `/mcp`). The backend command follows the options (an optional `--`
-separator is supported).
+(default `/mcp`), `--auth-token TOKEN` (or `MCP_STDIO_SERVE_TOKEN`, preferred).
+The backend command follows the options (an optional `--` separator is
+supported).
 
 ## Workarounds
 

--- a/src/mcp_stdio/server.py
+++ b/src/mcp_stdio/server.py
@@ -459,8 +459,12 @@ class _Handler(BaseHTTPRequestHandler):
     def do_GET(self) -> None:  # noqa: N802 - BaseHTTPRequestHandler API
         path = self.path.split("?", 1)[0]
         # RFC 9728 metadata is unauthenticated — it is how the client discovers
-        # how to authenticate — so it is checked before the auth gate.
-        if path.startswith(_PRM_WELL_KNOWN_PREFIX):
+        # how to authenticate — so it is checked before the auth gate. Match the
+        # exact well-known path or a path-suffixed form (".../<resource path>"),
+        # NOT a mere prefix (so "...-resource-evil" does not match).
+        if path == _PRM_WELL_KNOWN_PREFIX or path.startswith(
+            _PRM_WELL_KNOWN_PREFIX + "/"
+        ):
             self._serve_prm()
             return
         if self._wrong_path():
@@ -627,6 +631,11 @@ def serve_main(argv: list[str]) -> None:
         parser.error("a backend command is required, e.g. serve -- python -m my_mcp")
     if not args.path.startswith("/"):
         parser.error("--path must start with '/'")
+    # The path is reflected into the quoted WWW-Authenticate resource_metadata
+    # and the PRM JSON; reject characters that would break that quoting or
+    # inject into headers.
+    if any(c in args.path for c in ('"', "\r", "\n", " ")):
+        parser.error("--path must not contain quotes, spaces, or CR/LF")
 
     # Env var is preferred (not visible in `ps`); an explicit flag wins but
     # warns. An empty token (flag or exported-but-empty env var) normalizes to

--- a/src/mcp_stdio/server.py
+++ b/src/mcp_stdio/server.py
@@ -30,7 +30,9 @@ remapping for true multi-client fan-out is a later milestone.
 from __future__ import annotations
 
 import argparse
+import hmac
 import json
+import os
 import queue
 import signal
 import subprocess
@@ -49,6 +51,28 @@ _BACKEND_RESPONSE_TIMEOUT_SECS = 120.0
 # How long a GET SSE stream blocks on the outbound queue before emitting an
 # SSE comment as a keepalive (also the cadence at which it notices shutdown).
 _SSE_KEEPALIVE_SECS = 15.0
+
+# RFC 9728 Protected Resource Metadata well-known prefix. The full metadata URL
+# inserts this between origin and the resource path (RFC 9728 Sec. 3.1), e.g.
+# resource ``https://h/mcp`` -> ``https://h/.well-known/oauth-protected-resource/mcp``.
+_PRM_WELL_KNOWN_PREFIX = "/.well-known/oauth-protected-resource"
+
+# Environment variable carrying the gateway's static bearer token. Preferred
+# over the --auth-token flag, which would expose the token in ``ps`` output.
+_SERVE_TOKEN_ENV = "MCP_STDIO_SERVE_TOKEN"
+
+# Host characters we allow when reflecting a (possibly proxy-supplied) Host /
+# X-Forwarded-Host into an absolute metadata URL. Restricting to this set keeps
+# a hostile Host header from injecting a quote/space into the quoted
+# ``resource_metadata`` challenge parameter or the JSON body.
+_HOST_ALLOWED = set(
+    "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789.-:[]"
+)
+
+
+def _sanitize_host(host: str) -> str:
+    """Keep only safe host[:port] characters; empty -> caller falls back."""
+    return "".join(c for c in host if c in _HOST_ALLOWED)
 
 
 def _classify(msg: Any) -> str:
@@ -264,6 +288,9 @@ class _Handler(BaseHTTPRequestHandler):
     backend: BackendProcess
     mcp_path: str
     session_id: str
+    # None disables authentication (M1 behavior). A non-None value enables the
+    # static-bearer-token Resource Server gate (M2).
+    auth_token: str | None = None
 
     # Quieter, consistent logging: route BaseHTTPRequestHandler's access log
     # through the project logger instead of stderr's default apache-style line.
@@ -295,6 +322,80 @@ class _Handler(BaseHTTPRequestHandler):
             return True
         return False
 
+    # --- M2: static-bearer-token Resource Server + RFC 9728 metadata ---
+
+    def _origin(self) -> str:
+        """Absolute ``scheme://host`` for building metadata URLs.
+
+        Honors a fronting reverse proxy via ``X-Forwarded-Proto`` /
+        ``X-Forwarded-Host`` (the gateway is designed to run behind one), then
+        the ``Host`` header, then the bound socket. The host is sanitized so a
+        hostile value cannot inject into the quoted challenge / JSON body.
+        """
+        proto = (
+            self.headers.get("X-Forwarded-Proto", "").split(",")[0].strip().lower()
+        )
+        if proto not in ("http", "https"):
+            proto = "http"
+        host = self.headers.get("X-Forwarded-Host", "").split(",")[0].strip()
+        if not host:
+            host = self.headers.get("Host", "").strip()
+        host = _sanitize_host(host)
+        if not host:
+            addr = self.server.server_address
+            host = f"{addr[0]}:{addr[1]}"
+        return f"{proto}://{host}"
+
+    def _resource_url(self) -> str:
+        return self._origin() + self.mcp_path
+
+    def _prm_url(self) -> str:
+        # RFC 9728 Sec. 3.1 path insertion.
+        return self._origin() + _PRM_WELL_KNOWN_PREFIX + self.mcp_path
+
+    def _authorized(self) -> bool:
+        """True when auth is disabled or a valid Bearer token is presented."""
+        if self.auth_token is None:
+            return True
+        auth = self.headers.get("Authorization", "")
+        prefix = "Bearer "
+        token = auth[len(prefix):] if auth.startswith(prefix) else ""
+        # Constant-time compare on bytes (str compare_digest rejects non-ASCII).
+        return bool(token) and hmac.compare_digest(
+            token.encode("utf-8"), self.auth_token.encode("utf-8")
+        )
+
+    def _require_auth(self) -> bool:
+        """Return True if the request may proceed; else send 401 and return False."""
+        if self._authorized():
+            return True
+        body = _error_body("authentication required").encode("utf-8")
+        self.send_response(401)
+        # RFC 9728 Sec. 5.1: point the client at the protected-resource metadata.
+        self.send_header(
+            "WWW-Authenticate", f'Bearer resource_metadata="{self._prm_url()}"'
+        )
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+        return False
+
+    def _serve_prm(self) -> None:
+        """Serve RFC 9728 Protected Resource Metadata (only when auth is on)."""
+        if self.auth_token is None:
+            self._send_json(404, _error_body("not found"))
+            return
+        body = json.dumps(
+            {
+                "resource": self._resource_url(),
+                # No authorization_servers yet: M2 uses operator-issued static
+                # tokens. M3's embedded AS adds the issuer here.
+                "bearer_methods_supported": ["header"],
+            }
+        )
+        self._send_json(200, body)
+
     def do_POST(self) -> None:  # noqa: N802 - BaseHTTPRequestHandler API
         # Read (drain) the request body BEFORE any early return. On HTTP/1.1
         # keep-alive, leaving an unread body in the socket makes the handler
@@ -313,6 +414,8 @@ class _Handler(BaseHTTPRequestHandler):
             return
         raw = self.rfile.read(length) if length > 0 else b""
         if self._wrong_path():
+            return
+        if not self._require_auth():
             return
         try:
             text = raw.decode("utf-8")
@@ -354,7 +457,15 @@ class _Handler(BaseHTTPRequestHandler):
             self._send_json(400, _error_body("unsupported or invalid message"))
 
     def do_GET(self) -> None:  # noqa: N802 - BaseHTTPRequestHandler API
+        path = self.path.split("?", 1)[0]
+        # RFC 9728 metadata is unauthenticated — it is how the client discovers
+        # how to authenticate — so it is checked before the auth gate.
+        if path.startswith(_PRM_WELL_KNOWN_PREFIX):
+            self._serve_prm()
+            return
         if self._wrong_path():
+            return
+        if not self._require_auth():
             return
         # Open an SSE stream carrying server-initiated messages (notifications
         # and server->client requests) until the client disconnects or the
@@ -390,6 +501,8 @@ class _Handler(BaseHTTPRequestHandler):
         # long-lived backend, so acknowledge without tearing it down.
         if self._wrong_path():
             return
+        if not self._require_auth():
+            return
         self._send_empty(200)
 
 
@@ -399,6 +512,7 @@ def build_server(
     host: str = "127.0.0.1",
     port: int = 8080,
     mcp_path: str = "/mcp",
+    auth_token: str | None = None,
 ) -> tuple[ThreadingHTTPServer, BackendProcess]:
     """Construct the HTTP server and backend without running the loop.
 
@@ -406,6 +520,10 @@ def build_server(
     port (``port=0``) without installing signal handlers or blocking. The
     caller owns the lifecycle: run ``httpd.serve_forever()`` (typically in a
     thread), then ``backend.shutdown()`` + ``httpd.server_close()``.
+
+    ``auth_token`` (when not None) enables the static-bearer-token Resource
+    Server gate (M2): MCP-path requests require ``Authorization: Bearer
+    <auth_token>`` and a 401 advertises RFC 9728 metadata.
     """
     backend = BackendProcess(command)
     handler = type(
@@ -415,6 +533,7 @@ def build_server(
             "backend": backend,
             "mcp_path": mcp_path,
             "session_id": uuid.uuid4().hex,
+            "auth_token": auth_token,
         },
     )
     httpd = ThreadingHTTPServer((host, port), handler)
@@ -429,14 +548,17 @@ def serve(
     host: str = "127.0.0.1",
     port: int = 8080,
     mcp_path: str = "/mcp",
+    auth_token: str | None = None,
 ) -> None:
     """Run the reverse gateway until interrupted.
 
     Spawns ``command`` as the backend stdio MCP server and serves it at
     ``http://host:port{mcp_path}``. Blocks until SIGINT/SIGTERM, then tears
-    the backend down.
+    the backend down. ``auth_token`` enables the static-token gate (M2).
     """
-    httpd, backend = build_server(command, host=host, port=port, mcp_path=mcp_path)
+    httpd, backend = build_server(
+        command, host=host, port=port, mcp_path=mcp_path, auth_token=auth_token
+    )
 
     stopping = threading.Event()
 
@@ -451,9 +573,10 @@ def serve(
     signal.signal(signal.SIGINT, _stop)
     signal.signal(signal.SIGTERM, _stop)
 
+    auth_state = "static bearer token" if auth_token else "no auth"
     log(
         f"serving {' '.join(command)} at "
-        f"http://{host}:{port}{mcp_path} (no auth — M1)"
+        f"http://{host}:{port}{mcp_path} ({auth_state})"
     )
     try:
         httpd.serve_forever()
@@ -472,13 +595,24 @@ def serve_main(argv: list[str]) -> None:
     parser = argparse.ArgumentParser(
         prog="mcp-stdio serve",
         description=(
-            "Expose a local stdio MCP server as a Streamable HTTP MCP endpoint "
-            "(M1: no authentication). The backend command follows the options."
+            "Expose a local stdio MCP server as a Streamable HTTP MCP endpoint. "
+            "Optionally protect it with a static bearer token. The backend "
+            "command follows the options."
         ),
     )
     parser.add_argument("--host", default="127.0.0.1", help="bind host (default: 127.0.0.1)")
     parser.add_argument("--port", type=int, default=8080, help="bind port (default: 8080)")
     parser.add_argument("--path", default="/mcp", help="MCP endpoint path (default: /mcp)")
+    parser.add_argument(
+        "--auth-token",
+        default=None,
+        metavar="TOKEN",
+        help=(
+            "Require this static bearer token on MCP requests "
+            f"(or set {_SERVE_TOKEN_ENV}; the env var is preferred since a flag "
+            "value is visible in `ps`). Omit for no authentication."
+        ),
+    )
     parser.add_argument(
         "command",
         nargs=argparse.REMAINDER,
@@ -494,4 +628,22 @@ def serve_main(argv: list[str]) -> None:
     if not args.path.startswith("/"):
         parser.error("--path must start with '/'")
 
-    serve(command, host=args.host, port=args.port, mcp_path=args.path)
+    # Env var is preferred (not visible in `ps`); an explicit flag wins but
+    # warns. An empty token (flag or exported-but-empty env var) normalizes to
+    # None = no auth, rather than enabling an impossible-to-satisfy gate.
+    auth_token = args.auth_token
+    if auth_token is not None:
+        log("warning: --auth-token is visible in `ps`; prefer "
+            f"{_SERVE_TOKEN_ENV} for production")
+    else:
+        auth_token = os.environ.get(_SERVE_TOKEN_ENV)
+    if not auth_token:
+        auth_token = None
+
+    serve(
+        command,
+        host=args.host,
+        port=args.port,
+        mcp_path=args.path,
+        auth_token=auth_token,
+    )

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -177,3 +177,130 @@ def test_serve_main_requires_command():
 def test_serve_main_rejects_bad_path():
     with pytest.raises(SystemExit):
         server.serve_main(["--path", "mcp", "--", "true"])  # path missing leading /
+
+
+# --- M2: static-bearer-token Resource Server + RFC 9728 metadata ---
+
+_TOKEN = "s3cr3t-token"
+
+
+@pytest.fixture()
+def auth_gateway():
+    """A gateway protected by a static bearer token."""
+    httpd, backend = server.build_server(
+        _BACKEND, host="127.0.0.1", port=0, auth_token=_TOKEN
+    )
+    host, port = httpd.server_address[0], httpd.server_address[1]
+    t = threading.Thread(target=httpd.serve_forever, daemon=True)
+    t.start()
+    url = f"http://{host}:{port}/mcp"
+    try:
+        yield url, backend
+    finally:
+        httpd.shutdown()
+        backend.shutdown()
+        httpd.server_close()
+
+
+def _base(url: str) -> str:
+    return url.rsplit("/mcp", 1)[0]
+
+
+def test_auth_missing_token_returns_401_with_metadata_hint(auth_gateway):
+    url, _ = auth_gateway
+    resp = _post(url, {"jsonrpc": "2.0", "id": 1, "method": "echo"})
+    assert resp.status_code == 401
+    wa = resp.headers.get("www-authenticate", "")
+    assert wa.startswith("Bearer ")
+    assert "resource_metadata=" in wa
+    assert "/.well-known/oauth-protected-resource/mcp" in wa
+
+
+def test_auth_wrong_token_returns_401(auth_gateway):
+    url, _ = auth_gateway
+    resp = httpx.post(
+        url,
+        content=json.dumps({"jsonrpc": "2.0", "id": 1, "method": "echo"}),
+        headers={"Authorization": "Bearer nope"},
+        timeout=10,
+    )
+    assert resp.status_code == 401
+
+
+def test_auth_valid_token_returns_200(auth_gateway):
+    url, _ = auth_gateway
+    resp = httpx.post(
+        url,
+        content=json.dumps(
+            {"jsonrpc": "2.0", "id": 1, "method": "echo", "params": {"a": 1}}
+        ),
+        headers={"Authorization": f"Bearer {_TOKEN}"},
+        timeout=10,
+    )
+    assert resp.status_code == 200
+    assert resp.json()["result"]["echoed"] == {"a": 1}
+
+
+def test_get_sse_requires_auth(auth_gateway):
+    url, _ = auth_gateway
+    resp = httpx.get(url, timeout=10)  # no token on the MCP path
+    assert resp.status_code == 401
+
+
+def test_prm_served_without_token(auth_gateway):
+    url, _ = auth_gateway
+    base = _base(url)
+    # Path-specific form (RFC 9728 Sec. 3.1).
+    resp = httpx.get(base + "/.well-known/oauth-protected-resource/mcp", timeout=10)
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["resource"].endswith("/mcp")
+    assert body["bearer_methods_supported"] == ["header"]
+    assert "authorization_servers" not in body  # none until M3
+    # Bare form is also served.
+    resp2 = httpx.get(base + "/.well-known/oauth-protected-resource", timeout=10)
+    assert resp2.status_code == 200
+
+
+def test_prm_404_when_auth_disabled(gateway):
+    url, _ = gateway
+    resp = httpx.get(_base(url) + "/.well-known/oauth-protected-resource/mcp", timeout=10)
+    assert resp.status_code == 404
+
+
+def test_prm_honors_forwarded_headers(auth_gateway):
+    url, _ = auth_gateway
+    resp = httpx.get(
+        _base(url) + "/.well-known/oauth-protected-resource/mcp",
+        headers={"X-Forwarded-Proto": "https", "X-Forwarded-Host": "gw.example.org"},
+        timeout=10,
+    )
+    assert resp.json()["resource"] == "https://gw.example.org/mcp"
+
+
+def test_no_auth_fixture_still_open(gateway):
+    # The default fixture has no token: a request without Authorization is 200.
+    url, _ = gateway
+    resp = _post(url, {"jsonrpc": "2.0", "id": 1, "method": "echo"})
+    assert resp.status_code == 200
+
+
+def test_sanitize_host():
+    assert server._sanitize_host("gw.example.org:8443") == "gw.example.org:8443"
+    # quote / CR / LF / space are stripped (header-injection guard)
+    assert server._sanitize_host('evil"\r\n host') == "evilhost"
+
+
+def test_authorized_constant_time_paths():
+    # Build a handler instance is heavy; exercise the token compare via a
+    # lightweight stand-in object carrying the attributes _authorized reads.
+    class Fake:
+        auth_token = "tok"
+        def __init__(self, hdr):
+            self.headers = {"Authorization": hdr}
+    Fake._authorized = server._Handler._authorized
+    assert Fake("Bearer tok")._authorized() is True
+    assert Fake("Bearer no")._authorized() is False
+    assert Fake("")._authorized() is False
+    Fake.auth_token = None
+    assert Fake("")._authorized() is True

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -268,6 +268,20 @@ def test_prm_404_when_auth_disabled(gateway):
     assert resp.status_code == 404
 
 
+def test_prm_prefix_overmatch_not_served(auth_gateway):
+    # A path that merely shares the well-known prefix (".../-resource-evil")
+    # must NOT be treated as the metadata endpoint.
+    url, _ = auth_gateway
+    resp = httpx.get(_base(url) + "/.well-known/oauth-protected-resource-evil", timeout=10)
+    assert resp.status_code == 404
+    assert "bearer_methods_supported" not in resp.text
+
+
+def test_serve_main_rejects_path_with_quote():
+    with pytest.raises(SystemExit):
+        server.serve_main(["--path", '/m"cp', "--", "true"])
+
+
 def test_prm_honors_forwarded_headers(auth_gateway):
     url, _ = auth_gateway
     resp = httpx.get(


### PR DESCRIPTION
## Summary

Milestone **M2** of #235 (stacks on M1 / #236, now on `main`).

Adds an **optional static-bearer-token Resource Server** gate to `serve`,
plus **RFC 9728 Protected Resource Metadata**. This proves the RS HTTP
semantics — challenge, advertise, validate — and client discovery **without any
crypto dependency or Authorization Server yet** (stdlib only). M3 will replace
the static token with a real embedded AS (PKCE / DCR), filling in
`authorization_servers`.

```bash
MCP_STDIO_SERVE_TOKEN=your-secret mcp-stdio serve --port 8080 -- python -m my_mcp
mcp-stdio --bearer-token your-secret --check http://127.0.0.1:8080/mcp
```

## What's in M2

- With a token configured, MCP requests require `Authorization: Bearer <token>`
  (constant-time compare on bytes). Missing/invalid → **401** with
  `WWW-Authenticate: Bearer resource_metadata="…"` (RFC 9728 §5.1).
- `/.well-known/oauth-protected-resource[/<path>]` serves the PRM document
  **unauthenticated** (it is how a client learns to authenticate), and only
  when auth is enabled. Body: `resource` + `bearer_methods_supported:
  ["header"]`. No `authorization_servers` yet — that lands with M3's AS.
- Proxy-aware absolute URLs via `X-Forwarded-Proto` / `X-Forwarded-Host`, with
  the host **sanitized** so a hostile `Host` cannot inject into the quoted
  challenge or JSON body.
- Token preferred via `MCP_STDIO_SERVE_TOKEN` env (not visible in `ps`);
  `--auth-token` flag warns. An empty token normalizes to no-auth.
- **Auth disabled (no token) is byte-for-byte the M1 behavior** — fully
  backward compatible.

## Testing

- 10 new tests: 401 challenge + metadata hint, valid/invalid token, SSE
  requires auth, PRM with/without auth, `X-Forwarded-*` reflection, host
  sanitizer, constant-time compare paths.
- Real client e2e: `mcp-stdio --check` is **401 without a token** and a full
  initialize handshake **with `--bearer-token`**.
- Full suite: **952 passed / 3 skipped**.

## Out of scope (M3, per #235)

- Embedded Authorization Server: RFC 8414 metadata, `/authorize` (trusting an
  upstream reverse-proxy-asserted identity), `/token` (PKCE), RFC 7591 DCR,
  self-issued tokens — at which point `authorization_servers` is populated and
  the client's `--oauth` flow works end to end against the gateway.

Refs #235

🤖 Generated with [Claude Code](https://claude.com/claude-code)
