### PR TITLE
feat: embedded OAuth 2.1 Authorization Server for serve mode

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -238,25 +238,43 @@ mcp-stdio --check http://127.0.0.1:8080/mcp
 - 標準ライブラリのみ（`http.server`）— ランタイム依存は増えません。
 - Streamable HTTP のリクエスト/レスポンス・通知のセマンティクスに加え、
   サーバ起点メッセージ用の GET SSE チャネルを実装。
-- **認証は任意。** トークン無しならエンドポイントは素通し（TLS 終端の
-  リバースプロキシ背後で運用）。トークンを設定すると OAuth リソースサーバ
-  として振る舞い、MCP リクエストに `Authorization: Bearer <token>` を要求し、
-  401 で [RFC 9728](https://www.rfc-editor.org/rfc/rfc9728) Protected Resource
-  Metadata（`/.well-known/oauth-protected-resource`）を広告します。埋め込み
-  認可サーバ（PKCE・動的クライアント登録）は後続マイルストーン —
-  [#235](https://github.com/shigechika/mcp-stdio/issues/235) 参照。
+- **認証は任意・段階的:**
+  - *トークン無し* — エンドポイントは素通し（TLS 終端プロキシ背後で運用）。
+  - *静的トークン*（`--auth-token` / `MCP_STDIO_SERVE_TOKEN`）— OAuth リソース
+    サーバとして `Authorization: Bearer <token>` を要求、401 で
+    [RFC 9728](https://www.rfc-editor.org/rfc/rfc9728) Protected Resource
+    Metadata（`/.well-known/oauth-protected-resource`）を広告。
+  - *埋め込み OAuth AS*（`--enable-oauth`）— 最小 OAuth 2.1 認可サーバ
+    （PKCE 認可コード・[RFC 7591](https://www.rfc-editor.org/rfc/rfc7591) 動的
+    クライアント登録・refresh・不透明インメモリトークン・stdlib のみ）。
+    mcp-stdio クライアントの `--oauth` がこのゲートウェイ相手に通ります。
 - 当面はシングルクライアント前提（JSON-RPC の id はそのまま透過）。
 
-認証付きの例（トークンは env 経由で `ps` に出さない）:
+静的トークンの例（トークンは env 経由で `ps` に出さない）:
 
 ```bash
 MCP_STDIO_SERVE_TOKEN=your-secret mcp-stdio serve --port 8080 -- python -m my_mcp_server
 mcp-stdio --bearer-token your-secret --check http://127.0.0.1:8080/mcp
 ```
 
+埋め込み OAuth の例。ユーザ認証は**前段リバースプロキシに委譲**し、ログイン
+済みユーザをヘッダで主張させます（`--trusted-user-header`、クライアント由来の
+同名ヘッダを除去するプロキシ背後でのみ信頼）。`--dev-user` はローカル検証用の
+**非セキュア**な loopback 限定ショートカットです:
+
+```bash
+mcp-stdio serve --enable-oauth --public-url http://127.0.0.1:8080 \
+  --dev-user alice --port 8080 -- python -m my_mcp_server
+mcp-stdio --oauth http://127.0.0.1:8080/mcp
+```
+
 オプション: `--host`（既定 `127.0.0.1`）、`--port`（既定 `8080`）、`--path`
-（既定 `/mcp`）、`--auth-token TOKEN`（または `MCP_STDIO_SERVE_TOKEN`、こちらが
-推奨）。バックエンドコマンドはオプションの後に置きます（`--` 区切りも可）。
+（既定 `/mcp`）、`--auth-token TOKEN`（または `MCP_STDIO_SERVE_TOKEN`、推奨）;
+埋め込み AS 用: `--enable-oauth`、`--public-url URL`（issuer 固定・プロキシ背後
+で推奨）、`--trusted-user-header HEADER`、`--dev-user USER`（非セキュア・検証用）、
+`--access-token-ttl SECONDS`。インメモリなので再起動で発行済みトークンは失効
+（クライアントは `--oauth` を再実行）。バックエンドコマンドはオプションの後に
+置きます（`--` 区切りも可）。
 
 ## ワークアラウンド
 

--- a/README.md
+++ b/README.md
@@ -240,26 +240,43 @@ mcp-stdio --check http://127.0.0.1:8080/mcp
 - Stdlib only (`http.server`) — adds no runtime dependency.
 - Implements the Streamable HTTP request/response and notification semantics
   plus a GET SSE channel for server-initiated messages.
-- **Authentication is optional.** Without a token the endpoint is open (run it
-  behind a TLS-terminating reverse proxy). With a token it acts as an OAuth
-  Resource Server: MCP requests require `Authorization: Bearer <token>`, and a
-  401 advertises [RFC 9728](https://www.rfc-editor.org/rfc/rfc9728) Protected
-  Resource Metadata at `/.well-known/oauth-protected-resource`. A full embedded
-  Authorization Server (PKCE, dynamic client registration) is a later milestone
-  — see [#235](https://github.com/shigechika/mcp-stdio/issues/235).
+- **Authentication is optional and layered:**
+  - *No token* — the endpoint is open (run it behind a TLS-terminating proxy).
+  - *Static token* (`--auth-token` / `MCP_STDIO_SERVE_TOKEN`) — acts as an OAuth
+    Resource Server: MCP requests require `Authorization: Bearer <token>`, and a
+    401 advertises [RFC 9728](https://www.rfc-editor.org/rfc/rfc9728) Protected
+    Resource Metadata at `/.well-known/oauth-protected-resource`.
+  - *Embedded OAuth AS* (`--enable-oauth`) — a minimal OAuth 2.1 Authorization
+    Server (PKCE auth-code, [RFC 7591](https://www.rfc-editor.org/rfc/rfc7591)
+    dynamic client registration, refresh, opaque in-memory tokens, stdlib only).
+    The mcp-stdio client's `--oauth` flow then works against the gateway.
 - Single-client assumption for now: JSON-RPC ids pass through verbatim.
 
-Authenticated example (token via env so it is not visible in `ps`):
+Static-token example (token via env so it is not visible in `ps`):
 
 ```bash
 MCP_STDIO_SERVE_TOKEN=your-secret mcp-stdio serve --port 8080 -- python -m my_mcp_server
 mcp-stdio --bearer-token your-secret --check http://127.0.0.1:8080/mcp
 ```
 
+Embedded-OAuth example. User authentication is **delegated to a fronting
+reverse proxy** that asserts the logged-in user via a header
+(`--trusted-user-header`, only trusted behind a proxy that strips client copies).
+`--dev-user` is an **insecure** loopback-only shortcut for local testing:
+
+```bash
+mcp-stdio serve --enable-oauth --public-url http://127.0.0.1:8080 \
+  --dev-user alice --port 8080 -- python -m my_mcp_server
+mcp-stdio --oauth http://127.0.0.1:8080/mcp
+```
+
 Options: `--host` (default `127.0.0.1`), `--port` (default `8080`), `--path`
-(default `/mcp`), `--auth-token TOKEN` (or `MCP_STDIO_SERVE_TOKEN`, preferred).
-The backend command follows the options (an optional `--` separator is
-supported).
+(default `/mcp`), `--auth-token TOKEN` (or `MCP_STDIO_SERVE_TOKEN`, preferred);
+and for the embedded AS: `--enable-oauth`, `--public-url URL` (pins the issuer;
+recommended behind a proxy), `--trusted-user-header HEADER`, `--dev-user USER`
+(insecure, testing only), `--access-token-ttl SECONDS`. In-memory tokens mean a
+restart invalidates issued tokens (the client re-runs `--oauth`). The backend
+command follows the options (an optional `--` separator is supported).
 
 ## Workarounds
 

--- a/src/mcp_stdio/server.py
+++ b/src/mcp_stdio/server.py
@@ -6,11 +6,11 @@ it spawns a local stdio MCP server as a child process and publishes it as a
 Streamable HTTP MCP endpoint, so clients that cannot spawn the server locally
 (a laptop without it installed, a remote bot) can reach it over the network.
 
-Milestone M1 (this file): a single backend, **no authentication**. The HTTP
+A single backend. Authentication is optional and layered: with no token the
+endpoint is open; ``--auth-token`` adds a static-bearer Resource Server gate;
+``--enable-oauth`` adds an embedded OAuth 2.1 Authorization Server. The HTTP
 surface implements the MCP Streamable HTTP transport's request/response and
 notification semantics plus a GET SSE channel for server-initiated messages.
-Authentication (Bearer/JWT validation as a Resource Server, then an embedded
-Authorization Server) layers on top in later milestones — see issue #235.
 
 Stdlib only (``http.server`` + ``subprocess`` + ``threading``), matching the
 project's httpx-only-runtime constraint: the server path adds no dependency.
@@ -21,10 +21,10 @@ stdout and routes each message — a response (id + result/error, no method)
 wakes the waiting HTTP handler keyed by the JSON-RPC id; anything
 server-initiated (carries ``method``) is queued for the GET SSE stream.
 
-M1 single-client assumption: JSON-RPC ids are passed through verbatim, so two
+Single-client assumption: JSON-RPC ids are passed through verbatim, so two
 distinct clients that happen to reuse the same id while sharing one backend
-could cross responses. M1 targets one logical client (e.g. one Claude); id
-remapping for true multi-client fan-out is a later milestone.
+could cross responses. This targets one logical client (e.g. one Claude); id
+remapping for true multi-client fan-out is left for later.
 """
 
 from __future__ import annotations
@@ -88,7 +88,7 @@ def _classify(msg: Any) -> str:
     ``"notification"`` (method, no id), ``"response"`` (id + result/error,
     no method — e.g. a client answering a server-initiated request), or
     ``"invalid"`` (anything else, including non-objects and batches, which
-    M1 does not handle).
+    not handled here).
     """
     if not isinstance(msg, dict):
         return "invalid"
@@ -145,8 +145,8 @@ class BackendProcess:
         # id -> single-slot holder {"event": Event, "line": str|None}
         self._pending: dict[Any, dict[str, Any]] = {}
         # Server-initiated messages (requests/notifications) awaiting an SSE
-        # consumer. Unbounded queue is acceptable for M1's single client; a
-        # later milestone can bound + shed.
+        # consumer. Unbounded queue is acceptable for the single-client model;
+        # a later change can bound + shed.
         self.server_initiated: "queue.Queue[str]" = queue.Queue()
         self._closed = threading.Event()
         self._reader = threading.Thread(
@@ -222,7 +222,7 @@ class BackendProcess:
             if self._closed.is_set():
                 return None
             # Reuse-of-an-in-flight-id is a client bug; last writer wins and the
-            # earlier waiter will time out. Acceptable for M1.
+            # earlier waiter will time out. Acceptable for the single-client model.
             self._pending[req_id] = slot
         if not self._write(line):
             with self._lock:
@@ -284,7 +284,7 @@ class BackendProcess:
             log(f"backend shutdown error: {e}")
 
 
-# --- M3: embedded OAuth 2.1 Authorization Server (stdlib only, opaque tokens) ---
+# --- embedded OAuth 2.1 Authorization Server (stdlib only, opaque tokens) ---
 
 _AS_METADATA_PATH = "/.well-known/oauth-authorization-server"
 _AUTHORIZE_PATH = "/authorize"
@@ -376,10 +376,14 @@ def _redact_query(line: str) -> str:
 
     OAuth /authorize requests carry the client's single-use CSRF ``state`` (and
     error redirects can echo it); the bundled client deliberately keeps that
-    nonce out of its own logs, so the gateway must not reintroduce it. MCP
-    requests carry no query, so blanket redaction is lossless here.
+    nonce out of its own logs, so the gateway must not reintroduce it. Every
+    ``?...`` run (up to whitespace or a quote) is redacted, covering BOTH the
+    origin-form ``/authorize?...`` and the absolute-form
+    ``http://host/authorize?...`` request targets (RFC 7230 allows the latter,
+    e.g. via a forwarding proxy). MCP requests carry no query, so this is
+    lossless here.
     """
-    return re.sub(r"(\s/[^\s?]*)\?\S*", r"\1?<redacted>", line)
+    return re.sub(r'\?[^\s"]*', "?<redacted>", line)
 
 
 class _OAuthProvider:
@@ -453,8 +457,7 @@ class _OAuthProvider:
         client_id = secrets.token_urlsafe(32)
         now = self._now()
         with self._lock:
-            if len(self._clients) >= _CLIENT_CAP:
-                self._gc_locked()
+            self._recycle_clients_locked()
             if len(self._clients) >= _CLIENT_CAP:
                 return bad("registration limit reached")
             self._clients[client_id] = {
@@ -653,8 +656,12 @@ class _OAuthProvider:
         for store in (self._codes, self._access, self._refresh):
             for k in [k for k, v in store.items() if v["expires_at"] < now]:
                 del store[k]
+
+    def _recycle_clients_locked(self) -> None:
         # Clients carry no TTL: recycle the oldest at the cap so /register never
         # permanently bricks (evict down to cap-1 to leave room for one insert).
+        # Called ONLY from register() so token-issuance GC never evicts a client
+        # that is not under registration pressure.
         if len(self._clients) >= _CLIENT_CAP:
             oldest = sorted(self._clients.items(), key=lambda kv: kv[1]["created_at"])
             for k, _ in oldest[: len(self._clients) - (_CLIENT_CAP - 1)]:
@@ -671,10 +678,10 @@ class _Handler(BaseHTTPRequestHandler):
     backend: BackendProcess
     mcp_path: str
     session_id: str
-    # None disables authentication (M1 behavior). A non-None value enables the
-    # static-bearer-token Resource Server gate (M2).
+    # None disables authentication. A non-None value enables the
+    # static-bearer-token Resource Server gate.
     auth_token: str | None = None
-    # None disables the embedded OAuth AS (M1/M2). A provider enables M3:
+    # None disables the embedded OAuth AS. A provider enables it:
     # /authorize /token /register + AS metadata + issued-token RS validation.
     oauth: _OAuthProvider | None = None
 
@@ -735,7 +742,7 @@ class _Handler(BaseHTTPRequestHandler):
             return True
         return False
 
-    # --- M2: static-bearer-token Resource Server + RFC 9728 metadata ---
+    # --- static-bearer-token Resource Server + RFC 9728 metadata ---
 
     def _origin(self) -> str:
         """Absolute ``scheme://host`` for building metadata URLs.
@@ -771,8 +778,8 @@ class _Handler(BaseHTTPRequestHandler):
     def _authorized(self) -> bool:
         """True when no auth is configured, or a valid Bearer token is presented.
 
-        Precedence: the M2 static token is checked first (constant-time, exempt
-        from expiry), then an M3 issued access token (lookup + expiry). The
+        Precedence: the static token is checked first (constant-time, exempt
+        from expiry), then an issued access token (lookup + expiry). The
         endpoint is open only when NEITHER mechanism is configured.
         """
         auth = self.headers.get("Authorization", "")
@@ -807,8 +814,8 @@ class _Handler(BaseHTTPRequestHandler):
     def _serve_prm(self) -> None:
         """Serve RFC 9728 Protected Resource Metadata when any auth is enabled.
 
-        ``authorization_servers`` is added ONLY when the embedded AS is on (M3);
-        a static-token-only deployment (M2) omits it.
+        ``authorization_servers`` is added ONLY when the embedded AS is on;
+        a static-token-only deployment omits it.
         """
         if self.auth_token is None and self.oauth is None:
             self._send_json(404, _error_body("not found"))
@@ -819,7 +826,7 @@ class _Handler(BaseHTTPRequestHandler):
         body["bearer_methods_supported"] = ["header"]
         self._send_json(200, json.dumps(body))
 
-    # --- M3: embedded OAuth AS endpoint handlers ---
+    # --- embedded OAuth AS endpoint handlers ---
 
     def _serve_as_metadata(self) -> None:
         """RFC 8414 Authorization Server Metadata."""
@@ -945,7 +952,7 @@ class _Handler(BaseHTTPRequestHandler):
             self.backend.send_oneway(json.dumps(msg))
             self._send_empty(202)
         else:
-            # Batches and malformed payloads are out of scope for M1.
+            # Batches and malformed payloads are out of scope here.
             self._send_json(400, _error_body("unsupported or invalid message"))
 
     def do_GET(self) -> None:  # noqa: N802 - BaseHTTPRequestHandler API
@@ -1002,7 +1009,7 @@ class _Handler(BaseHTTPRequestHandler):
             return
 
     def do_DELETE(self) -> None:  # noqa: N802 - BaseHTTPRequestHandler API
-        # MCP clients DELETE the endpoint to end a session. M1 has one
+        # MCP clients DELETE the endpoint to end a session. This gateway has one
         # long-lived backend, so acknowledge without tearing it down.
         if self._wrong_path():
             return
@@ -1028,8 +1035,8 @@ def build_server(
     thread), then ``backend.shutdown()`` + ``httpd.server_close()``.
 
     ``auth_token`` (when not None) enables the static-bearer-token Resource
-    Server gate (M2). ``oauth`` (when not None) enables the embedded OAuth
-    Authorization Server (M3): /authorize /token /register + AS metadata, and
+    Server gate. ``oauth`` (when not None) enables the embedded OAuth
+    Authorization Server: /authorize /token /register + AS metadata, and
     the RS gate then also accepts issued access tokens.
     """
     backend = BackendProcess(command)
@@ -1063,8 +1070,8 @@ def serve(
 
     Spawns ``command`` as the backend stdio MCP server and serves it at
     ``http://host:port{mcp_path}``. Blocks until SIGINT/SIGTERM, then tears
-    the backend down. ``auth_token`` enables the static-token gate (M2);
-    ``oauth`` enables the embedded Authorization Server (M3).
+    the backend down. ``auth_token`` enables the static-token gate;
+    ``oauth`` enables the embedded Authorization Server.
     """
     httpd, backend = build_server(
         command,
@@ -1212,7 +1219,7 @@ def serve_main(argv: list[str]) -> None:
     if not auth_token:
         auth_token = None
 
-    # --- embedded OAuth AS (M3) ---
+    # --- embedded OAuth AS setup ---
     oauth = None
     if args.dev_user is not None and not args.enable_oauth:
         parser.error("--dev-user requires --enable-oauth")

--- a/src/mcp_stdio/server.py
+++ b/src/mcp_stdio/server.py
@@ -30,16 +30,21 @@ remapping for true multi-client fan-out is a later milestone.
 from __future__ import annotations
 
 import argparse
+import base64
+import hashlib
 import hmac
 import json
 import os
 import queue
+import secrets
 import signal
 import subprocess
 import threading
+import time
 import uuid
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from typing import Any
+from urllib.parse import parse_qs, urlencode, urlsplit
 
 from .relay import log
 
@@ -278,6 +283,330 @@ class BackendProcess:
             log(f"backend shutdown error: {e}")
 
 
+# --- M3: embedded OAuth 2.1 Authorization Server (stdlib only, opaque tokens) ---
+
+_AS_METADATA_PATH = "/.well-known/oauth-authorization-server"
+_AUTHORIZE_PATH = "/authorize"
+_TOKEN_PATH = "/token"
+_REGISTER_PATH = "/register"
+
+_AUTH_CODE_TTL_SECS = 60.0
+_DEFAULT_ACCESS_TTL_SECS = 3600.0
+_REFRESH_TTL_SECS = 60.0 * 60.0 * 24.0 * 30.0  # 30 days
+_STORE_CAP = 10000  # per-store entry cap (DoS bound); GC runs before the cap
+_CLIENT_CAP = 1000
+
+_LOOPBACK_HOSTS = frozenset({"127.0.0.1", "::1", "localhost"})
+# RFC 7636 Sec. 4.1 code_verifier unreserved set.
+_PKCE_VERIFIER_CHARS = frozenset(
+    "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~"
+)
+
+
+def _pkce_s256_challenge(verifier: str) -> str:
+    """BASE64URL(SHA256(verifier)) without padding — byte-identical to the
+    client's ``oauth.generate_pkce`` so a correct verifier always matches."""
+    digest = hashlib.sha256(verifier.encode("ascii")).digest()
+    return base64.urlsafe_b64encode(digest).rstrip(b"=").decode("ascii")
+
+
+def _valid_code_verifier(v: str) -> bool:
+    return 43 <= len(v) <= 128 and all(c in _PKCE_VERIFIER_CHARS for c in v)
+
+
+def _redirect_key(uri: str) -> tuple[str, str, str] | None:
+    """RFC 8252 loopback redirect key (scheme, host, path), port-agnostic.
+
+    Returns None for anything that is not an ``http://`` loopback URI, or that
+    carries a fragment or CR/LF (open-redirect / response-splitting guard).
+    Comparing on this key lets a per-run ephemeral callback port still match a
+    registered client_id whose stored port differs (step-up reuse).
+    """
+    if "\r" in uri or "\n" in uri:
+        return None
+    try:
+        p = urlsplit(uri)
+    except ValueError:
+        return None
+    if p.fragment:
+        return None
+    host = (p.hostname or "").lower()
+    if p.scheme != "http" or host not in _LOOPBACK_HOSTS:
+        return None
+    return (p.scheme, host, p.path or "/")
+
+
+def _normalize_public_url(url: str) -> str:
+    """Normalize --public-url to a bare origin ``scheme://host[:port]``.
+
+    Raises ValueError on a non-http(s) URL, a missing host, userinfo, or
+    CR/LF/quote/space. The path/query/fragment are stripped — the OAuth issuer
+    MUST be the bare origin or the client cross-origin-rejects the metadata.
+    """
+    if any(c in url for c in ('"', "\r", "\n", " ")):
+        raise ValueError("public-url contains forbidden characters")
+    p = urlsplit(url)
+    if p.scheme not in ("http", "https") or not p.hostname:
+        raise ValueError("public-url must be an absolute http(s) URL with a host")
+    if "@" in p.netloc:
+        raise ValueError("public-url must not contain userinfo")
+    return f"{p.scheme}://{p.netloc}"
+
+
+class _OAuthProvider:
+    """Minimal OAuth 2.1 Authorization Server: DCR + authorization-code + PKCE
+    + refresh, with opaque in-memory tokens (no crypto dependency).
+
+    All four stores share one lock; ThreadingHTTPServer serves each request on
+    its own thread. ``now`` is injectable so tests can drive TTL expiry without
+    sleeping. ``public_url`` (bare origin) pins the issuer; when None the caller
+    passes a per-request reflected origin into the metadata builders.
+    """
+
+    def __init__(
+        self,
+        *,
+        public_url: str | None,
+        trusted_user_header: str | None,
+        dev_user: str | None,
+        access_ttl: float = _DEFAULT_ACCESS_TTL_SECS,
+        code_ttl: float = _AUTH_CODE_TTL_SECS,
+        refresh_ttl: float = _REFRESH_TTL_SECS,
+        now: Any = time.time,
+    ) -> None:
+        self.public_url = public_url
+        self.trusted_user_header = trusted_user_header
+        self.dev_user = dev_user
+        self.access_ttl = access_ttl
+        self.code_ttl = code_ttl
+        self.refresh_ttl = refresh_ttl
+        self._now = now
+        self._lock = threading.Lock()
+        self._clients: dict[str, dict[str, Any]] = {}
+        self._codes: dict[str, dict[str, Any]] = {}
+        self._access: dict[str, dict[str, Any]] = {}
+        self._refresh: dict[str, dict[str, Any]] = {}
+
+    # -- metadata --------------------------------------------------------
+
+    def metadata(self, issuer: str) -> dict[str, Any]:
+        return {
+            "issuer": issuer,
+            "authorization_endpoint": issuer + _AUTHORIZE_PATH,
+            "token_endpoint": issuer + _TOKEN_PATH,
+            "registration_endpoint": issuer + _REGISTER_PATH,
+            "response_types_supported": ["code"],
+            "grant_types_supported": ["authorization_code", "refresh_token"],
+            "code_challenge_methods_supported": ["S256"],
+            "token_endpoint_auth_methods_supported": ["none"],
+        }
+
+    # -- dynamic client registration (RFC 7591) --------------------------
+
+    def register(self, raw: bytes) -> tuple[int, dict[str, Any]]:
+        def bad(desc: str) -> tuple[int, dict[str, Any]]:
+            return 400, {"error": "invalid_client_metadata", "error_description": desc}
+
+        try:
+            body = json.loads(raw.decode("utf-8"))
+        except (UnicodeDecodeError, json.JSONDecodeError):
+            return bad("body must be JSON")
+        if not isinstance(body, dict):
+            return bad("body must be a JSON object")
+        uris = body.get("redirect_uris")
+        if not isinstance(uris, list) or not uris:
+            return bad("redirect_uris must be a non-empty array")
+        keys = set()
+        for u in uris:
+            if not isinstance(u, str) or _redirect_key(u) is None:
+                return bad("redirect_uris must be loopback http URLs")
+            keys.add(_redirect_key(u))
+        client_id = secrets.token_urlsafe(32)
+        now = self._now()
+        with self._lock:
+            if len(self._clients) >= _CLIENT_CAP:
+                self._gc_locked()
+            if len(self._clients) >= _CLIENT_CAP:
+                return bad("registration limit reached")
+            self._clients[client_id] = {
+                "redirect_keys": keys,
+                "redirect_uris": list(uris),
+                "created_at": now,
+            }
+        return 201, {
+            "client_id": client_id,
+            "redirect_uris": list(uris),
+            "token_endpoint_auth_method": "none",
+            "grant_types": ["authorization_code", "refresh_token"],
+            "response_types": ["code"],
+            "client_id_issued_at": int(now),
+        }
+
+    # -- authorization endpoint (RFC 6749 4.1 + RFC 7636) ----------------
+
+    def authorize(self, params: dict[str, str], user: str | None) -> dict[str, str]:
+        """Return an instruction dict for the handler.
+
+        ``{"kind": "bad_request", "message": ...}`` -> direct 400 (NO redirect,
+        per RFC 6749 4.1.2.1 for client_id/redirect_uri errors).
+        ``{"kind": "redirect", "location": ...}`` -> 302 (success, or an in-band
+        error whose Location carries error= + the echoed state).
+        """
+        cid = params.get("client_id", "")
+        redirect_uri = params.get("redirect_uri", "")
+        with self._lock:
+            client = self._clients.get(cid)
+        if not cid or client is None:
+            return {"kind": "bad_request", "message": "unknown or missing client_id"}
+        rk = _redirect_key(redirect_uri)
+        if rk is None or rk not in client["redirect_keys"]:
+            return {"kind": "bad_request", "message": "invalid redirect_uri"}
+
+        state = params.get("state", "")
+
+        def redirect(query: dict[str, str]) -> dict[str, str]:
+            if state:
+                query = {**query, "state": state}
+            return {"kind": "redirect", "location": redirect_uri + "?" + urlencode(query)}
+
+        if params.get("response_type") != "code":
+            return redirect({"error": "unsupported_response_type"})
+        challenge = params.get("code_challenge", "")
+        if not challenge:
+            return redirect(
+                {"error": "invalid_request", "error_description": "code_challenge required"}
+            )
+        if params.get("code_challenge_method") != "S256":
+            return redirect(
+                {"error": "invalid_request", "error_description": "code_challenge_method must be S256"}
+            )
+        if not user:
+            # Fail closed: never mint a code for an empty/anonymous user.
+            return redirect(
+                {"error": "access_denied", "error_description": "no authenticated user"}
+            )
+        code = secrets.token_urlsafe(32)
+        now = self._now()
+        with self._lock:
+            if len(self._codes) >= _STORE_CAP:
+                self._gc_locked()
+            self._codes[code] = {
+                "client_id": cid,
+                "redirect_uri": redirect_uri,
+                "code_challenge": challenge,
+                "user": user,
+                "scope": params.get("scope", ""),
+                "resource": params.get("resource"),
+                "expires_at": now + self.code_ttl,
+            }
+        return redirect({"code": code})
+
+    # -- token endpoint (RFC 6749 + RFC 7636) ----------------------------
+
+    def token(self, form: dict[str, str]) -> tuple[int, dict[str, Any]]:
+        grant = form.get("grant_type")
+        if grant == "authorization_code":
+            return self._token_auth_code(form)
+        if grant == "refresh_token":
+            return self._token_refresh(form)
+        return 400, {"error": "unsupported_grant_type"}
+
+    def _token_auth_code(self, form: dict[str, str]) -> tuple[int, dict[str, Any]]:
+        code = form.get("code", "")
+        if not code:
+            return 400, {"error": "invalid_request", "error_description": "missing code"}
+        now = self._now()
+        with self._lock:
+            # Single-use: POP before validating so a replay / concurrent
+            # double-POST sees None and cannot mint a second token.
+            entry = self._codes.pop(code, None)
+        if entry is None:
+            return 400, {"error": "invalid_grant", "error_description": "unknown or used code"}
+        if entry["expires_at"] < now:
+            return 400, {"error": "invalid_grant", "error_description": "code expired"}
+        if form.get("client_id") != entry["client_id"]:
+            return 400, {"error": "invalid_grant", "error_description": "client_id mismatch"}
+        if form.get("redirect_uri") != entry["redirect_uri"]:
+            return 400, {"error": "invalid_grant", "error_description": "redirect_uri mismatch"}
+        verifier = form.get("code_verifier", "")
+        if not _valid_code_verifier(verifier):
+            return 400, {"error": "invalid_request", "error_description": "invalid code_verifier"}
+        if not hmac.compare_digest(_pkce_s256_challenge(verifier), entry["code_challenge"]):
+            return 400, {"error": "invalid_grant", "error_description": "PKCE verification failed"}
+        return self._issue(entry["user"], entry["client_id"], entry["scope"], entry["resource"])
+
+    def _token_refresh(self, form: dict[str, str]) -> tuple[int, dict[str, Any]]:
+        rt = form.get("refresh_token", "")
+        if not rt:
+            return 400, {"error": "invalid_request", "error_description": "missing refresh_token"}
+        now = self._now()
+        with self._lock:
+            # Rotate: remove the presented refresh token now; a fresh one is
+            # issued by _issue (OAuth 2.1 / RFC 9700 rotation).
+            entry = self._refresh.pop(rt, None)
+        if entry is None:
+            return 400, {"error": "invalid_grant", "error_description": "unknown refresh_token"}
+        if entry["expires_at"] < now:
+            return 400, {"error": "invalid_grant", "error_description": "refresh_token expired"}
+        if form.get("client_id") != entry["client_id"]:
+            return 400, {"error": "invalid_grant", "error_description": "client_id mismatch"}
+        return self._issue(entry["user"], entry["client_id"], entry["scope"], entry["resource"])
+
+    def _issue(
+        self, user: str, client_id: str, scope: str, resource: str | None
+    ) -> tuple[int, dict[str, Any]]:
+        now = self._now()
+        access = secrets.token_urlsafe(32)
+        refresh = secrets.token_urlsafe(32)
+        with self._lock:
+            if len(self._access) >= _STORE_CAP or len(self._refresh) >= _STORE_CAP:
+                self._gc_locked()
+            self._access[access] = {
+                "user": user, "client_id": client_id, "scope": scope,
+                "resource": resource, "expires_at": now + self.access_ttl,
+            }
+            self._refresh[refresh] = {
+                "user": user, "client_id": client_id, "scope": scope,
+                "resource": resource, "expires_at": now + self.refresh_ttl,
+            }
+        body: dict[str, Any] = {
+            "access_token": access,
+            "token_type": "Bearer",
+            # Positive finite int strictly below the server TTL.
+            "expires_in": max(1, int(self.access_ttl) - 1),
+            "refresh_token": refresh,
+        }
+        if scope:
+            body["scope"] = scope
+        return 200, body
+
+    # -- resource-server validation --------------------------------------
+
+    def validate_access_token(self, token: str) -> bool:
+        """True if ``token`` is a live issued access token (lookup + expiry)."""
+        if not token:
+            return False
+        now = self._now()
+        with self._lock:
+            entry = self._access.get(token)
+            if entry is None:
+                return False
+            if entry["expires_at"] < now:
+                del self._access[token]
+                return False
+            return True
+
+    def _gc_locked(self) -> None:
+        now = self._now()
+        for store in (self._codes, self._access, self._refresh):
+            for k in [k for k, v in store.items() if v["expires_at"] < now]:
+                del store[k]
+        if len(self._clients) > _CLIENT_CAP:
+            oldest = sorted(self._clients.items(), key=lambda kv: kv[1]["created_at"])
+            for k, _ in oldest[: len(self._clients) - _CLIENT_CAP]:
+                del self._clients[k]
+
+
 class _Handler(BaseHTTPRequestHandler):
     """Streamable HTTP MCP endpoint backed by a single stdio child.
 
@@ -291,6 +620,9 @@ class _Handler(BaseHTTPRequestHandler):
     # None disables authentication (M1 behavior). A non-None value enables the
     # static-bearer-token Resource Server gate (M2).
     auth_token: str | None = None
+    # None disables the embedded OAuth AS (M1/M2). A provider enables M3:
+    # /authorize /token /register + AS metadata + issued-token RS validation.
+    oauth: _OAuthProvider | None = None
 
     # Quieter, consistent logging: route BaseHTTPRequestHandler's access log
     # through the project logger instead of stderr's default apache-style line.
@@ -313,6 +645,32 @@ class _Handler(BaseHTTPRequestHandler):
         self.send_header("Content-Length", "0")
         self.send_header("Mcp-Session-Id", self.session_id)
         self.end_headers()
+
+    def _send_oauth_json(self, status: int, body: str, *, no_store: bool = False) -> None:
+        """JSON response for OAuth endpoints (no Mcp-Session-Id header).
+
+        ``no_store`` adds the RFC 6749 Sec. 5.1/5.2 cache headers required on
+        token-endpoint responses.
+        """
+        data = body.encode("utf-8")
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(data)))
+        if no_store:
+            self.send_header("Cache-Control", "no-store")
+            self.send_header("Pragma", "no-cache")
+        self.end_headers()
+        self.wfile.write(data)
+
+    def _effective_issuer(self) -> str:
+        """The pinned --public-url origin, else the (reflected) request origin.
+
+        Drives the AS metadata issuer + endpoint URLs and the PRM
+        authorization_servers/resource so all three are byte-stable per request.
+        """
+        if self.oauth is not None and self.oauth.public_url:
+            return self.oauth.public_url
+        return self._origin()
 
     def _wrong_path(self) -> bool:
         # Compare only the path component; ignore any query string.
@@ -347,23 +705,31 @@ class _Handler(BaseHTTPRequestHandler):
         return f"{proto}://{host}"
 
     def _resource_url(self) -> str:
-        return self._origin() + self.mcp_path
+        return self._effective_issuer() + self.mcp_path
 
     def _prm_url(self) -> str:
         # RFC 9728 Sec. 3.1 path insertion.
         return self._origin() + _PRM_WELL_KNOWN_PREFIX + self.mcp_path
 
     def _authorized(self) -> bool:
-        """True when auth is disabled or a valid Bearer token is presented."""
-        if self.auth_token is None:
-            return True
+        """True when no auth is configured, or a valid Bearer token is presented.
+
+        Precedence: the M2 static token is checked first (constant-time, exempt
+        from expiry), then an M3 issued access token (lookup + expiry). The
+        endpoint is open only when NEITHER mechanism is configured.
+        """
         auth = self.headers.get("Authorization", "")
         prefix = "Bearer "
         token = auth[len(prefix):] if auth.startswith(prefix) else ""
-        # Constant-time compare on bytes (str compare_digest rejects non-ASCII).
-        return bool(token) and hmac.compare_digest(
-            token.encode("utf-8"), self.auth_token.encode("utf-8")
-        )
+        if (
+            self.auth_token is not None
+            and token
+            and hmac.compare_digest(token.encode("utf-8"), self.auth_token.encode("utf-8"))
+        ):
+            return True
+        if self.oauth is not None and token and self.oauth.validate_access_token(token):
+            return True
+        return self.auth_token is None and self.oauth is None
 
     def _require_auth(self) -> bool:
         """Return True if the request may proceed; else send 401 and return False."""
@@ -382,19 +748,78 @@ class _Handler(BaseHTTPRequestHandler):
         return False
 
     def _serve_prm(self) -> None:
-        """Serve RFC 9728 Protected Resource Metadata (only when auth is on)."""
-        if self.auth_token is None:
+        """Serve RFC 9728 Protected Resource Metadata when any auth is enabled.
+
+        ``authorization_servers`` is added ONLY when the embedded AS is on (M3);
+        a static-token-only deployment (M2) omits it.
+        """
+        if self.auth_token is None and self.oauth is None:
             self._send_json(404, _error_body("not found"))
             return
-        body = json.dumps(
-            {
-                "resource": self._resource_url(),
-                # No authorization_servers yet: M2 uses operator-issued static
-                # tokens. M3's embedded AS adds the issuer here.
-                "bearer_methods_supported": ["header"],
-            }
-        )
-        self._send_json(200, body)
+        body: dict[str, Any] = {"resource": self._resource_url()}
+        if self.oauth is not None:
+            body["authorization_servers"] = [self._effective_issuer()]
+        body["bearer_methods_supported"] = ["header"]
+        self._send_json(200, json.dumps(body))
+
+    # --- M3: embedded OAuth AS endpoint handlers ---
+
+    def _serve_as_metadata(self) -> None:
+        """RFC 8414 Authorization Server Metadata."""
+        self._send_oauth_json(200, json.dumps(self.oauth.metadata(self._effective_issuer())))
+
+    def _resolve_user(self) -> str | None:
+        """Identify the end user for /authorize. Fails closed.
+
+        Reads the operator-opted-in trusted header (set by a fronting proxy that
+        performed the real login), else falls back to --dev-user. With neither,
+        returns None and /authorize denies — never an anonymous user. The header
+        is trusted ONLY when --trusted-user-header is explicitly configured.
+        """
+        prov = self.oauth
+        if prov.trusted_user_header:
+            val = self.headers.get(prov.trusted_user_header, "")
+            val = val.strip()
+            if val and "\r" not in val and "\n" not in val and len(val) <= 256:
+                return val
+        return prov.dev_user or None
+
+    def _handle_register(self, raw: bytes) -> None:
+        status, body = self.oauth.register(raw)
+        self._send_oauth_json(status, json.dumps(body))
+
+    def _handle_token(self, raw: bytes) -> None:
+        try:
+            parsed = parse_qs(raw.decode("utf-8"), keep_blank_values=True)
+            form = {k: v[0] for k, v in parsed.items()}
+        except (UnicodeDecodeError, ValueError):
+            self._send_oauth_json(
+                400, json.dumps({"error": "invalid_request"}), no_store=True
+            )
+            return
+        status, body = self.oauth.token(form)
+        self._send_oauth_json(status, json.dumps(body), no_store=True)
+
+    def _handle_authorize(self) -> None:
+        query = urlsplit(self.path).query
+        parsed = parse_qs(query, keep_blank_values=True)
+        params = {k: v[0] for k, v in parsed.items()}
+        user = self._resolve_user()
+        result = self.oauth.authorize(params, user)
+        if result["kind"] == "bad_request":
+            self._send_oauth_json(
+                400,
+                json.dumps(
+                    {"error": "invalid_request", "error_description": result["message"]}
+                ),
+            )
+            return
+        # 302 to the validated redirect_uri (Location built via urlencode and a
+        # CR/LF-free, registered loopback redirect_uri — no injection surface).
+        self.send_response(302)
+        self.send_header("Location", result["location"])
+        self.send_header("Content-Length", "0")
+        self.end_headers()
 
     def do_POST(self) -> None:  # noqa: N802 - BaseHTTPRequestHandler API
         # Read (drain) the request body BEFORE any early return. On HTTP/1.1
@@ -413,6 +838,16 @@ class _Handler(BaseHTTPRequestHandler):
             self._send_json(400, _error_body("invalid Content-Length"))
             return
         raw = self.rfile.read(length) if length > 0 else b""
+        if self.oauth is not None:
+            # AS POST endpoints (DCR + token) bootstrap the token, exempt from
+            # the RS gate. Match by EXACT path. Body already drained above.
+            path = self.path.split("?", 1)[0]
+            if path == _REGISTER_PATH:
+                self._handle_register(raw)
+                return
+            if path == _TOKEN_PATH:
+                self._handle_token(raw)
+                return
         if self._wrong_path():
             return
         if not self._require_auth():
@@ -467,6 +902,15 @@ class _Handler(BaseHTTPRequestHandler):
         ):
             self._serve_prm()
             return
+        if self.oauth is not None:
+            # AS endpoints bootstrap the token, so they are exempt from the RS
+            # gate. Match by EXACT path (never prefix).
+            if path == _AS_METADATA_PATH:
+                self._serve_as_metadata()
+                return
+            if path == _AUTHORIZE_PATH:
+                self._handle_authorize()
+                return
         if self._wrong_path():
             return
         if not self._require_auth():
@@ -517,6 +961,7 @@ def build_server(
     port: int = 8080,
     mcp_path: str = "/mcp",
     auth_token: str | None = None,
+    oauth: _OAuthProvider | None = None,
 ) -> tuple[ThreadingHTTPServer, BackendProcess]:
     """Construct the HTTP server and backend without running the loop.
 
@@ -526,8 +971,9 @@ def build_server(
     thread), then ``backend.shutdown()`` + ``httpd.server_close()``.
 
     ``auth_token`` (when not None) enables the static-bearer-token Resource
-    Server gate (M2): MCP-path requests require ``Authorization: Bearer
-    <auth_token>`` and a 401 advertises RFC 9728 metadata.
+    Server gate (M2). ``oauth`` (when not None) enables the embedded OAuth
+    Authorization Server (M3): /authorize /token /register + AS metadata, and
+    the RS gate then also accepts issued access tokens.
     """
     backend = BackendProcess(command)
     handler = type(
@@ -538,6 +984,7 @@ def build_server(
             "mcp_path": mcp_path,
             "session_id": uuid.uuid4().hex,
             "auth_token": auth_token,
+            "oauth": oauth,
         },
     )
     httpd = ThreadingHTTPServer((host, port), handler)
@@ -553,15 +1000,22 @@ def serve(
     port: int = 8080,
     mcp_path: str = "/mcp",
     auth_token: str | None = None,
+    oauth: _OAuthProvider | None = None,
 ) -> None:
     """Run the reverse gateway until interrupted.
 
     Spawns ``command`` as the backend stdio MCP server and serves it at
     ``http://host:port{mcp_path}``. Blocks until SIGINT/SIGTERM, then tears
-    the backend down. ``auth_token`` enables the static-token gate (M2).
+    the backend down. ``auth_token`` enables the static-token gate (M2);
+    ``oauth`` enables the embedded Authorization Server (M3).
     """
     httpd, backend = build_server(
-        command, host=host, port=port, mcp_path=mcp_path, auth_token=auth_token
+        command,
+        host=host,
+        port=port,
+        mcp_path=mcp_path,
+        auth_token=auth_token,
+        oauth=oauth,
     )
 
     stopping = threading.Event()
@@ -577,7 +1031,12 @@ def serve(
     signal.signal(signal.SIGINT, _stop)
     signal.signal(signal.SIGTERM, _stop)
 
-    auth_state = "static bearer token" if auth_token else "no auth"
+    modes = []
+    if auth_token:
+        modes.append("static bearer token")
+    if oauth is not None:
+        modes.append("embedded OAuth AS")
+    auth_state = " + ".join(modes) if modes else "no auth"
     log(
         f"serving {' '.join(command)} at "
         f"http://{host}:{port}{mcp_path} ({auth_state})"
@@ -618,6 +1077,53 @@ def serve_main(argv: list[str]) -> None:
         ),
     )
     parser.add_argument(
+        "--enable-oauth",
+        action="store_true",
+        help=(
+            "Enable the embedded OAuth 2.1 Authorization Server (PKCE auth-code, "
+            "dynamic client registration, refresh). MCP requests then require an "
+            "issued bearer token; the mcp-stdio client's --oauth flow works "
+            "against this gateway."
+        ),
+    )
+    parser.add_argument(
+        "--public-url",
+        default=None,
+        metavar="URL",
+        help=(
+            "Canonical external origin (e.g. https://gw.example.org) used to pin "
+            "the OAuth issuer and all endpoint URLs. Strongly recommended behind "
+            "a reverse proxy; normalized to a bare origin (path stripped)."
+        ),
+    )
+    parser.add_argument(
+        "--trusted-user-header",
+        default=None,
+        metavar="HEADER",
+        help=(
+            "Trust this request header as the authenticated user at /authorize "
+            "(e.g. X-Forwarded-User). ONLY safe behind a reverse proxy that "
+            "STRIPS any client-supplied copy. Off by default (fails closed)."
+        ),
+    )
+    parser.add_argument(
+        "--dev-user",
+        default=None,
+        metavar="USER",
+        help=(
+            "INSECURE local-testing identity for /authorize when no trusted "
+            "header is present. For loopback smoke tests only; never a real "
+            "auth boundary."
+        ),
+    )
+    parser.add_argument(
+        "--access-token-ttl",
+        type=int,
+        default=int(_DEFAULT_ACCESS_TTL_SECS),
+        metavar="SECONDS",
+        help="Issued access-token lifetime in seconds (default: 3600).",
+    )
+    parser.add_argument(
         "command",
         nargs=argparse.REMAINDER,
         help="backend stdio MCP server command (after the options)",
@@ -649,10 +1155,49 @@ def serve_main(argv: list[str]) -> None:
     if not auth_token:
         auth_token = None
 
+    # --- embedded OAuth AS (M3) ---
+    oauth = None
+    if args.dev_user is not None and not args.enable_oauth:
+        parser.error("--dev-user requires --enable-oauth")
+    if args.trusted_user_header is not None and any(
+        c in args.trusted_user_header for c in (" ", "\r", "\n", ":")
+    ):
+        parser.error("--trusted-user-header must be a valid header name")
+    if args.access_token_ttl <= 0:
+        parser.error("--access-token-ttl must be > 0")
+    if args.enable_oauth:
+        public_url = None
+        if args.public_url is not None:
+            try:
+                public_url = _normalize_public_url(args.public_url)
+            except ValueError as e:
+                parser.error(f"--public-url invalid: {e}")
+            if public_url != args.public_url.rstrip("/"):
+                log(f"note: --public-url normalized to origin {public_url}")
+        else:
+            log(
+                "warning: --enable-oauth without --public-url; the issuer is "
+                "reflected from the request Host. Set --public-url behind a proxy."
+            )
+        if args.trusted_user_header is None and args.dev_user is None:
+            log(
+                "warning: --enable-oauth without --trusted-user-header or "
+                "--dev-user; /authorize will deny all users (no identity source)."
+            )
+        if args.dev_user is not None:
+            log("warning: --dev-user is INSECURE; for loopback testing only")
+        oauth = _OAuthProvider(
+            public_url=public_url,
+            trusted_user_header=args.trusted_user_header,
+            dev_user=args.dev_user,
+            access_ttl=float(args.access_token_ttl),
+        )
+
     serve(
         command,
         host=args.host,
         port=args.port,
         mcp_path=args.path,
         auth_token=auth_token,
+        oauth=oauth,
     )

--- a/src/mcp_stdio/server.py
+++ b/src/mcp_stdio/server.py
@@ -36,6 +36,7 @@ import hmac
 import json
 import os
 import queue
+import re
 import secrets
 import signal
 import subprocess
@@ -318,9 +319,12 @@ def _redirect_key(uri: str) -> tuple[str, str, str] | None:
     """RFC 8252 loopback redirect key (scheme, host, path), port-agnostic.
 
     Returns None for anything that is not an ``http://`` loopback URI, or that
-    carries a fragment or CR/LF (open-redirect / response-splitting guard).
-    Comparing on this key lets a per-run ephemeral callback port still match a
-    registered client_id whose stored port differs (step-up reuse).
+    carries a fragment, query, userinfo, or CR/LF. Comparing on this key lets a
+    per-run ephemeral callback port still match a registered client_id whose
+    stored port differs (step-up reuse). The query is rejected (not just
+    ignored): the key drops it, so accepting it would let the raw redirect_uri
+    be reflected into a malformed double-``?`` Location and smuggle a second
+    identity behind one registered (scheme, host, path).
     """
     if "\r" in uri or "\n" in uri:
         return None
@@ -328,7 +332,7 @@ def _redirect_key(uri: str) -> tuple[str, str, str] | None:
         p = urlsplit(uri)
     except ValueError:
         return None
-    if p.fragment:
+    if p.fragment or p.query or p.username or p.password or "@" in p.netloc:
         return None
     host = (p.hostname or "").lower()
     if p.scheme != "http" or host not in _LOOPBACK_HOSTS:
@@ -337,20 +341,45 @@ def _redirect_key(uri: str) -> tuple[str, str, str] | None:
 
 
 def _normalize_public_url(url: str) -> str:
-    """Normalize --public-url to a bare origin ``scheme://host[:port]``.
+    """Normalize --public-url to a canonical bare origin ``scheme://host[:port]``.
 
-    Raises ValueError on a non-http(s) URL, a missing host, userinfo, or
-    CR/LF/quote/space. The path/query/fragment are stripped — the OAuth issuer
-    MUST be the bare origin or the client cross-origin-rejects the metadata.
+    Raises ValueError on a non-http(s) URL, a missing host, userinfo,
+    CR/LF/quote/space, or a non-loopback ``http://`` (a compliant client refuses
+    cleartext non-loopback endpoints). The host is lowercased, an explicit
+    default port is dropped, and an IPv6 literal is re-bracketed, so the issuer
+    is byte-identical to what a client derives (RFC 8414 Sec. 3.3). The
+    path/query/fragment are stripped — the OAuth issuer MUST be the bare origin
+    or the client cross-origin-rejects the metadata.
     """
     if any(c in url for c in ('"', "\r", "\n", " ")):
         raise ValueError("public-url contains forbidden characters")
     p = urlsplit(url)
     if p.scheme not in ("http", "https") or not p.hostname:
         raise ValueError("public-url must be an absolute http(s) URL with a host")
-    if "@" in p.netloc:
+    if p.username or p.password or "@" in p.netloc:
         raise ValueError("public-url must not contain userinfo")
-    return f"{p.scheme}://{p.netloc}"
+    host = p.hostname.lower()
+    if p.scheme == "http" and host not in _LOOPBACK_HOSTS:
+        raise ValueError("a non-loopback public-url must use https")
+    try:
+        port = p.port
+    except ValueError as e:
+        raise ValueError("public-url has an invalid port") from e
+    hostpart = f"[{host}]" if ":" in host else host
+    default_port = 80 if p.scheme == "http" else 443
+    netloc = hostpart if (port is None or port == default_port) else f"{hostpart}:{port}"
+    return f"{p.scheme}://{netloc}"
+
+
+def _redact_query(line: str) -> str:
+    """Redact query strings from an access-log line.
+
+    OAuth /authorize requests carry the client's single-use CSRF ``state`` (and
+    error redirects can echo it); the bundled client deliberately keeps that
+    nonce out of its own logs, so the gateway must not reintroduce it. MCP
+    requests carry no query, so blanket redaction is lossless here.
+    """
+    return re.sub(r"(\s/[^\s?]*)\?\S*", r"\1?<redacted>", line)
 
 
 class _OAuthProvider:
@@ -490,6 +519,7 @@ class _OAuthProvider:
         with self._lock:
             if len(self._codes) >= _STORE_CAP:
                 self._gc_locked()
+                self._evict_to_capacity_locked(self._codes, _STORE_CAP)
             self._codes[code] = {
                 "client_id": cid,
                 "redirect_uri": redirect_uri,
@@ -509,6 +539,10 @@ class _OAuthProvider:
             return self._token_auth_code(form)
         if grant == "refresh_token":
             return self._token_refresh(form)
+        if not grant:
+            # RFC 6749 Sec. 5.2: a missing required parameter is invalid_request,
+            # not unsupported_grant_type (which is for an unrecognized value).
+            return 400, {"error": "invalid_request", "error_description": "missing grant_type"}
         return 400, {"error": "unsupported_grant_type"}
 
     def _token_auth_code(self, form: dict[str, str]) -> tuple[int, dict[str, Any]]:
@@ -541,15 +575,20 @@ class _OAuthProvider:
             return 400, {"error": "invalid_request", "error_description": "missing refresh_token"}
         now = self._now()
         with self._lock:
-            # Rotate: remove the presented refresh token now; a fresh one is
-            # issued by _issue (OAuth 2.1 / RFC 9700 rotation).
-            entry = self._refresh.pop(rt, None)
-        if entry is None:
-            return 400, {"error": "invalid_grant", "error_description": "unknown refresh_token"}
-        if entry["expires_at"] < now:
-            return 400, {"error": "invalid_grant", "error_description": "refresh_token expired"}
-        if form.get("client_id") != entry["client_id"]:
-            return 400, {"error": "invalid_grant", "error_description": "client_id mismatch"}
+            # Validate BEFORE mutating: only consume (rotate) the token once it
+            # passes. A wrong/blank client_id must NOT destroy an otherwise-valid
+            # 30-day token. Single-use still holds because the successful delete
+            # happens under this same lock, so a concurrent double-submit of the
+            # same valid token finds None on the second pass.
+            entry = self._refresh.get(rt)
+            if entry is None:
+                return 400, {"error": "invalid_grant", "error_description": "unknown refresh_token"}
+            if entry["expires_at"] < now:
+                del self._refresh[rt]
+                return 400, {"error": "invalid_grant", "error_description": "refresh_token expired"}
+            if form.get("client_id") != entry["client_id"]:
+                return 400, {"error": "invalid_grant", "error_description": "client_id mismatch"}
+            del self._refresh[rt]  # consume on success (RFC 9700 rotation)
         return self._issue(entry["user"], entry["client_id"], entry["scope"], entry["resource"])
 
     def _issue(
@@ -561,6 +600,8 @@ class _OAuthProvider:
         with self._lock:
             if len(self._access) >= _STORE_CAP or len(self._refresh) >= _STORE_CAP:
                 self._gc_locked()
+                self._evict_to_capacity_locked(self._access, _STORE_CAP)
+                self._evict_to_capacity_locked(self._refresh, _STORE_CAP)
             self._access[access] = {
                 "user": user, "client_id": client_id, "scope": scope,
                 "resource": resource, "expires_at": now + self.access_ttl,
@@ -596,14 +637,27 @@ class _OAuthProvider:
                 return False
             return True
 
+    def _evict_to_capacity_locked(self, store: dict[str, dict[str, Any]], cap: int) -> None:
+        """Hard-bound a TTL store: if still at the cap after GC, evict the
+        soonest-expiring entries to make room. GC alone frees nothing when every
+        entry is still live, so without this the cap is not a real bound."""
+        overflow = len(store) - (cap - 1)
+        if overflow <= 0:
+            return
+        victims = sorted(store.items(), key=lambda kv: kv[1]["expires_at"])
+        for k, _ in victims[:overflow]:
+            del store[k]
+
     def _gc_locked(self) -> None:
         now = self._now()
         for store in (self._codes, self._access, self._refresh):
             for k in [k for k, v in store.items() if v["expires_at"] < now]:
                 del store[k]
-        if len(self._clients) > _CLIENT_CAP:
+        # Clients carry no TTL: recycle the oldest at the cap so /register never
+        # permanently bricks (evict down to cap-1 to leave room for one insert).
+        if len(self._clients) >= _CLIENT_CAP:
             oldest = sorted(self._clients.items(), key=lambda kv: kv[1]["created_at"])
-            for k, _ in oldest[: len(self._clients) - _CLIENT_CAP]:
+            for k, _ in oldest[: len(self._clients) - (_CLIENT_CAP - 1)]:
                 del self._clients[k]
 
 
@@ -627,7 +681,8 @@ class _Handler(BaseHTTPRequestHandler):
     # Quieter, consistent logging: route BaseHTTPRequestHandler's access log
     # through the project logger instead of stderr's default apache-style line.
     def log_message(self, fmt: str, *args: Any) -> None:
-        log("http: " + (fmt % args))
+        # Redact query strings (OAuth state / code never belong in shared logs).
+        log("http: " + _redact_query(fmt % args))
 
     protocol_version = "HTTP/1.1"
 
@@ -708,8 +763,10 @@ class _Handler(BaseHTTPRequestHandler):
         return self._effective_issuer() + self.mcp_path
 
     def _prm_url(self) -> str:
-        # RFC 9728 Sec. 3.1 path insertion.
-        return self._origin() + _PRM_WELL_KNOWN_PREFIX + self.mcp_path
+        # RFC 9728 Sec. 3.1 path insertion. Use the effective issuer (pinned
+        # --public-url when set) so the 401 hint, the PRM document, and the AS
+        # metadata all advertise the same origin behind a proxy.
+        return self._effective_issuer() + _PRM_WELL_KNOWN_PREFIX + self.mcp_path
 
     def _authorized(self) -> bool:
         """True when no auth is configured, or a valid Bearer token is presented.

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -700,8 +700,12 @@ def test_public_url_pins_issuer():
 
 def test_normalize_public_url():
     assert server._normalize_public_url("https://gw.example.org/mcp") == "https://gw.example.org"
-    assert server._normalize_public_url("http://h:8080") == "http://h:8080"
-    for bad in ("ftp://h", "https://", 'https://h"x', "https://user@h"):
+    assert server._normalize_public_url("http://127.0.0.1:8080") == "http://127.0.0.1:8080"
+    # canonicalization: lowercase host, drop explicit default port
+    assert server._normalize_public_url("https://EXAMPLE.com:443/x") == "https://example.com"
+    assert server._normalize_public_url("http://LOCALHOST:80") == "http://localhost"
+    for bad in ("ftp://h", "https://", 'https://h"x', "https://user@h",
+                "http://gw.example.org"):  # non-loopback http is rejected
         with pytest.raises(ValueError):
             server._normalize_public_url(bad)
 
@@ -755,3 +759,82 @@ def test_real_client_ensure_token(monkeypatch, tmp_path):
                        content=json.dumps({"jsonrpc": "2.0", "id": 1, "method": "echo"}),
                        headers={"Authorization": f"Bearer {td.access_token}"}, timeout=10)
         assert r.status_code == 200
+
+
+# --- M3 adversarial-review fixes ---
+
+def test_store_cap_is_a_hard_bound(monkeypatch):
+    # GC frees only expired entries; the cap must still bound live tokens.
+    monkeypatch.setattr(server, "_STORE_CAP", 5)
+    prov = _provider()
+    for i in range(30):
+        prov._issue(f"u{i}", "c", "", None)
+    assert len(prov._access) <= 5
+    assert len(prov._refresh) <= 5
+
+
+def test_client_cap_recycles_not_bricks(monkeypatch):
+    # /register must never permanently lock out: at the cap the oldest client
+    # is recycled rather than rejected.
+    monkeypatch.setattr(server, "_CLIENT_CAP", 3)
+    prov = _provider()
+    last = None
+    for i in range(8):
+        status, body = prov.register(
+            json.dumps({"redirect_uris": [f"http://127.0.0.1:{1000 + i}/callback"]}).encode()
+        )
+        assert status == 201, body
+        last = body["client_id"]
+    assert len(prov._clients) <= 3
+    assert last in prov._clients  # newest registration survives
+
+
+def test_redirect_key_rejects_query_userinfo_fragment():
+    assert server._redirect_key("http://127.0.0.1:5/cb") == ("http", "127.0.0.1", "/cb")
+    assert server._redirect_key("http://127.0.0.1:5/cb?next=x") is None
+    assert server._redirect_key("http://u:p@127.0.0.1:5/cb") is None
+    assert server._redirect_key("http://127.0.0.1:5/cb#frag") is None
+    assert server._redirect_key("https://127.0.0.1:5/cb") is None
+    assert server._redirect_key("http://evil.example.com/cb") is None
+
+
+def test_register_rejects_query_bearing_redirect(oauth_gateway):
+    base, _ = oauth_gateway
+    r = _register(base, redirect="http://127.0.0.1:5555/callback?next=x")
+    assert r.status_code == 400
+    assert r.json()["error"] == "invalid_client_metadata"
+
+
+def test_refresh_wrong_client_id_preserves_token(oauth_gateway):
+    base, _ = oauth_gateway
+    cid, _, _, _, tok = _full_flow(base)
+    rt = tok.json()["refresh_token"]
+    # a wrong client_id must be rejected WITHOUT destroying the valid token
+    bad = _token(base, {"grant_type": "refresh_token", "refresh_token": rt, "client_id": "wrong"})
+    assert bad.status_code == 400 and bad.json()["error"] == "invalid_grant"
+    good = _token(base, {"grant_type": "refresh_token", "refresh_token": rt, "client_id": cid})
+    assert good.status_code == 200
+
+
+def test_token_missing_grant_is_invalid_request(oauth_gateway):
+    base, _ = oauth_gateway
+    r = _token(base, {"foo": "bar"})
+    assert r.status_code == 400
+    assert r.json()["error"] == "invalid_request"
+
+
+def test_401_hint_uses_pinned_issuer():
+    with _run(oauth=_provider(public_url="https://gw.example.org")) as (base, _):
+        r = httpx.post(base + "/mcp",
+                       content=json.dumps({"jsonrpc": "2.0", "id": 1, "method": "echo"}), timeout=10)
+        assert r.status_code == 401
+        assert ('resource_metadata="https://gw.example.org/.well-known/'
+                'oauth-protected-resource/mcp"') in r.headers["www-authenticate"]
+
+
+def test_redact_query():
+    out = server._redact_query('"GET /authorize?state=SECRET&x=1 HTTP/1.1" 302 -')
+    assert out == '"GET /authorize?<redacted> HTTP/1.1" 302 -'
+    assert "SECRET" not in out
+    # a query-less line is unchanged
+    assert server._redact_query('"POST /mcp HTTP/1.1" 200 -') == '"POST /mcp HTTP/1.1" 200 -'

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -183,7 +183,7 @@ def test_serve_main_rejects_bad_path():
         server.serve_main(["--path", "mcp", "--", "true"])  # path missing leading /
 
 
-# --- M2: static-bearer-token Resource Server + RFC 9728 metadata ---
+# --- static-bearer-token Resource Server + RFC 9728 metadata ---
 
 _TOKEN = "s3cr3t-token"
 
@@ -260,7 +260,7 @@ def test_prm_served_without_token(auth_gateway):
     body = resp.json()
     assert body["resource"].endswith("/mcp")
     assert body["bearer_methods_supported"] == ["header"]
-    assert "authorization_servers" not in body  # none until M3
+    assert "authorization_servers" not in body  # none without the embedded AS
     # Bare form is also served.
     resp2 = httpx.get(base + "/.well-known/oauth-protected-resource", timeout=10)
     assert resp2.status_code == 200
@@ -325,7 +325,7 @@ def test_authorized_constant_time_paths():
     assert Fake("")._authorized() is True
 
 
-# --- M3: embedded OAuth 2.1 Authorization Server ---
+# --- embedded OAuth 2.1 Authorization Server ---
 
 _REDIRECT = "http://127.0.0.1:5555/callback"
 
@@ -761,7 +761,7 @@ def test_real_client_ensure_token(monkeypatch, tmp_path):
         assert r.status_code == 200
 
 
-# --- M3 adversarial-review fixes ---
+# --- adversarial-review fixes ---
 
 def test_store_cap_is_a_hard_bound(monkeypatch):
     # GC frees only expired entries; the cap must still bound live tokens.
@@ -836,5 +836,35 @@ def test_redact_query():
     out = server._redact_query('"GET /authorize?state=SECRET&x=1 HTTP/1.1" 302 -')
     assert out == '"GET /authorize?<redacted> HTTP/1.1" 302 -'
     assert "SECRET" not in out
+    # absolute-form request target (RFC 7230, e.g. via a forwarding proxy) too
+    out2 = server._redact_query(
+        '"GET http://gw.example.org/authorize?state=SECRET&code=ABC HTTP/1.1" 404 -'
+    )
+    assert out2 == '"GET http://gw.example.org/authorize?<redacted> HTTP/1.1" 404 -'
+    assert "SECRET" not in out2 and "ABC" not in out2
     # a query-less line is unchanged
     assert server._redact_query('"POST /mcp HTTP/1.1" 200 -') == '"POST /mcp HTTP/1.1" 200 -'
+
+
+def test_concurrent_refresh_single_use(oauth_gateway):
+    # The same refresh token submitted concurrently must rotate exactly once.
+    base, _ = oauth_gateway
+    cid, _, _, _, tok = _full_flow(base)
+    rt = tok.json()["refresh_token"]
+    data = {"grant_type": "refresh_token", "refresh_token": rt, "client_id": cid}
+    with ThreadPoolExecutor(max_workers=8) as ex:
+        codes = list(ex.map(lambda _: _token(base, data).status_code, range(8)))
+    assert codes.count(200) == 1
+    assert codes.count(400) == 7
+
+
+def test_refresh_token_expires():
+    clock = [1000.0]
+    prov = _provider(refresh_ttl=50, now=lambda: clock[0])
+    with _run(oauth=prov) as (base, _):
+        cid, _, _, _, tok = _full_flow(base)
+        rt = tok.json()["refresh_token"]
+        clock[0] += 100  # advance past refresh_ttl
+        r = _token(base, {"grant_type": "refresh_token", "refresh_token": rt, "client_id": cid})
+        assert r.status_code == 400
+        assert r.json()["error"] == "invalid_grant"

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -2,15 +2,19 @@
 
 from __future__ import annotations
 
+import contextlib
 import json
 import os
 import sys
 import threading
 import time
+from concurrent.futures import ThreadPoolExecutor
+from urllib.parse import parse_qs, urlsplit
 
 import httpx
 import pytest
 
+from mcp_stdio import oauth as client_oauth
 from mcp_stdio import server
 
 _BACKEND = [sys.executable, os.path.join(os.path.dirname(__file__), "_fake_backend.py")]
@@ -310,6 +314,7 @@ def test_authorized_constant_time_paths():
     # lightweight stand-in object carrying the attributes _authorized reads.
     class Fake:
         auth_token = "tok"
+        oauth = None
         def __init__(self, hdr):
             self.headers = {"Authorization": hdr}
     Fake._authorized = server._Handler._authorized
@@ -318,3 +323,435 @@ def test_authorized_constant_time_paths():
     assert Fake("")._authorized() is False
     Fake.auth_token = None
     assert Fake("")._authorized() is True
+
+
+# --- M3: embedded OAuth 2.1 Authorization Server ---
+
+_REDIRECT = "http://127.0.0.1:5555/callback"
+
+
+@contextlib.contextmanager
+def _run(*, auth_token=None, oauth=None):
+    """Start a gateway with the given auth config; yield (base_url, backend)."""
+    httpd, backend = server.build_server(
+        _BACKEND, host="127.0.0.1", port=0, auth_token=auth_token, oauth=oauth
+    )
+    host, port = httpd.server_address[0], httpd.server_address[1]
+    t = threading.Thread(target=httpd.serve_forever, daemon=True)
+    t.start()
+    try:
+        yield f"http://{host}:{port}", backend
+    finally:
+        httpd.shutdown()
+        backend.shutdown()
+        httpd.server_close()
+
+
+def _provider(**kw):
+    kw.setdefault("public_url", None)
+    kw.setdefault("trusted_user_header", None)
+    kw.setdefault("dev_user", "alice")
+    return server._OAuthProvider(**kw)
+
+
+@pytest.fixture()
+def oauth_gateway():
+    """A gateway with the embedded AS enabled and --dev-user=alice."""
+    with _run(oauth=_provider()) as (base, backend):
+        yield base, backend
+
+
+def _register(base, redirect=_REDIRECT):
+    return httpx.post(
+        base + "/register",
+        json={
+            "client_name": "test",
+            "redirect_uris": [redirect],
+            "response_types": ["code"],
+            "grant_types": ["authorization_code", "refresh_token"],
+            "token_endpoint_auth_method": "none",
+        },
+        timeout=10,
+    )
+
+
+def _authorize(base, client_id, challenge, *, redirect=_REDIRECT, state="st-123",
+               method="S256", response_type="code", headers=None, drop=None):
+    params = {
+        "client_id": client_id,
+        "response_type": response_type,
+        "redirect_uri": redirect,
+        "state": state,
+        "code_challenge": challenge,
+        "code_challenge_method": method,
+        "resource": base + "/mcp",
+    }
+    for k in (drop or []):
+        params.pop(k, None)
+    return httpx.get(base + "/authorize", params=params, headers=headers or {},
+                     follow_redirects=False, timeout=10)
+
+
+def _redirect_params(resp):
+    return {k: v[0] for k, v in parse_qs(urlsplit(resp.headers["location"]).query).items()}
+
+
+def _token(base, data):
+    return httpx.post(base + "/token", data=data, timeout=10)
+
+
+def _full_flow(base, redirect=_REDIRECT, headers=None):
+    cid = _register(base, redirect).json()["client_id"]
+    verifier, challenge = client_oauth.generate_pkce()
+    az = _authorize(base, cid, challenge, redirect=redirect, headers=headers)
+    assert az.status_code == 302, az.text
+    code = _redirect_params(az)["code"]
+    tok = _token(base, {
+        "grant_type": "authorization_code", "code": code,
+        "redirect_uri": redirect, "client_id": cid, "code_verifier": verifier,
+    })
+    return cid, verifier, challenge, code, tok
+
+
+# -- metadata / registration --
+
+def test_pkce_s256_matches_client():
+    # The server transform MUST equal what the client's generate_pkce produced.
+    verifier, challenge = client_oauth.generate_pkce()
+    assert server._pkce_s256_challenge(verifier) == challenge
+
+
+def test_as_metadata(oauth_gateway):
+    base, _ = oauth_gateway
+    md = httpx.get(base + "/.well-known/oauth-authorization-server", timeout=10).json()
+    assert md["issuer"].startswith("http://127.0.0.1:")
+    assert md["authorization_endpoint"] == md["issuer"] + "/authorize"
+    assert md["token_endpoint"] == md["issuer"] + "/token"
+    assert md["registration_endpoint"] == md["issuer"] + "/register"
+    assert md["response_types_supported"] == ["code"]
+    assert md["code_challenge_methods_supported"] == ["S256"]
+    assert md["token_endpoint_auth_methods_supported"] == ["none"]
+
+
+def test_prm_has_authorization_servers_when_oauth(oauth_gateway):
+    base, _ = oauth_gateway
+    prm = httpx.get(base + "/.well-known/oauth-protected-resource/mcp", timeout=10).json()
+    assert prm["authorization_servers"] == [prm["resource"].rsplit("/mcp", 1)[0]]
+
+
+def test_register_public_client(oauth_gateway):
+    base, _ = oauth_gateway
+    r = _register(base)
+    assert r.status_code == 201
+    body = r.json()
+    assert isinstance(body["client_id"], str) and body["client_id"]
+    assert "client_secret" not in body
+    assert body["token_endpoint_auth_method"] == "none"
+
+
+def test_register_rejects_non_loopback(oauth_gateway):
+    base, _ = oauth_gateway
+    r = _register(base, redirect="https://evil.example.com/callback")
+    assert r.status_code == 400
+    assert r.json()["error"] == "invalid_client_metadata"
+
+
+def test_register_rejects_non_json(oauth_gateway):
+    base, _ = oauth_gateway
+    r = httpx.post(base + "/register", content="not json", timeout=10)
+    assert r.status_code == 400
+
+
+# -- full flow + RS --
+
+def test_full_auth_code_flow_and_use_token(oauth_gateway):
+    base, _ = oauth_gateway
+    cid, verifier, challenge, code, tok = _full_flow(base)
+    assert tok.status_code == 200, tok.text
+    body = tok.json()
+    assert body["token_type"] == "Bearer"
+    assert isinstance(body["access_token"], str) and body["access_token"]
+    assert body["expires_in"] > 0
+    assert body["refresh_token"]
+    assert tok.headers.get("cache-control") == "no-store"
+    # use the issued token on an MCP request
+    r = httpx.post(base + "/mcp",
+                   content=json.dumps({"jsonrpc": "2.0", "id": 1, "method": "echo", "params": {"x": 1}}),
+                   headers={"Authorization": f"Bearer {body['access_token']}"}, timeout=10)
+    assert r.status_code == 200
+    assert r.json()["result"]["echoed"] == {"x": 1}
+    # without the token -> 401
+    r2 = httpx.post(base + "/mcp",
+                    content=json.dumps({"jsonrpc": "2.0", "id": 2, "method": "echo"}), timeout=10)
+    assert r2.status_code == 401
+
+
+def test_redirect_uri_port_agnostic(oauth_gateway):
+    # RFC 8252: registered :5555, authorize with :6666 (same scheme/host/path) ok.
+    base, _ = oauth_gateway
+    cid = _register(base, "http://127.0.0.1:5555/callback").json()["client_id"]
+    verifier, challenge = client_oauth.generate_pkce()
+    az = _authorize(base, cid, challenge, redirect="http://127.0.0.1:6666/callback")
+    assert az.status_code == 302
+
+
+# -- authorize negatives --
+
+def test_authorize_unknown_client_400_no_redirect(oauth_gateway):
+    base, _ = oauth_gateway
+    _, challenge = client_oauth.generate_pkce()
+    az = _authorize(base, "nope", challenge)
+    assert az.status_code == 400  # NOT a redirect (RFC 6749 4.1.2.1)
+
+
+def test_authorize_bad_redirect_uri_400(oauth_gateway):
+    base, _ = oauth_gateway
+    cid = _register(base).json()["client_id"]
+    _, challenge = client_oauth.generate_pkce()
+    az = _authorize(base, cid, challenge, redirect="http://127.0.0.1:5555/evil")
+    assert az.status_code == 400
+
+
+def test_authorize_missing_code_challenge_redirects_error(oauth_gateway):
+    base, _ = oauth_gateway
+    cid = _register(base).json()["client_id"]
+    az = _authorize(base, cid, "x", drop=["code_challenge"])
+    assert az.status_code == 302
+    p = _redirect_params(az)
+    assert p["error"] == "invalid_request"
+    assert p["state"] == "st-123"  # state echoed on error
+
+
+def test_authorize_plain_method_rejected(oauth_gateway):
+    base, _ = oauth_gateway
+    cid = _register(base).json()["client_id"]
+    _, challenge = client_oauth.generate_pkce()
+    az = _authorize(base, cid, challenge, method="plain")
+    assert az.status_code == 302
+    assert _redirect_params(az)["error"] == "invalid_request"
+
+
+def test_authorize_unsupported_response_type(oauth_gateway):
+    base, _ = oauth_gateway
+    cid = _register(base).json()["client_id"]
+    _, challenge = client_oauth.generate_pkce()
+    az = _authorize(base, cid, challenge, response_type="token")
+    assert az.status_code == 302
+    assert _redirect_params(az)["error"] == "unsupported_response_type"
+
+
+def test_authorize_fail_closed_without_user():
+    # No dev_user, no trusted header: a client-set X-Forwarded-User must NOT
+    # authenticate -> access_denied (never mint a code for a spoofed user).
+    with _run(oauth=_provider(dev_user=None)) as (base, _):
+        cid = _register(base).json()["client_id"]
+        _, challenge = client_oauth.generate_pkce()
+        az = _authorize(base, cid, challenge, headers={"X-Forwarded-User": "attacker"})
+        assert az.status_code == 302
+        assert _redirect_params(az)["error"] == "access_denied"
+
+
+def test_trusted_header_used_when_configured():
+    with _run(oauth=_provider(dev_user=None, trusted_user_header="X-Forwarded-User")) as (base, _):
+        cid = _register(base).json()["client_id"]
+        _, challenge = client_oauth.generate_pkce()
+        az = _authorize(base, cid, challenge, headers={"X-Forwarded-User": "bob"})
+        assert az.status_code == 302
+        assert "code" in _redirect_params(az)
+
+
+# -- token negatives --
+
+def test_token_pkce_mismatch_invalid_grant(oauth_gateway):
+    base, _ = oauth_gateway
+    cid = _register(base).json()["client_id"]
+    _, challenge = client_oauth.generate_pkce()
+    az = _authorize(base, cid, challenge)
+    code = _redirect_params(az)["code"]
+    bad_verifier = "B" * 64
+    r = _token(base, {"grant_type": "authorization_code", "code": code,
+                      "redirect_uri": _REDIRECT, "client_id": cid, "code_verifier": bad_verifier})
+    assert r.status_code == 400
+    assert r.json()["error"] == "invalid_grant"
+
+
+def test_token_code_replay_invalid_grant(oauth_gateway):
+    base, _ = oauth_gateway
+    cid, verifier, challenge, code, tok = _full_flow(base)
+    assert tok.status_code == 200
+    # replay the same code
+    r = _token(base, {"grant_type": "authorization_code", "code": code,
+                      "redirect_uri": _REDIRECT, "client_id": cid, "code_verifier": verifier})
+    assert r.status_code == 400
+    assert r.json()["error"] == "invalid_grant"
+
+
+def test_token_redirect_uri_mismatch(oauth_gateway):
+    base, _ = oauth_gateway
+    cid = _register(base).json()["client_id"]
+    verifier, challenge = client_oauth.generate_pkce()
+    az = _authorize(base, cid, challenge)
+    code = _redirect_params(az)["code"]
+    r = _token(base, {"grant_type": "authorization_code", "code": code,
+                      "redirect_uri": "http://127.0.0.1:9999/callback", "client_id": cid,
+                      "code_verifier": verifier})
+    assert r.status_code == 400
+    assert r.json()["error"] == "invalid_grant"
+
+
+def test_token_unsupported_grant(oauth_gateway):
+    base, _ = oauth_gateway
+    r = _token(base, {"grant_type": "password", "username": "x"})
+    assert r.status_code == 400
+    assert r.json()["error"] == "unsupported_grant_type"
+
+
+def test_token_missing_grant(oauth_gateway):
+    base, _ = oauth_gateway
+    r = _token(base, {"foo": "bar"})
+    assert r.status_code == 400
+
+
+def test_refresh_rotates(oauth_gateway):
+    base, _ = oauth_gateway
+    cid, verifier, challenge, code, tok = _full_flow(base)
+    rt = tok.json()["refresh_token"]
+    r = _token(base, {"grant_type": "refresh_token", "refresh_token": rt, "client_id": cid})
+    assert r.status_code == 200
+    assert r.json()["access_token"]
+    new_rt = r.json()["refresh_token"]
+    assert new_rt and new_rt != rt
+    # old refresh token is invalidated (rotation)
+    again = _token(base, {"grant_type": "refresh_token", "refresh_token": rt, "client_id": cid})
+    assert again.status_code == 400
+
+
+def test_concurrent_token_single_use(oauth_gateway):
+    base, _ = oauth_gateway
+    cid = _register(base).json()["client_id"]
+    verifier, challenge = client_oauth.generate_pkce()
+    az = _authorize(base, cid, challenge)
+    code = _redirect_params(az)["code"]
+    data = {"grant_type": "authorization_code", "code": code, "redirect_uri": _REDIRECT,
+            "client_id": cid, "code_verifier": verifier}
+    with ThreadPoolExecutor(max_workers=8) as ex:
+        results = list(ex.map(lambda _: _token(base, data).status_code, range(8)))
+    assert results.count(200) == 1
+    assert results.count(400) == 7
+
+
+def test_issued_token_expires():
+    clock = [1000.0]
+    prov = _provider(access_ttl=30, now=lambda: clock[0])
+    with _run(oauth=prov) as (base, _):
+        _, _, _, _, tok = _full_flow(base)
+        at = tok.json()["access_token"]
+        ok = httpx.post(base + "/mcp",
+                        content=json.dumps({"jsonrpc": "2.0", "id": 1, "method": "echo"}),
+                        headers={"Authorization": f"Bearer {at}"}, timeout=10)
+        assert ok.status_code == 200
+        clock[0] += 100  # advance past TTL
+        expired = httpx.post(base + "/mcp",
+                             content=json.dumps({"jsonrpc": "2.0", "id": 2, "method": "echo"}),
+                             headers={"Authorization": f"Bearer {at}"}, timeout=10)
+        assert expired.status_code == 401
+
+
+# -- coexistence / disabled --
+
+def test_coexistence_static_and_oauth():
+    with _run(auth_token="static-tok", oauth=_provider()) as (base, _):
+        # static token authorizes
+        r1 = httpx.post(base + "/mcp",
+                        content=json.dumps({"jsonrpc": "2.0", "id": 1, "method": "echo"}),
+                        headers={"Authorization": "Bearer static-tok"}, timeout=10)
+        assert r1.status_code == 200
+        # issued token authorizes
+        _, _, _, _, tok = _full_flow(base)
+        at = tok.json()["access_token"]
+        r2 = httpx.post(base + "/mcp",
+                        content=json.dumps({"jsonrpc": "2.0", "id": 2, "method": "echo"}),
+                        headers={"Authorization": f"Bearer {at}"}, timeout=10)
+        assert r2.status_code == 200
+        # PRM advertises authorization_servers
+        prm = httpx.get(base + "/.well-known/oauth-protected-resource/mcp", timeout=10).json()
+        assert "authorization_servers" in prm
+
+
+def test_as_endpoints_404_when_disabled(gateway):
+    url, _ = gateway
+    base = _base(url)
+    for p in ("/.well-known/oauth-authorization-server", "/authorize"):
+        assert httpx.get(base + p, timeout=10).status_code == 404
+    for p in ("/register", "/token"):
+        assert httpx.post(base + p, content="{}", timeout=10).status_code == 404
+
+
+# -- issuer pinning --
+
+def test_public_url_pins_issuer():
+    with _run(oauth=_provider(public_url="https://gw.example.org")) as (base, _):
+        md = httpx.get(base + "/.well-known/oauth-authorization-server", timeout=10).json()
+        assert md["issuer"] == "https://gw.example.org"
+        assert md["authorization_endpoint"] == "https://gw.example.org/authorize"
+        prm = httpx.get(base + "/.well-known/oauth-protected-resource/mcp", timeout=10).json()
+        assert prm["authorization_servers"] == ["https://gw.example.org"]
+
+
+def test_normalize_public_url():
+    assert server._normalize_public_url("https://gw.example.org/mcp") == "https://gw.example.org"
+    assert server._normalize_public_url("http://h:8080") == "http://h:8080"
+    for bad in ("ftp://h", "https://", 'https://h"x', "https://user@h"):
+        with pytest.raises(ValueError):
+            server._normalize_public_url(bad)
+
+
+# -- CLI flag validation (error paths return before serve() blocks) --
+
+def test_serve_main_dev_user_requires_oauth():
+    with pytest.raises(SystemExit):
+        server.serve_main(["--dev-user", "x", "--", "true"])
+
+
+def test_serve_main_bad_public_url():
+    with pytest.raises(SystemExit):
+        server.serve_main(["--enable-oauth", "--public-url", "ftp://x", "--dev-user", "a", "--", "true"])
+
+
+def test_serve_main_bad_trusted_header():
+    with pytest.raises(SystemExit):
+        server.serve_main(["--enable-oauth", "--trusted-user-header", "bad header", "--", "true"])
+
+
+# -- real-client interop: drive mcp_stdio.oauth.ensure_token end to end --
+
+def test_real_client_ensure_token(monkeypatch, tmp_path):
+    # Point the client token store at a temp dir (no touching real ~/.config).
+    from mcp_stdio import token_store
+    monkeypatch.setattr(token_store, "_STORE_DIR", tmp_path)
+    monkeypatch.setattr(token_store, "_STORE_FILE", tmp_path / "tokens.json")
+    monkeypatch.setattr(token_store, "_LEGACY_STORE_DIR", tmp_path / "legacy")
+    monkeypatch.setattr(token_store, "_LEGACY_STORE_FILE", tmp_path / "legacy" / "tokens.json")
+
+    with _run(oauth=_provider(dev_user="alice")) as (base, _):
+        # The client opens a browser at auth_url then waits for its loopback
+        # callback. Simulate the browser in a BACKGROUND thread (a synchronous
+        # GET would deadlock: the callback server's serve() thread starts only
+        # AFTER webbrowser.open returns).
+        def fake_open(auth_url):
+            def drive():
+                r = httpx.get(auth_url, follow_redirects=False, timeout=10)
+                if r.status_code == 302:
+                    httpx.get(r.headers["location"], timeout=10)
+            threading.Thread(target=drive, daemon=True).start()
+
+        monkeypatch.setattr(client_oauth.webbrowser, "open", fake_open)
+
+        with httpx.Client(timeout=10) as client:
+            td = client_oauth.ensure_token(base + "/mcp", client, timeout=15)
+        assert td.access_token
+        # the obtained token authorizes a real MCP call
+        r = httpx.post(base + "/mcp",
+                       content=json.dumps({"jsonrpc": "2.0", "id": 1, "method": "echo"}),
+                       headers={"Authorization": f"Bearer {td.access_token}"}, timeout=10)
+        assert r.status_code == 200


### PR DESCRIPTION
## Summary

Milestone **M3** of #235 (on top of M1 #236 + M2 #238). Adds a minimal embedded
**OAuth 2.1 Authorization Server** to `serve` so the bundled mcp-stdio client's
`--oauth` flow completes against the gateway — **stdlib only, opaque in-memory
tokens, no crypto dependency**. SAML/OIDC federation rides on `/authorize`
trusting a reverse-proxy-asserted user.

```bash
mcp-stdio serve --enable-oauth --public-url http://127.0.0.1:8080 \
  --dev-user alice --port 8080 -- python -m my_mcp
mcp-stdio --oauth http://127.0.0.1:8080/mcp     # completes end to end
```

## Endpoints

| Path | RFC | Notes |
|---|---|---|
| `GET /.well-known/oauth-authorization-server` | 8414 | issuer pinned to `--public-url` (bare origin) or reflected origin |
| `GET /.well-known/oauth-protected-resource` | 9728 | gains `authorization_servers` **only** when `--enable-oauth` (M2 invariant preserved) |
| `POST /register` | 7591 | public client, loopback redirect_uris, no secret |
| `GET /authorize` | 6749 + 7636 | client/redirect/PKCE-S256 validation, fail-closed identity, 302 with code + echoed state; bad client_id/redirect_uri → direct 400 (no redirect) |
| `POST /token` | 6749 + 7636 | authorization_code (S256 verify, byte-identical to the client's `generate_pkce`) + refresh (rotated) |

## Security posture

Codes single-use via pop-before-validate under one store lock, bound to
client/redirect/challenge/user/scope/resource with 60s TTL; RFC 8252
port-agnostic loopback redirect matching; fail-closed identity (no anonymous
user); `--trusted-user-header` **off by default** (only safe behind a stripping
proxy); `--dev-user` is insecure/loopback-only; hard-bounded stores;
static-token-then-issued-token RS gate; `Cache-Control: no-store` on `/token`.

## Process: design-hardened, then adversarially reviewed (multi-agent)

This milestone was built with two multi-agent passes:

1. **Design hardening** (5 expert lenses → synthesis) before coding — caught
   several non-obvious requirements (issuer MUST be the bare origin or the
   client cross-origin-rejects it; RFC 8252 port-agnostic redirect matching;
   PKCE byte-exactness; pop-before-validate single-use; `/token` form-encoded
   vs `/register` JSON).
2. **Adversarial review** (5 lenses → independent verification) after coding —
   surfaced **16 confirmed findings (10 distinct)**, all fixed in the second
   commit:
   - *High:* store caps weren't real bounds (unbounded memory); `_CLIENT_CAP`
     off-by-one permanently bricked `/register`; `_redirect_key` ignored the
     query (malformed `code` + identity smuggling).
   - *Medium:* refresh destroyed a valid token on a bad client_id; the 401 hint
     origin disagreed with the pinned issuer.
   - *Low:* `state` logged in cleartext; wrong error code for missing
     grant_type; non-loopback `http://` public-url accepted; userinfo in
     redirect_uri; non-canonical issuer.

## Testing

- 39 new tests, including a **real-client end-to-end** that drives
  `mcp_stdio.oauth.ensure_token` through the full discover → DCR → authorize →
  token → RS path, a **concurrent single-use** race, hard store/client-cap
  bounds, and a negative for each fixed finding.
- AS disabled (no `--enable-oauth`) is byte-for-byte M1/M2 behavior.
- Full suite: **993 passed / 3 skipped**.

## Out of scope (M4, optional)

External-AS JWT/JWKS validation (introduces the first crypto dependency);
multi-resource audience enforcement; multi-client JSON-RPC id remapping.

Refs #235

🤖 Generated with [Claude Code](https://claude.com/claude-code)
