### PR TITLE
feat: proactive OAuth token refresh timer for HTTP-200 expiry gateways

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -56,6 +56,7 @@ Bearer token、カスタムヘッダー、OAuth 2.1 認証情報をリモート�
 - **セッション回復** — 404 でセッション ID をリセットして再試行
 - **プロトコルバージョンヘッダー** — `initialize` 応答から交渉済みの `protocolVersion` を捕捉し、以降の Streamable HTTP リクエストすべてに `MCP-Protocol-Version` を付与（MCP 仕様 rev 2025-06-18）。このヘッダーを強制するサーバーは未送信時に初期化後リクエストを `400 Bad Request` で拒否する
 - **401 時の自動トークンリフレッシュ** — セッション中に OAuth トークンが失効しても自動更新（OAuth モード時のみ）
+- **プロアクティブなトークンリフレッシュ** — バックグラウンドタイマーが OAuth トークンを失効直前にリフレッシュ（リード時間は `--oauth-refresh-leeway`）。トークン失効をトランスポート層の 401 ではなく HTTP 200 のツールエラーとして返すゲートウェイ（例: Atlassian の MCP ゲートウェイ）でも長時間セッションが生き残る。OAuth モードではデフォルト有効、`--no-proactive-refresh` で無効化（#242）
 - **403 時のステップアップ認可** — `Bearer error="insufficient_scope"` チャレンジを受けると、付与済みスコープと要求スコープの和集合で再認可（[RFC 9470](https://www.rfc-editor.org/rfc/rfc9470) / MCP step-up、cf. anthropics/claude-code#44652）
 - **Bearer token 認証** — `--bearer-token` フラグまたは `MCP_BEARER_TOKEN` 環境変数
 - **カスタムヘッダー** — `-H` / `--header` で任意のヘッダーを送信
@@ -188,6 +189,11 @@ mcp-stdio [OPTIONS] URL
   --oauth-refresh-leeway SECONDS
                          アクセストークンを expire の何秒前に proactive refresh
                          するか（デフォルト: 60、または MCP_OAUTH_REFRESH_LEEWAY 環境変数）
+  --no-proactive-refresh
+                         OAuth トークンを失効前にリフレッシュするバックグラウンド
+                         タイマーを無効化する。OAuth モードではデフォルト有効。失効を
+                         401 ではなく HTTP 200 のツールエラーとして返すゲートウェイ
+                         でも長時間セッションを維持する（#242）
   --oauth-timeout SECONDS
                          対話的 OAuth フロー（ブラウザコールバック / デバイス
                          コード確認）の待機秒数（デフォルト: 120、OAuth 時のみ有効）
@@ -299,6 +305,7 @@ Claude Code・mcp-remote・MCP SDK・Windows の既知の問題については [
 3. HTTPS でリモート MCP サーバーへ転送
 4. レスポンスをパースして stdout に書き出し
 5. 401 で（OAuth モードのみ）アクセストークンをリフレッシュしてリトライ。静的な `--bearer-token` / `-H` 認証では 401 をそのままクライアントに返す
+6. OAuth モードではバックグラウンドタイマーも失効直前（`--oauth-refresh-leeway`）にトークンをリフレッシュする。リクエストの流れとは独立して動作し、トークン失効を 401 ではなく HTTP 200 のツールエラーとして返すゲートウェイでも長時間セッションを維持する（`--no-proactive-refresh` で無効化）
 
 トランスポート別の挙動：
 

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ Bearer tokens, custom headers, and OAuth 2.1 credentials are forwarded to the re
 - **Session recovery** — resets MCP session ID on 404 and retries
 - **Protocol version header** — captures the negotiated `protocolVersion` from the `initialize` response and injects `MCP-Protocol-Version` on every subsequent Streamable HTTP request (MCP spec rev 2025-06-18); servers that enforce the header would otherwise reject post-initialize requests with `400 Bad Request`
 - **Token refresh on 401** — automatically refreshes expired OAuth tokens mid-session (OAuth mode only)
+- **Proactive token refresh** — a background timer refreshes the OAuth token shortly before it expires (lead time: `--oauth-refresh-leeway`), so a long-lived session survives gateways that signal token expiry as an HTTP 200 tool-error instead of a transport 401 (e.g. Atlassian's MCP gateway); on by default in OAuth mode, opt out with `--no-proactive-refresh` (#242)
 - **Step-up authorization on 403** — on a `Bearer error="insufficient_scope"` challenge, re-authorizes for the union of the granted and required scopes ([RFC 9470](https://www.rfc-editor.org/rfc/rfc9470) / MCP step-up; cf. anthropics/claude-code#44652)
 - **Bearer token auth** — via `--bearer-token` flag or `MCP_BEARER_TOKEN` env var
 - **Custom headers** — pass any header with `-H` / `--header`
@@ -190,6 +191,11 @@ Options:
   --oauth-refresh-leeway SECONDS
                          Proactively refresh tokens this many seconds before
                          expiry (default: 60, or MCP_OAUTH_REFRESH_LEEWAY)
+  --no-proactive-refresh
+                         Disable the background timer that refreshes the OAuth
+                         token before it expires. On by default in OAuth mode;
+                         keeps long sessions alive against gateways that signal
+                         expiry as an HTTP 200 tool-error rather than a 401 (#242)
   --oauth-timeout SECONDS
                          Seconds to wait for the interactive OAuth flow (browser
                          callback / device-code confirmation) before giving up
@@ -301,6 +307,7 @@ See [WORKAROUNDS.md](WORKAROUNDS.md) for known issues in Claude Code, mcp-remote
 3. Relays them over HTTPS to the remote MCP server
 4. Parses responses and writes them to stdout
 5. On 401 (OAuth mode only), refreshes the access token and retries; with static `--bearer-token` / `-H` auth the 401 is surfaced to the client
+6. In OAuth mode a background timer also refreshes the token shortly before it expires (`--oauth-refresh-leeway`), independent of request flow — this keeps long sessions alive against gateways that report token expiry as an HTTP 200 tool-error rather than a 401 (opt out with `--no-proactive-refresh`)
 
 Transport details:
 

--- a/src/mcp_stdio/cli.py
+++ b/src/mcp_stdio/cli.py
@@ -217,6 +217,32 @@ def _build_scope_upgrader(
     return upgrader
 
 
+def _build_token_expiry_getter(
+    server_url: str,
+) -> Callable[[], float | None]:
+    """Build an ``expires_at`` getter for the proactive-refresh timer.
+
+    Returns a callable that reads the cached token's ``expires_at`` (Unix
+    seconds) via ``token_store.load_token``, or None when there is no cached
+    token / no expiry. Read fresh on each call so the timer always schedules
+    against the latest persisted expiry (the refresher's ``save_token`` writes
+    a new one). Exceptions degrade to None — the timer treats that as "nothing
+    to schedule" and quietly re-polls, never crashing the daemon thread.
+    """
+
+    def getter() -> float | None:
+        from .token_store import load_token
+
+        try:
+            data = load_token(server_url)
+        except Exception as e:
+            print(f"error: reading cached token expiry failed: {e}", file=sys.stderr)
+            return None
+        return data.expires_at if data else None
+
+    return getter
+
+
 def _main() -> None:
     """CLI body. Wrapped by ``main`` for top-level interrupt handling."""
     parser = argparse.ArgumentParser(
@@ -292,6 +318,20 @@ def _main() -> None:
             "malformed MCP_OAUTH_REFRESH_LEEWAY value aborts startup at argument "
             "parsing even on a non-OAuth run (the env default is validated eagerly "
             "so a bad value surfaces clearly rather than silently)"
+        ),
+    )
+    parser.add_argument(
+        "--no-proactive-refresh",
+        action="store_true",
+        help=(
+            "Disable the background timer that proactively refreshes the OAuth "
+            "access token shortly before it expires (lead time: "
+            "--oauth-refresh-leeway, default 60 s). Enabled by default in OAuth "
+            "mode. Without it, a long-lived session against a gateway that "
+            "signals token expiry as an HTTP 200 tool-error (e.g. Atlassian's "
+            "MCP gateway) rather than a transport 401 cannot recover until the "
+            "process restarts (#242). Only meaningful with --oauth / "
+            "--oauth-device; a no-op otherwise."
         ),
     )
     parser.add_argument(
@@ -542,6 +582,7 @@ def _main() -> None:
     # OAuth flow (before relay starts)
     token_refresher: Callable[[], dict[str, str] | None] | None = None
     scope_upgrader: Callable[[str], dict[str, str] | None] | None = None
+    token_expiry_getter: Callable[[], float | None] | None = None
     if args.oauth or args.oauth_device:
         # NOTE: this runs BEFORE the --check branch below, and
         # ensure_token only short-circuits on a valid cached/refreshable token.
@@ -614,6 +655,7 @@ def _main() -> None:
                     args.timeout_read,
                     args.oauth_timeout,
                 )
+                token_expiry_getter = _build_token_expiry_getter(args.url)
         except Exception as e:
             print(f"error: OAuth authentication failed: {e}", file=sys.stderr)
             sys.exit(1)
@@ -644,6 +686,7 @@ def _main() -> None:
     tcp_keepalive = not args.no_tcp_keepalive
     cancel_filter = not args.no_cancel_filter
     normalize_arguments = not args.no_normalize_arguments
+    proactive_refresh = not args.no_proactive_refresh
     if args.transport == "sse":
         run_sse(
             url=args.url,
@@ -656,6 +699,9 @@ def _main() -> None:
             normalize_arguments=normalize_arguments,
             token_refresher=token_refresher,
             scope_upgrader=scope_upgrader,
+            token_expiry_getter=token_expiry_getter,
+            proactive_refresh=proactive_refresh,
+            refresh_leeway=args.oauth_refresh_leeway,
         )
     else:
         run(
@@ -668,6 +714,9 @@ def _main() -> None:
             normalize_arguments=normalize_arguments,
             token_refresher=token_refresher,
             scope_upgrader=scope_upgrader,
+            token_expiry_getter=token_expiry_getter,
+            proactive_refresh=proactive_refresh,
+            refresh_leeway=args.oauth_refresh_leeway,
         )
 
 

--- a/src/mcp_stdio/relay.py
+++ b/src/mcp_stdio/relay.py
@@ -11,7 +11,7 @@ import socket
 import sys
 import threading
 import time
-from collections.abc import Iterable, Iterator
+from collections.abc import Callable, Iterable, Iterator
 from datetime import datetime, timezone
 from typing import Any
 from urllib.parse import urljoin, urlsplit
@@ -1651,6 +1651,122 @@ def check_connection(
         client.close()
 
 
+# Proactive token refresh — a background timer that refreshes the OAuth access
+# token shortly before it expires, independent of the request flow. Reactive
+# refresh only fires on a transport-level HTTP 401; some gateways (notably
+# Atlassian's MCP gateway) signal an expired token as an HTTP 200 tool-result
+# error (``isError: true``) instead, so neither reactive refresh nor the
+# startup-only proactive ``ensure_token`` ever fires and a long-lived --oauth
+# session cannot recover until the process restarts. The timer closes that gap
+# generically, without ever parsing a tool-result body (#242).
+_PROACTIVE_REFRESH_RECHECK_SECONDS = 60.0
+_PROACTIVE_REFRESH_MAX_SLEEP = 300.0
+
+
+def _proactive_refresh_loop(
+    *,
+    refresher: Callable[[], dict[str, str] | None],
+    expiry_getter: Callable[[], float | None],
+    leeway: float,
+    headers: dict[str, str],
+    headers_lock: threading.Lock,
+    refresh_lock: threading.Lock,
+    stop: threading.Event,
+    now: Any = time.time,
+    recheck: float = _PROACTIVE_REFRESH_RECHECK_SECONDS,
+    max_sleep: float = _PROACTIVE_REFRESH_MAX_SLEEP,
+) -> None:
+    """Refresh the OAuth token shortly before it expires, off the request path.
+
+    Wakes at ``expires_at - leeway`` (the expiry is read fresh each loop via
+    ``expiry_getter``, which the caller backs with ``token_store.load_token``),
+    calls ``refresher`` under ``refresh_lock`` to serialise against the main
+    loop's reactive 401 refresh (a concurrent refresh would race the AS's
+    refresh-token rotation), and merges the returned headers under
+    ``headers_lock``. The thread must never die: any exception is logged and
+    retried after a ``recheck`` backoff (mirrors the structural #11 safety net).
+    A ``None`` expiry (no cached token / non-expiring token) or a ``refresher``
+    that returns ``None`` (no refresh_token, refresh failed) degrades to a quiet
+    ``recheck``-interval poll rather than a hot loop. ``now`` is injectable for
+    deterministic tests, mirroring ``_CancelTracker``.
+    """
+    while not stop.is_set():
+        try:
+            exp = expiry_getter()
+            if exp is None:
+                # No cached token yet, or a token with no expiry — nothing to
+                # schedule against, so poll on the recheck interval and stay idle.
+                wait_for = recheck
+            else:
+                wait_for = exp - leeway - now()
+            if wait_for > 0:
+                # Interruptible sleep, capped at max_sleep so a token whose
+                # expires_at moved out-of-band (another refresher wrote a new
+                # value) is re-evaluated promptly instead of oversleeping to a
+                # stale deadline. stop.wait returns True when signalled.
+                if stop.wait(min(wait_for, max_sleep)):
+                    return
+                continue
+            # Past the refresh deadline — refresh now, serialised with the
+            # reactive 401 path so the two never race the refresh-token rotation.
+            with refresh_lock:
+                new_headers = refresher()
+                if new_headers:
+                    with headers_lock:
+                        headers.update(new_headers)
+            if not new_headers:
+                # Refresh unavailable (no refresh_token) or failed (the refresher
+                # swallows network errors and returns None). Back off before
+                # retrying so a persistently-failing refresh never hot-loops.
+                if stop.wait(recheck):
+                    return
+        except Exception as e:  # noqa: BLE001 — the daemon must never die
+            log(f"proactive token refresh error: {e}")
+            if stop.wait(recheck):
+                return
+
+
+def _start_proactive_refresh(
+    *,
+    refresher: Callable[[], dict[str, str] | None] | None,
+    expiry_getter: Callable[[], float | None] | None,
+    proactive_refresh: bool,
+    leeway: float,
+    headers: dict[str, str],
+    headers_lock: threading.Lock,
+    refresh_lock: threading.Lock,
+) -> tuple[threading.Thread | None, threading.Event | None]:
+    """Start the proactive-refresh daemon, or no-op when not applicable.
+
+    Returns ``(thread, stop_event)`` so the caller can stop and join it in its
+    ``finally``, or ``(None, None)`` when disabled (``--no-proactive-refresh``)
+    or when there is nothing to refresh (no OAuth: the refresher / expiry getter
+    is ``None``).
+    """
+    if not (
+        proactive_refresh
+        and refresher is not None
+        and expiry_getter is not None
+    ):
+        return None, None
+    stop = threading.Event()
+    thread = threading.Thread(
+        target=_proactive_refresh_loop,
+        kwargs={
+            "refresher": refresher,
+            "expiry_getter": expiry_getter,
+            "leeway": leeway,
+            "headers": headers,
+            "headers_lock": headers_lock,
+            "refresh_lock": refresh_lock,
+            "stop": stop,
+        },
+        daemon=True,
+    )
+    thread.start()
+    return thread, stop
+
+
 def run(
     url: str,
     headers: dict[str, str],
@@ -1663,6 +1779,9 @@ def run(
     normalize_arguments: bool = True,
     token_refresher: Any = None,
     scope_upgrader: Any = None,
+    token_expiry_getter: Any = None,
+    proactive_refresh: bool = True,
+    refresh_leeway: float = 60.0,
 ) -> None:
     """Run the stdio-to-HTTP relay loop.
 
@@ -1701,6 +1820,20 @@ def run(
             and returns updated headers containing a broader-scope
             token, or None on failure (RFC 9470 step-up authorization;
             cf. anthropics/claude-code#44652).
+        token_expiry_getter: Optional callable returning the cached
+            token's ``expires_at`` (Unix seconds) or None. Drives the
+            proactive-refresh timer's wake schedule; the caller backs it
+            with ``token_store.load_token`` so each read picks up the
+            latest persisted expiry.
+        proactive_refresh: When True (default), run a background timer
+            that refreshes the token at ``expires_at - refresh_leeway``
+            using ``token_refresher``, independent of request flow. This
+            keeps a long --oauth session alive against gateways that
+            signal expiry as an HTTP 200 tool-error rather than a 401
+            (e.g. Atlassian's MCP gateway; #242). No-op without
+            ``token_refresher`` / ``token_expiry_getter`` (i.e. no OAuth).
+        refresh_leeway: Seconds before ``expires_at`` at which the
+            proactive timer refreshes (default 60).
 
     Limitation — JSON-RPC batches: a top-level array (a batch) is
     treated like a notification for error synthesis. ``_extract_id_and_presence``
@@ -1740,6 +1873,14 @@ def run(
         )
     )
 
+    # ``run`` is otherwise single-threaded, but the proactive-refresh daemon
+    # (when enabled) mutates ``headers`` concurrently. ``headers_lock`` serialises
+    # every read/write of the shared ``headers`` object; ``refresh_lock`` serialises
+    # the timer's refresh against the reactive 401 refresh so the two never race
+    # the AS's refresh-token rotation. Both are uncontended when the timer is off.
+    headers_lock = threading.Lock()
+    refresh_lock = threading.Lock()
+
     def _prepare_headers() -> dict[str, str]:
         """Build per-request headers with the current session + protocol version.
 
@@ -1752,7 +1893,10 @@ def run(
         actually having a value, so an operator pin still rides through on the
         paths where the relay manages no value of its own.
         """
-        h = dict(headers)
+        with headers_lock:
+            h = dict(headers)
+        # session_id / protocol_version are mutated only by this (main) thread,
+        # so they need no lock; only the shared ``headers`` object is contended.
         if session_id:
             h = {k: v for k, v in h.items() if k.lower() != "mcp-session-id"}
             h["Mcp-Session-Id"] = session_id
@@ -1760,6 +1904,16 @@ def run(
             h = {k: v for k, v in h.items() if k.lower() != "mcp-protocol-version"}
             h["MCP-Protocol-Version"] = protocol_version
         return h
+
+    refresh_timer, refresh_stop = _start_proactive_refresh(
+        refresher=token_refresher,
+        expiry_getter=token_expiry_getter,
+        proactive_refresh=proactive_refresh,
+        leeway=refresh_leeway,
+        headers=headers,
+        headers_lock=headers_lock,
+        refresh_lock=refresh_lock,
+    )
 
     try:
         for line in sys.stdin:
@@ -1939,9 +2093,13 @@ def run(
                 # Token expired (401) — refresh and retry once
                 if result.status_code == 401 and token_refresher:
                     log("received 401, attempting token refresh")
-                    new_headers = token_refresher()
+                    # Serialise with the proactive timer's refresh so the two
+                    # never race the AS's refresh-token rotation (#242).
+                    with refresh_lock:
+                        new_headers = token_refresher()
                     if new_headers:
-                        headers.update(new_headers)
+                        with headers_lock:
+                            headers.update(new_headers)
                         req_headers = _prepare_headers()
                         result = _dispatch(line, req_headers)
                         if result is None:
@@ -1999,7 +2157,8 @@ def run(
                         )
                         new_headers = scope_upgrader(required_scope)
                         if new_headers:
-                            headers.update(new_headers)
+                            with headers_lock:
+                                headers.update(new_headers)
                             req_headers = _prepare_headers()
                             result = _dispatch(line, req_headers)
                             if result is None:
@@ -2028,8 +2187,10 @@ def run(
                 if result.status_code == 404 and session_id:
                     log("session expired, re-initializing and retrying")
                     session_id = None
+                    with headers_lock:
+                        headers_snapshot = dict(headers)
                     new_session_id, renegotiated = _reinitialize(
-                        client, url, dict(headers), protocol_version
+                        client, url, headers_snapshot, protocol_version
                     )
                     if new_session_id is None:
                         log("re-initialize failed, dropping request")
@@ -2111,6 +2272,10 @@ def run(
                         pass
                 continue
     finally:
+        if refresh_stop is not None:
+            refresh_stop.set()
+            if refresh_timer is not None:
+                refresh_timer.join(timeout=1.0)
         client.close()
 
 
@@ -2295,6 +2460,9 @@ def run_sse(
     normalize_arguments: bool = True,
     token_refresher: Any = None,
     scope_upgrader: Any = None,
+    token_expiry_getter: Any = None,
+    proactive_refresh: bool = True,
+    refresh_leeway: float = 60.0,
 ) -> None:
     """Run the stdio-to-SSE relay loop (MCP 2024-11-05 legacy transport).
 
@@ -2383,6 +2551,9 @@ def run_sse(
     # main loop below may mutate it on a 401/403 token refresh. Serialise the
     # two so the GET request build never iterates a dict mid-mutation.
     headers_lock = threading.Lock()
+    # Serialises the proactive-refresh timer's refresh against the reactive 401
+    # refresh below so the two never race the AS's refresh-token rotation (#242).
+    refresh_lock = threading.Lock()
     reader = threading.Thread(
         target=_sse_reader_loop,
         args=(client, url, headers, state, tracker, headers_lock),
@@ -2415,6 +2586,16 @@ def run_sse(
         """
         with headers_lock:
             return dict(headers)
+
+    refresh_timer, refresh_stop = _start_proactive_refresh(
+        refresher=token_refresher,
+        expiry_getter=token_expiry_getter,
+        proactive_refresh=proactive_refresh,
+        leeway=refresh_leeway,
+        headers=headers,
+        headers_lock=headers_lock,
+        refresh_lock=refresh_lock,
+    )
 
     try:
         for line in sys.stdin:
@@ -2518,7 +2699,10 @@ def run_sse(
                     # would be heavier than the project's minimalism warrants.
                     if resp.status_code == 401 and token_refresher:
                         log("received 401, attempting token refresh")
-                        new_headers = token_refresher()
+                        # Serialise with the proactive timer's refresh so the two
+                        # never race the AS's refresh-token rotation (#242).
+                        with refresh_lock:
+                            new_headers = token_refresher()
                         if new_headers:
                             with headers_lock:
                                 headers.update(new_headers)
@@ -2633,5 +2817,9 @@ def run_sse(
         # the resulting HTTPError and, because stop is already set, returns
         # without logging a reconnect. The daemon flag guarantees process exit
         # is never blocked regardless.
+        if refresh_stop is not None:
+            refresh_stop.set()
+            if refresh_timer is not None:
+                refresh_timer.join(timeout=1.0)
         reader.join(timeout=1.0)
         client.close()

--- a/src/mcp_stdio/relay.py
+++ b/src/mcp_stdio/relay.py
@@ -1767,6 +1767,22 @@ def _start_proactive_refresh(
     return thread, stop
 
 
+def _stop_proactive_refresh(
+    thread: threading.Thread | None, stop: threading.Event | None
+) -> None:
+    """Signal and briefly join the proactive-refresh daemon in a relay finally.
+
+    Mirrors ``_start_proactive_refresh``; a ``(None, None)`` pair (timer never
+    started) is a no-op. The daemon flag guarantees process exit is never blocked
+    even if the join times out (the thread may be parked in ``stop.wait`` for up
+    to its recheck interval).
+    """
+    if stop is not None:
+        stop.set()
+        if thread is not None:
+            thread.join(timeout=1.0)
+
+
 def run(
     url: str,
     headers: dict[str, str],
@@ -2272,10 +2288,7 @@ def run(
                         pass
                 continue
     finally:
-        if refresh_stop is not None:
-            refresh_stop.set()
-            if refresh_timer is not None:
-                refresh_timer.join(timeout=1.0)
+        _stop_proactive_refresh(refresh_timer, refresh_stop)
         client.close()
 
 
@@ -2817,9 +2830,6 @@ def run_sse(
         # the resulting HTTPError and, because stop is already set, returns
         # without logging a reconnect. The daemon flag guarantees process exit
         # is never blocked regardless.
-        if refresh_stop is not None:
-            refresh_stop.set()
-            if refresh_timer is not None:
-                refresh_timer.join(timeout=1.0)
+        _stop_proactive_refresh(refresh_timer, refresh_stop)
         reader.join(timeout=1.0)
         client.close()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -936,6 +936,92 @@ class TestMain:
             main()
         assert mock_run_sse.call_args.kwargs["normalize_arguments"] is False
 
+    def test_proactive_refresh_default_on(self):
+        """#242: proactive refresh is ON by default → run() sees True."""
+        with (
+            patch("sys.argv", ["mcp-stdio", "https://example.com/mcp"]),
+            patch("mcp_stdio.cli.run") as mock_run,
+        ):
+            main()
+        assert mock_run.call_args.kwargs["proactive_refresh"] is True
+
+    def test_proactive_refresh_opt_out(self):
+        """#242: --no-proactive-refresh flips the flag to False."""
+        with (
+            patch(
+                "sys.argv",
+                ["mcp-stdio", "https://example.com/mcp", "--no-proactive-refresh"],
+            ),
+            patch("mcp_stdio.cli.run") as mock_run,
+        ):
+            main()
+        assert mock_run.call_args.kwargs["proactive_refresh"] is False
+
+    def test_proactive_refresh_passed_to_run_sse(self):
+        """#242: --no-proactive-refresh reaches run_sse on the sse transport."""
+        with (
+            patch(
+                "sys.argv",
+                [
+                    "mcp-stdio",
+                    "https://example.com/mcp",
+                    "--transport",
+                    "sse",
+                    "--no-proactive-refresh",
+                ],
+            ),
+            patch("mcp_stdio.cli.run_sse") as mock_run_sse,
+        ):
+            main()
+        assert mock_run_sse.call_args.kwargs["proactive_refresh"] is False
+
+    def test_refresh_leeway_default_passed_to_run(self):
+        """#242: the default --oauth-refresh-leeway (60) reaches run()."""
+        with (
+            patch("sys.argv", ["mcp-stdio", "https://example.com/mcp"]),
+            patch("mcp_stdio.cli.run") as mock_run,
+        ):
+            main()
+        assert mock_run.call_args.kwargs["refresh_leeway"] == 60.0
+
+    def test_refresh_leeway_custom_passed_to_run(self):
+        """#242: an explicit --oauth-refresh-leeway value reaches run()."""
+        with (
+            patch(
+                "sys.argv",
+                [
+                    "mcp-stdio",
+                    "https://example.com/mcp",
+                    "--oauth-refresh-leeway",
+                    "30",
+                ],
+            ),
+            patch("mcp_stdio.cli.run") as mock_run,
+        ):
+            main()
+        assert mock_run.call_args.kwargs["refresh_leeway"] == 30.0
+
+    def test_token_expiry_getter_none_without_oauth(self):
+        """#242: without --oauth there is no expiry getter (timer is a no-op)."""
+        with (
+            patch("sys.argv", ["mcp-stdio", "https://example.com/mcp"]),
+            patch("mcp_stdio.cli.run") as mock_run,
+        ):
+            main()
+        assert mock_run.call_args.kwargs["token_expiry_getter"] is None
+
+    def test_token_expiry_getter_built_with_oauth(self):
+        """#242: --oauth builds an expiry getter and passes it to run()."""
+        with (
+            patch("sys.argv", ["mcp-stdio", "--oauth", "https://example.com/mcp"]),
+            patch("mcp_stdio.oauth.ensure_token") as mock_ensure,
+            patch("mcp_stdio.cli.run") as mock_run,
+        ):
+            mock_ensure.return_value.access_token = "tok"
+            main()
+        getter = mock_run.call_args.kwargs["token_expiry_getter"]
+        assert getter is not None and callable(getter)
+
     def test_no_resource_indicator_default_is_true(self):
         """By default resource_indicator=True is passed to ensure_token."""
         with (

--- a/tests/test_relay.py
+++ b/tests/test_relay.py
@@ -40,6 +40,7 @@ from mcp_stdio.relay import (
     _proactive_refresh_loop,
     _reinitialize,
     _start_proactive_refresh,
+    _stop_proactive_refresh,
     _same_origin,
     _split_sse_text,
     _sse_reader_loop,
@@ -5231,6 +5232,25 @@ class TestProactiveRefresh:
         assert not thread.is_alive()
         assert headers["Authorization"] == "Bearer new"
 
+    def test_stop_none_is_noop(self):
+        """_stop_proactive_refresh((None, None)) — never-started timer — no-op."""
+        _stop_proactive_refresh(None, None)  # must not raise
+
+    def test_stop_signals_and_joins(self):
+        """_stop_proactive_refresh sets the stop event and joins the thread."""
+        thread, stop = _start_proactive_refresh(
+            refresher=lambda: None,
+            expiry_getter=lambda: time.time() + 3600,  # park far out
+            proactive_refresh=True,
+            leeway=0.0,
+            headers={},
+            headers_lock=threading.Lock(),
+            refresh_lock=threading.Lock(),
+        )
+        _stop_proactive_refresh(thread, stop)
+        assert stop.is_set()
+        assert not thread.is_alive()
+
     def test_run_proactive_timer_fires(self, httpx_mock):
         """run() starts the timer; it refreshes while the main loop parks on stdin."""
         httpx_mock.add_response(
@@ -5268,9 +5288,19 @@ class TestProactiveRefresh:
         assert headers["Authorization"] == "Bearer refreshed"
 
     def test_run_sse_proactive_timer_fires(self, httpx_mock):
-        """run_sse starts the timer; it refreshes while the main loop parks."""
+        """run_sse starts the timer; it refreshes while the main loop parks.
+
+        No request line is sent (the stdin yields one empty line, skipped, then
+        blocks): this test only proves the timer fires, so it avoids a POST whose
+        timing would race the reader nulling the endpoint on stream end. The GET
+        gen parks until the timer has fired *and* the main loop has exited, so the
+        reader never reconnects mid-test (which would otherwise leave a mocked GET
+        unrequested at teardown).
+        """
         url = "https://example.com/sse"
         refreshed = threading.Event()
+        release_stdin = threading.Event()
+        gen_park = threading.Event()  # never set; bounds the gen's final wait
 
         def refresher():
             refreshed.set()
@@ -5284,7 +5314,9 @@ class TestProactiveRefresh:
 
         def sse_gen():
             yield b"event: endpoint\ndata: /messages?sid=abc\n\n"
-            refreshed.wait(timeout=5)  # hold the GET open until the timer fires
+            refreshed.wait(timeout=3)  # hold the GET open until the timer fires
+            release_stdin.set()  # then let the main loop exit
+            gen_park.wait(timeout=3)  # stay parked so the stream never reconnects
 
         httpx_mock.add_response(
             url=url,
@@ -5292,17 +5324,11 @@ class TestProactiveRefresh:
             stream=IteratorStream(sse_gen()),
             headers={"content-type": "text/event-stream"},
         )
-        httpx_mock.add_response(
-            url="https://example.com/messages?sid=abc",
-            method="POST",
-            status_code=202,
-            is_reusable=True,
-        )
 
         headers = {"Content-Type": "application/json"}
-        stdin = _BlockingStdin(
-            '{"jsonrpc":"2.0","method":"notifications/initialized"}', refreshed
-        )
+        # Empty line → skipped by the main loop (no POST) → then blocks until the
+        # timer fires and the gen releases it.
+        stdin = _BlockingStdin("", release_stdin)
         stdout = StringIO()
         with patch("sys.stdin", stdin), patch("sys.stdout", stdout):
             run_sse(

--- a/tests/test_relay.py
+++ b/tests/test_relay.py
@@ -37,7 +37,9 @@ from mcp_stdio.relay import (
     _parse_retry_after,
     _parse_www_authenticate_scope,
     _post_and_stream,
+    _proactive_refresh_loop,
     _reinitialize,
+    _start_proactive_refresh,
     _same_origin,
     _split_sse_text,
     _sse_reader_loop,
@@ -5064,6 +5066,255 @@ class TestRunSseReaderRecovery:
         gets = [r for r in httpx_mock.get_requests() if r.method == "GET"]
         assert len(gets) >= 2, f"expected a reconnect (>=2 GETs), got {len(gets)}"
         assert "recovered" in stdout.getvalue()
+
+
+class TestProactiveRefresh:
+    """Unit + integration tests for the proactive token-refresh timer (#242)."""
+
+    @staticmethod
+    def _loop_kwargs(**overrides):
+        base = {
+            "refresher": lambda: {"Authorization": "Bearer new"},
+            "expiry_getter": lambda: 100.0,
+            "leeway": 0.0,
+            "headers": {"Authorization": "Bearer old"},
+            "headers_lock": threading.Lock(),
+            "refresh_lock": threading.Lock(),
+            "stop": threading.Event(),
+            "now": lambda: 1000.0,  # well past expiry → refresh fires immediately
+            "recheck": 0.001,
+            "max_sleep": 300.0,
+        }
+        base.update(overrides)
+        return base
+
+    def test_refreshes_when_past_deadline(self):
+        """Past expiry → refresher called and headers merged under the lock."""
+        stop = threading.Event()
+        calls = []
+
+        def refresher():
+            calls.append(1)
+            if len(calls) >= 3:
+                stop.set()
+            return {"Authorization": "Bearer new"}
+
+        headers = {"Authorization": "Bearer old"}
+        _proactive_refresh_loop(
+            **self._loop_kwargs(refresher=refresher, headers=headers, stop=stop)
+        )
+        assert len(calls) == 3
+        assert headers["Authorization"] == "Bearer new"
+
+    def test_none_expiry_polls_without_refreshing(self):
+        """A None expiry (no token / non-expiring) idles without refreshing."""
+        stop = threading.Event()
+        polls = []
+        refresher_calls = []
+
+        def expiry_getter():
+            polls.append(1)
+            stop.set()  # stop on the first poll so the recheck wait returns at once
+            return None
+
+        _proactive_refresh_loop(
+            **self._loop_kwargs(
+                expiry_getter=expiry_getter,
+                refresher=lambda: refresher_calls.append(1) or {"x": "y"},
+                stop=stop,
+            )
+        )
+        assert polls == [1]
+        assert refresher_calls == []  # never refreshed: nothing to schedule against
+
+    def test_failed_refresh_backs_off_and_retries(self):
+        """A refresher returning None backs off (recheck) and retries, no crash."""
+        stop = threading.Event()
+        calls = []
+
+        def refresher():
+            calls.append(1)
+            if len(calls) >= 2:
+                stop.set()
+            return None  # refresh unavailable / failed
+
+        _proactive_refresh_loop(
+            **self._loop_kwargs(refresher=refresher, stop=stop)
+        )
+        assert len(calls) == 2
+
+    def test_prestopped_returns_immediately(self):
+        """A pre-set stop event makes the loop a no-op."""
+        stop = threading.Event()
+        stop.set()
+        calls = []
+        _proactive_refresh_loop(
+            **self._loop_kwargs(
+                refresher=lambda: calls.append(1) or {"x": "y"}, stop=stop
+            )
+        )
+        assert calls == []
+
+    def test_exception_does_not_kill_loop(self):
+        """An exception from getter/refresher is logged and retried, never fatal."""
+        stop = threading.Event()
+        calls = []
+
+        def expiry_getter():
+            calls.append(1)
+            if len(calls) >= 3:
+                stop.set()
+            raise RuntimeError("boom")
+
+        # Must return normally (loop survived all three raises), not propagate.
+        _proactive_refresh_loop(
+            **self._loop_kwargs(expiry_getter=expiry_getter, stop=stop)
+        )
+        assert len(calls) == 3
+
+    def test_start_disabled_returns_none(self):
+        """proactive_refresh=False → no thread started."""
+        thread, stop = _start_proactive_refresh(
+            refresher=lambda: None,
+            expiry_getter=lambda: None,
+            proactive_refresh=False,
+            leeway=60.0,
+            headers={},
+            headers_lock=threading.Lock(),
+            refresh_lock=threading.Lock(),
+        )
+        assert thread is None and stop is None
+
+    def test_start_without_oauth_returns_none(self):
+        """No refresher / getter (no OAuth) → no thread started even if enabled."""
+        thread, stop = _start_proactive_refresh(
+            refresher=None,
+            expiry_getter=None,
+            proactive_refresh=True,
+            leeway=60.0,
+            headers={},
+            headers_lock=threading.Lock(),
+            refresh_lock=threading.Lock(),
+        )
+        assert thread is None and stop is None
+
+    def test_start_runs_and_stops(self):
+        """An enabled timer starts, refreshes once, then stops/joins cleanly."""
+        headers = {"Authorization": "Bearer old"}
+        refreshed = threading.Event()
+        calls = []
+
+        def expiry_getter():
+            calls.append(1)
+            # First read is past-due (fire now); afterwards park far in the future.
+            return 0.0 if len(calls) == 1 else time.time() + 3600
+
+        def refresher():
+            refreshed.set()
+            return {"Authorization": "Bearer new"}
+
+        thread, stop = _start_proactive_refresh(
+            refresher=refresher,
+            expiry_getter=expiry_getter,
+            proactive_refresh=True,
+            leeway=0.0,
+            headers=headers,
+            headers_lock=threading.Lock(),
+            refresh_lock=threading.Lock(),
+        )
+        assert thread is not None and stop is not None
+        try:
+            assert refreshed.wait(timeout=2.0), "timer never refreshed"
+        finally:
+            stop.set()
+            thread.join(timeout=2.0)
+        assert not thread.is_alive()
+        assert headers["Authorization"] == "Bearer new"
+
+    def test_run_proactive_timer_fires(self, httpx_mock):
+        """run() starts the timer; it refreshes while the main loop parks on stdin."""
+        httpx_mock.add_response(
+            text='{"jsonrpc":"2.0","result":{},"id":1}',
+            headers={"content-type": "application/json"},
+        )
+        refreshed = threading.Event()
+
+        def refresher():
+            refreshed.set()
+            return {"Authorization": "Bearer refreshed"}
+
+        calls = []
+
+        def expiry_getter():
+            calls.append(1)
+            return 0.0 if len(calls) == 1 else time.time() + 3600
+
+        headers = {"Content-Type": "application/json"}
+        # _BlockingStdin releases (StopIteration) once the timer sets ``refreshed``.
+        stdin = _BlockingStdin(
+            '{"jsonrpc":"2.0","method":"init","id":1}', refreshed
+        )
+        stdout = StringIO()
+        with patch("sys.stdin", stdin), patch("sys.stdout", stdout):
+            run(
+                "https://example.com/mcp",
+                headers,
+                token_refresher=refresher,
+                token_expiry_getter=expiry_getter,
+                proactive_refresh=True,
+                refresh_leeway=0.0,
+            )
+        assert refreshed.is_set()
+        assert headers["Authorization"] == "Bearer refreshed"
+
+    def test_run_sse_proactive_timer_fires(self, httpx_mock):
+        """run_sse starts the timer; it refreshes while the main loop parks."""
+        url = "https://example.com/sse"
+        refreshed = threading.Event()
+
+        def refresher():
+            refreshed.set()
+            return {"Authorization": "Bearer refreshed"}
+
+        calls = []
+
+        def expiry_getter():
+            calls.append(1)
+            return 0.0 if len(calls) == 1 else time.time() + 3600
+
+        def sse_gen():
+            yield b"event: endpoint\ndata: /messages?sid=abc\n\n"
+            refreshed.wait(timeout=5)  # hold the GET open until the timer fires
+
+        httpx_mock.add_response(
+            url=url,
+            method="GET",
+            stream=IteratorStream(sse_gen()),
+            headers={"content-type": "text/event-stream"},
+        )
+        httpx_mock.add_response(
+            url="https://example.com/messages?sid=abc",
+            method="POST",
+            status_code=202,
+            is_reusable=True,
+        )
+
+        headers = {"Content-Type": "application/json"}
+        stdin = _BlockingStdin(
+            '{"jsonrpc":"2.0","method":"notifications/initialized"}', refreshed
+        )
+        stdout = StringIO()
+        with patch("sys.stdin", stdin), patch("sys.stdout", stdout):
+            run_sse(
+                url,
+                headers,
+                token_refresher=refresher,
+                token_expiry_getter=expiry_getter,
+                proactive_refresh=True,
+                refresh_leeway=0.0,
+            )
+        assert refreshed.is_set()
+        assert headers["Authorization"] == "Bearer refreshed"
 
 
 class TestRunSse:


### PR DESCRIPTION
## Summary

Closes #242. Adds a background timer that proactively refreshes the OAuth access token shortly before it expires, independent of request flow.

Reactive token refresh only fires on a transport-level **HTTP 401**. Some MCP gateways — notably Atlassian's `https://mcp.atlassian.com/v1/mcp` — signal an expired token as **HTTP 200 + a tool-result `isError: true`** instead. Neither reactive refresh (no 401) nor the startup-only proactive `ensure_token` ever fires, so a long-lived `--oauth` session fails every `tools/call` until the process restarts.

## Approach (option 3 from the issue)

A daemon timer wakes at `expires_at - leeway` and refreshes via the existing `token_refresher`, **without ever parsing a tool-result body** — gateway-agnostic and preserving the "body is opaque" invariant. The next wake reads the freshly persisted `expires_at` through a new `load_token`-backed expiry getter.

- **On by default** in OAuth mode; opt out with `--no-proactive-refresh`.
- Lead time reuses the existing `--oauth-refresh-leeway` (default 60 s).
- No-op without `--oauth` / `--oauth-device`.

## Thread safety

- `refresh_lock` serialises the timer's refresh against the reactive 401 refresh, so the two never race the AS's refresh-token rotation.
- `run()` now guards the shared `headers` dict with a `headers_lock` (`run_sse` already had one).
- The daemon thread is stopped + joined in the relay's `finally`; every exception in the loop is logged and retried after a backoff, so the thread never dies.

## Edge cases handled

- `expires_at is None` (no token / non-expiring) or a refresher returning `None` (no refresh_token / failed) → quiet recheck-interval poll, no hot loop.
- Clock skew absorbed by `leeway`; wake sleep capped at 300 s so an out-of-band expiry change is re-evaluated promptly.

## Tests

- `tests/test_relay.py::TestProactiveRefresh` — 8 deterministic unit tests driving `_proactive_refresh_loop` / `_start_proactive_refresh` directly (injected `now`/`stop`), plus `run()` and `run_sse()` integration tests proving the timer fires while the main loop parks on stdin and updates the shared headers.
- `tests/test_cli.py` — flag parsing (`--no-proactive-refresh`), `refresh_leeway` wiring, and the expiry getter being built only with `--oauth`.

Full suite: **1012 passed, 3 skipped**, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)