### PR TITLE
docs: drop "experimental" from serve mode

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -218,7 +218,7 @@ mcp-stdio [OPTIONS] URL
 
 各フラグの詳細（プラットフォーム注記や issue 参照を含む）は `mcp-stdio --help` を実行してください。この表より詳しい説明が表示されます。
 
-## 逆ゲートウェイ: `serve` モード（実験的）
+## 逆ゲートウェイ: `serve` モード
 
 通常モードは **stdio → HTTP**（クライアント側）の橋渡しですが、`serve`
 サブコマンドはその逆向き — **HTTP → stdio** — で、ローカルの stdio MCP

--- a/README.ja.md
+++ b/README.ja.md
@@ -226,12 +226,12 @@ mcp-stdio [OPTIONS] URL
 インストールしていないクライアントからネットワーク越しに到達できます:
 
 ```mermaid
-flowchart LR
+flowchart BT
     A["MCP クライアント<br>Claude Code / Desktop<br>(または mcp-stdio --oauth)"]
     B("mcp-stdio serve<br><b>HTTP → stdio</b> ゲートウェイ<br>認証: なし / 静的トークン /<br>埋め込み OAuth 2.1 AS")
     C["ローカルの stdio<br>MCP サーバ"]
-    A == "HTTPS · Streamable HTTP<br>Bearer / OAuth 2.1 (PKCE)" ==> B
-    B -- "stdio (子プロセス起動)" --> C
+    A <== "HTTPS · Streamable HTTP<br>Bearer / OAuth 2.1 (PKCE)" ==> B
+    B <-- "stdio (子プロセス起動)" --> C
 ```
 
 冒頭のクライアント側の図と対になります。あちらは mcp-stdio が **stdio → HTTP**、

--- a/README.ja.md
+++ b/README.ja.md
@@ -230,7 +230,7 @@ flowchart BT
     A["MCP クライアント<br>Claude Code / Desktop<br>(または mcp-stdio --oauth)"]
     B("mcp-stdio serve<br><b>HTTP → stdio</b> ゲートウェイ<br>認証: なし / 静的トークン /<br>埋め込み OAuth 2.1 AS")
     C["ローカルの stdio<br>MCP サーバ"]
-    A <== "HTTPS · Streamable HTTP<br>Bearer / OAuth 2.1 (PKCE)" ==> B
+    A <== "Streamable HTTP<br>Bearer / OAuth 2.1 (PKCE)" ==> B
     B <-- "stdio (子プロセス起動)" --> C
 ```
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -225,6 +225,18 @@ mcp-stdio [OPTIONS] URL
 サーバを Streamable HTTP の MCP エンドポイントとして公開します。ローカルに
 インストールしていないクライアントからネットワーク越しに到達できます:
 
+```mermaid
+flowchart LR
+    A["MCP クライアント<br>Claude Code / Desktop<br>(または mcp-stdio --oauth)"]
+    B("mcp-stdio serve<br><b>HTTP → stdio</b> ゲートウェイ<br>認証: なし / 静的トークン /<br>埋め込み OAuth 2.1 AS")
+    C["ローカルの stdio<br>MCP サーバ"]
+    A == "HTTPS · Streamable HTTP<br>Bearer / OAuth 2.1 (PKCE)" ==> B
+    B -- "stdio (子プロセス起動)" --> C
+```
+
+冒頭のクライアント側の図と対になります。あちらは mcp-stdio が **stdio → HTTP**、
+こちらは **HTTP → stdio** です。
+
 ```bash
 mcp-stdio serve --port 8080 -- python -m my_mcp_server
 ```

--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ Options:
 
 Run `mcp-stdio --help` for the full per-flag detail (platform notes and issue references are more verbose than this table).
 
-## Reverse gateway: `serve` mode (experimental)
+## Reverse gateway: `serve` mode
 
 The default mode bridges **stdio → HTTP** (client side). The `serve` subcommand
 is the mirror image — **HTTP → stdio** — exposing a local stdio MCP server as a

--- a/README.md
+++ b/README.md
@@ -227,6 +227,18 @@ is the mirror image — **HTTP → stdio** — exposing a local stdio MCP server
 Streamable HTTP MCP endpoint so clients that cannot spawn it locally can reach
 it over the network:
 
+```mermaid
+flowchart LR
+    A["MCP client<br>Claude Code / Desktop<br>(or mcp-stdio --oauth)"]
+    B("mcp-stdio serve<br><b>HTTP → stdio</b> gateway<br>auth: none / static token /<br>embedded OAuth 2.1 AS")
+    C["local stdio<br>MCP server"]
+    A == "HTTPS · Streamable HTTP<br>Bearer / OAuth 2.1 (PKCE)" ==> B
+    B -- "stdio (spawned child)" --> C
+```
+
+This is the mirror of the client-side diagram at the top: there mcp-stdio is
+**stdio → HTTP**; here it is **HTTP → stdio**.
+
 ```bash
 mcp-stdio serve --port 8080 -- python -m my_mcp_server
 ```

--- a/README.md
+++ b/README.md
@@ -228,12 +228,12 @@ Streamable HTTP MCP endpoint so clients that cannot spawn it locally can reach
 it over the network:
 
 ```mermaid
-flowchart LR
+flowchart BT
     A["MCP client<br>Claude Code / Desktop<br>(or mcp-stdio --oauth)"]
     B("mcp-stdio serve<br><b>HTTP → stdio</b> gateway<br>auth: none / static token /<br>embedded OAuth 2.1 AS")
     C["local stdio<br>MCP server"]
-    A == "HTTPS · Streamable HTTP<br>Bearer / OAuth 2.1 (PKCE)" ==> B
-    B -- "stdio (spawned child)" --> C
+    A <== "HTTPS · Streamable HTTP<br>Bearer / OAuth 2.1 (PKCE)" ==> B
+    B <-- "stdio (spawned child)" --> C
 ```
 
 This is the mirror of the client-side diagram at the top: there mcp-stdio is

--- a/README.md
+++ b/README.md
@@ -232,7 +232,7 @@ flowchart BT
     A["MCP client<br>Claude Code / Desktop<br>(or mcp-stdio --oauth)"]
     B("mcp-stdio serve<br><b>HTTP → stdio</b> gateway<br>auth: none / static token /<br>embedded OAuth 2.1 AS")
     C["local stdio<br>MCP server"]
-    A <== "HTTPS · Streamable HTTP<br>Bearer / OAuth 2.1 (PKCE)" ==> B
+    A <== "Streamable HTTP<br>Bearer / OAuth 2.1 (PKCE)" ==> B
     B <-- "stdio (spawned child)" --> C
 ```
 


### PR DESCRIPTION
The `serve` reverse-gateway mode has been verified end-to-end across all three auth modes in real processes:

- **no-auth** — `mcp-stdio --check` initialize handshake
- **static token** — no token → 401, `--bearer-token` → ok, PRM omits `authorization_servers`
- **embedded OAuth AS** — AS metadata (pinned issuer, S256, public client), PRM `authorization_servers`, DCR → `/authorize` → `/token` → issued token authorizes an MCP call; no token → 401 + `WWW-Authenticate` hint

Plus 995 unit tests and CI green across Python 3.10–3.14 + Windows. Dropping the `(experimental)` label; the single-client / single-backend / in-memory-token caveats remain documented in the section body.

🤖 Generated with [Claude Code](https://claude.com/claude-code)