### PR TITLE
feat(serve): path-scoped issuer for --enable-oauth (#245)

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -294,6 +294,19 @@ mcp-stdio --oauth http://127.0.0.1:8080/mcp
 （クライアントは `--oauth` を再実行）。バックエンドコマンドはオプションの後に
 置きます（`--` 区切りも可）。
 
+  - *パススコープ issuer* — `--public-url` がパスを保持するので、1 ホスト配下で
+    複数の `--enable-oauth` バックエンドをパスプレフィックスで多重化できる
+    （例: `--public-url https://gw.example.org/team-a` で
+    `https://gw.example.org/team-a/mcp` を配信）。issuer は
+    `https://gw.example.org/team-a` となり、AS エンドポイントはプレフィックス配下
+    （`/team-a/authorize`・`/token`・`/register`）、well-known ドキュメントは
+    [RFC 8414](https://www.rfc-editor.org/rfc/rfc8414) §3.1 /
+    [RFC 9728](https://www.rfc-editor.org/rfc/rfc9728) §3.1 の root-inserted
+    位置（`/.well-known/oauth-authorization-server/team-a`、
+    `/.well-known/oauth-protected-resource/team-a/mcp`）に置かれ、クライアントの
+    パス対応ディスカバリとバイト単位で対称。パスなしの `--public-url` は従来通り
+    動作します（#245）。
+
 ## ワークアラウンド
 
 Claude Code・mcp-remote・MCP SDK・Windows の既知の問題については [WORKAROUNDS.md](WORKAROUNDS.md) を参照してください。

--- a/README.md
+++ b/README.md
@@ -296,6 +296,19 @@ recommended behind a proxy), `--trusted-user-header HEADER`, `--dev-user USER`
 restart invalidates issued tokens (the client re-runs `--oauth`). The backend
 command follows the options (an optional `--` separator is supported).
 
+  - *Path-scoped issuer* — `--public-url` retains a path, so several
+    `--enable-oauth` backends can share one host behind a reverse proxy, each
+    under its own prefix (e.g. `--public-url https://gw.example.org/team-a`
+    serving `https://gw.example.org/team-a/mcp`). The issuer becomes
+    `https://gw.example.org/team-a`, its AS endpoints live under the prefix
+    (`/team-a/authorize`, `/token`, `/register`), and the well-known documents
+    sit at the [RFC 8414](https://www.rfc-editor.org/rfc/rfc8414) §3.1 /
+    [RFC 9728](https://www.rfc-editor.org/rfc/rfc9728) §3.1 root-inserted
+    locations (`/.well-known/oauth-authorization-server/team-a`,
+    `/.well-known/oauth-protected-resource/team-a/mcp`) — byte-symmetric with
+    the client's path-aware discovery. A bare-origin `--public-url` behaves
+    exactly as before (#245).
+
 ## Workarounds
 
 See [WORKAROUNDS.md](WORKAROUNDS.md) for known issues in Claude Code, mcp-remote, the MCP SDKs, and Windows that mcp-stdio addresses.

--- a/src/mcp_stdio/server.py
+++ b/src/mcp_stdio/server.py
@@ -380,6 +380,20 @@ def _normalize_public_url(url: str) -> str:
     # "https://host/a/" and "https://host/a" canonicalize identically and a bare
     # "https://host/" collapses to the bare origin (unchanged legacy behavior).
     path = p.path.rstrip("/")
+    if path:
+        # The prefix is concatenated verbatim into the endpoint URLs and the
+        # well-known locations, so it MUST be a canonical, traversal-free
+        # absolute path: an empty ("//"), "." or ".." segment would be
+        # re-normalized differently by a proxy or the client and break the
+        # byte-identical-issuer contract (and could escape the intended
+        # namespace). Reject rather than silently rewrite. The leading segment
+        # is always "" because an authority-form URL path is "/"-rooted.
+        segments = path.split("/")
+        if segments[0] != "" or any(seg in ("", ".", "..") for seg in segments[1:]):
+            raise ValueError(
+                "public-url path must be a canonical absolute path "
+                "(no empty, '.', or '..' segments)"
+            )
     return f"{p.scheme}://{netloc}{path}"
 
 

--- a/src/mcp_stdio/server.py
+++ b/src/mcp_stdio/server.py
@@ -341,15 +341,21 @@ def _redirect_key(uri: str) -> tuple[str, str, str] | None:
 
 
 def _normalize_public_url(url: str) -> str:
-    """Normalize --public-url to a canonical bare origin ``scheme://host[:port]``.
+    """Normalize --public-url to a canonical issuer ``scheme://host[:port][/path]``.
 
     Raises ValueError on a non-http(s) URL, a missing host, userinfo,
-    CR/LF/quote/space, or a non-loopback ``http://`` (a compliant client refuses
-    cleartext non-loopback endpoints). The host is lowercased, an explicit
-    default port is dropped, and an IPv6 literal is re-bracketed, so the issuer
-    is byte-identical to what a client derives (RFC 8414 Sec. 3.3). The
-    path/query/fragment are stripped — the OAuth issuer MUST be the bare origin
-    or the client cross-origin-rejects the metadata.
+    CR/LF/quote/space, a non-loopback ``http://`` (a compliant client refuses
+    cleartext non-loopback endpoints), a bad port, or a query/fragment (the
+    RFC 8414 Sec. 2 issuer grammar forbids them). The host is lowercased, an
+    explicit default port is dropped, an IPv6 literal is re-bracketed, and a
+    trailing slash is stripped, so the issuer is byte-identical to what a client
+    derives (RFC 8414 Sec. 3.3).
+
+    A PATH component is RETAINED: a path-scoped issuer (``https://host/team-a``)
+    lets several ``--enable-oauth`` backends share one host behind a reverse
+    proxy, each owning its AS namespace under its own prefix, symmetric with the
+    bundled client's RFC 8414 Sec. 3.1 / RFC 9728 Sec. 3.1 path-aware discovery
+    (#245). A bare-origin URL (no path) behaves exactly as before.
     """
     if any(c in url for c in ('"', "\r", "\n", " ")):
         raise ValueError("public-url contains forbidden characters")
@@ -358,6 +364,8 @@ def _normalize_public_url(url: str) -> str:
         raise ValueError("public-url must be an absolute http(s) URL with a host")
     if p.username or p.password or "@" in p.netloc:
         raise ValueError("public-url must not contain userinfo")
+    if p.query or p.fragment:
+        raise ValueError("public-url must not contain a query or fragment")
     host = p.hostname.lower()
     if p.scheme == "http" and host not in _LOOPBACK_HOSTS:
         raise ValueError("a non-loopback public-url must use https")
@@ -368,7 +376,11 @@ def _normalize_public_url(url: str) -> str:
     hostpart = f"[{host}]" if ":" in host else host
     default_port = 80 if p.scheme == "http" else 443
     netloc = hostpart if (port is None or port == default_port) else f"{hostpart}:{port}"
-    return f"{p.scheme}://{netloc}"
+    # Retain the path as the issuer prefix; strip only a trailing slash so
+    # "https://host/a/" and "https://host/a" canonicalize identically and a bare
+    # "https://host/" collapses to the bare origin (unchanged legacy behavior).
+    path = p.path.rstrip("/")
+    return f"{p.scheme}://{netloc}{path}"
 
 
 def _redact_query(line: str) -> str:
@@ -734,10 +746,34 @@ class _Handler(BaseHTTPRequestHandler):
             return self.oauth.public_url
         return self._origin()
 
+    def _issuer_origin_and_prefix(self) -> tuple[str, str]:
+        """Split the effective issuer into (bare origin, path prefix).
+
+        The prefix is ``""`` for a bare-origin issuer (the legacy behavior and
+        the reflected-Host fallback) and e.g. ``"/team-a"`` for a path-scoped
+        ``--public-url``. It drives the root-inserted well-known locations and
+        the prefixed AS endpoint / MCP paths so a path-scoped issuer is
+        byte-symmetric with the bundled client's RFC 8414 Sec. 3.1 / RFC 9728
+        Sec. 3.1 construction (#245). The path prefix can only come from a pinned
+        ``--public-url``; the reflected ``_origin()`` never carries one.
+        """
+        parsed = urlsplit(self._effective_issuer())
+        origin = f"{parsed.scheme}://{parsed.netloc}"
+        return origin, parsed.path
+
+    def _mcp_wire_path(self) -> str:
+        """The on-the-wire MCP path: the issuer prefix + the configured path.
+
+        Behind a path-multiplexing proxy the backend receives the full prefixed
+        path (e.g. ``/team-a/mcp``); a bare-origin issuer leaves it ``/mcp``.
+        """
+        _, prefix = self._issuer_origin_and_prefix()
+        return prefix + self.mcp_path
+
     def _wrong_path(self) -> bool:
         # Compare only the path component; ignore any query string.
         path = self.path.split("?", 1)[0]
-        if path != self.mcp_path:
+        if path != self._mcp_wire_path():
             self._send_json(404, _error_body("not found"))
             return True
         return False
@@ -770,10 +806,15 @@ class _Handler(BaseHTTPRequestHandler):
         return self._effective_issuer() + self.mcp_path
 
     def _prm_url(self) -> str:
-        # RFC 9728 Sec. 3.1 path insertion. Use the effective issuer (pinned
-        # --public-url when set) so the 401 hint, the PRM document, and the AS
-        # metadata all advertise the same origin behind a proxy.
-        return self._effective_issuer() + _PRM_WELL_KNOWN_PREFIX + self.mcp_path
+        # RFC 9728 Sec. 3.1 path insertion: the well-known label is inserted
+        # between the host and the resource's FULL path (issuer prefix +
+        # mcp_path), so a path-scoped issuer yields e.g.
+        # https://host/.well-known/oauth-protected-resource/team-a/mcp — byte-
+        # symmetric with the client's _build_well_known_url. For a bare-origin
+        # issuer (prefix "") this is identical to the legacy form. The 401 hint,
+        # the PRM document, and the AS metadata thus all stay consistent (#245).
+        origin, prefix = self._issuer_origin_and_prefix()
+        return origin + _PRM_WELL_KNOWN_PREFIX + prefix + self.mcp_path
 
     def _authorized(self) -> bool:
         """True when no auth is configured, or a valid Bearer token is presented.
@@ -904,12 +945,14 @@ class _Handler(BaseHTTPRequestHandler):
         raw = self.rfile.read(length) if length > 0 else b""
         if self.oauth is not None:
             # AS POST endpoints (DCR + token) bootstrap the token, exempt from
-            # the RS gate. Match by EXACT path. Body already drained above.
+            # the RS gate. Match by EXACT path under the issuer prefix (empty for
+            # a bare-origin issuer). Body already drained above.
             path = self.path.split("?", 1)[0]
-            if path == _REGISTER_PATH:
+            _, prefix = self._issuer_origin_and_prefix()
+            if path == prefix + _REGISTER_PATH:
                 self._handle_register(raw)
                 return
-            if path == _TOKEN_PATH:
+            if path == prefix + _TOKEN_PATH:
                 self._handle_token(raw)
                 return
         if self._wrong_path():
@@ -968,11 +1011,15 @@ class _Handler(BaseHTTPRequestHandler):
             return
         if self.oauth is not None:
             # AS endpoints bootstrap the token, so they are exempt from the RS
-            # gate. Match by EXACT path (never prefix).
-            if path == _AS_METADATA_PATH:
+            # gate. The AS metadata sits at the RFC 8414 Sec. 3.1 root-inserted
+            # location (well-known label + issuer prefix); /authorize lives under
+            # the prefix. Both reduce to the legacy root paths when the prefix is
+            # empty. Match by EXACT path (never a loose prefix).
+            origin, prefix = self._issuer_origin_and_prefix()
+            if path == _AS_METADATA_PATH + prefix:
                 self._serve_as_metadata()
                 return
-            if path == _AUTHORIZE_PATH:
+            if path == prefix + _AUTHORIZE_PATH:
                 self._handle_authorize()
                 return
         if self._wrong_path():
@@ -1155,9 +1202,14 @@ def serve_main(argv: list[str]) -> None:
         default=None,
         metavar="URL",
         help=(
-            "Canonical external origin (e.g. https://gw.example.org) used to pin "
-            "the OAuth issuer and all endpoint URLs. Strongly recommended behind "
-            "a reverse proxy; normalized to a bare origin (path stripped)."
+            "Canonical external issuer URL (e.g. https://gw.example.org) used to "
+            "pin the OAuth issuer and all endpoint URLs. Strongly recommended "
+            "behind a reverse proxy. A PATH is retained as an issuer prefix "
+            "(e.g. https://gw.example.org/team-a), letting several "
+            "--enable-oauth backends share one host under distinct path "
+            "prefixes; the AS endpoints then live under that prefix and the "
+            "well-known docs at the RFC 8414/9728 root-inserted locations. A "
+            "bare-origin URL behaves as before."
         ),
     )
     parser.add_argument(
@@ -1237,7 +1289,7 @@ def serve_main(argv: list[str]) -> None:
             except ValueError as e:
                 parser.error(f"--public-url invalid: {e}")
             if public_url != args.public_url.rstrip("/"):
-                log(f"note: --public-url normalized to origin {public_url}")
+                log(f"note: --public-url normalized to {public_url}")
         else:
             log(
                 "warning: --enable-oauth without --public-url; the issuer is "

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -698,14 +698,155 @@ def test_public_url_pins_issuer():
         assert prm["authorization_servers"] == ["https://gw.example.org"]
 
 
+# -- path-scoped issuer (#245): multiple --enable-oauth backends behind one host --
+
+_PREFIXED = "https://gw.example.org/team-a"
+
+
+def test_path_scoped_as_metadata_root_inserted():
+    """A path-scoped issuer serves AS metadata at the RFC 8414 Sec. 3.1
+    root-inserted location, advertising prefixed endpoints; the bare-origin
+    location 404s so two backends never collide there."""
+    with _run(oauth=_provider(public_url=_PREFIXED)) as (base, _):
+        # Root-inserted well-known: /.well-known/oauth-authorization-server/team-a
+        md = httpx.get(
+            base + "/.well-known/oauth-authorization-server/team-a", timeout=10
+        ).json()
+        assert md["issuer"] == _PREFIXED
+        assert md["authorization_endpoint"] == _PREFIXED + "/authorize"
+        assert md["token_endpoint"] == _PREFIXED + "/token"
+        assert md["registration_endpoint"] == _PREFIXED + "/register"
+        # The bare-origin AS metadata path must NOT serve this backend.
+        assert httpx.get(
+            base + "/.well-known/oauth-authorization-server", timeout=10
+        ).status_code == 404
+
+
+def test_path_scoped_prm_root_inserted():
+    """PRM is root-inserted with the full resource path (prefix + mcp_path),
+    byte-symmetric with the client's _build_well_known_url."""
+    with _run(oauth=_provider(public_url=_PREFIXED)) as (base, _):
+        prm = httpx.get(
+            base + "/.well-known/oauth-protected-resource/team-a/mcp", timeout=10
+        ).json()
+        assert prm["resource"] == _PREFIXED + "/mcp"
+        assert prm["authorization_servers"] == [_PREFIXED]
+
+
+def test_path_scoped_bare_as_endpoints_404():
+    """With a prefix pinned, the bare-origin AS endpoints 404 (isolation)."""
+    with _run(oauth=_provider(public_url=_PREFIXED)) as (base, _):
+        assert httpx.get(base + "/authorize", timeout=10).status_code == 404
+        assert httpx.post(base + "/register", content="{}", timeout=10).status_code == 404
+        assert httpx.post(base + "/token", content="x=1", timeout=10).status_code == 404
+        # The MCP endpoint also lives under the prefix now.
+        assert httpx.post(base + "/mcp", content="{}", timeout=10).status_code == 404
+
+
+def test_path_scoped_full_flow():
+    """End-to-end under a path prefix: DCR -> PKCE authorize -> token -> MCP."""
+    prefix = "/team-a"
+    with _run(oauth=_provider(public_url=_PREFIXED)) as (base, _):
+        # DCR under the prefix.
+        cid = httpx.post(
+            base + prefix + "/register",
+            json={
+                "client_name": "test",
+                "redirect_uris": [_REDIRECT],
+                "response_types": ["code"],
+                "grant_types": ["authorization_code", "refresh_token"],
+                "token_endpoint_auth_method": "none",
+            },
+            timeout=10,
+        ).json()["client_id"]
+        verifier, challenge = client_oauth.generate_pkce()
+        az = httpx.get(
+            base + prefix + "/authorize",
+            params={
+                "client_id": cid,
+                "response_type": "code",
+                "redirect_uri": _REDIRECT,
+                "state": "st-1",
+                "code_challenge": challenge,
+                "code_challenge_method": "S256",
+                "resource": _PREFIXED + "/mcp",
+            },
+            follow_redirects=False,
+            timeout=10,
+        )
+        assert az.status_code == 302, az.text
+        code = _redirect_params(az)["code"]
+        tok = httpx.post(
+            base + prefix + "/token",
+            data={
+                "grant_type": "authorization_code",
+                "code": code,
+                "redirect_uri": _REDIRECT,
+                "client_id": cid,
+                "code_verifier": verifier,
+            },
+            timeout=10,
+        ).json()
+        access = tok["access_token"]
+        # The issued token authorizes a real MCP call at the prefixed path.
+        r = httpx.post(
+            base + prefix + "/mcp",
+            content=json.dumps({"jsonrpc": "2.0", "id": 1, "method": "echo"}),
+            headers={"Authorization": f"Bearer {access}"},
+            timeout=10,
+        )
+        assert r.status_code == 200
+        # An unauthenticated prefixed MCP call is challenged with the
+        # root-inserted PRM hint.
+        chal = httpx.post(
+            base + prefix + "/mcp",
+            content=json.dumps({"jsonrpc": "2.0", "id": 2, "method": "echo"}),
+            timeout=10,
+        )
+        assert chal.status_code == 401
+        assert "/.well-known/oauth-protected-resource/team-a/mcp" in chal.headers[
+            "WWW-Authenticate"
+        ]
+
+
+def test_two_path_scoped_backends_do_not_collide():
+    """Two prefixes route to disjoint AS-metadata / endpoint paths."""
+    a = "https://gw.example.org/team-a"
+    b = "https://gw.example.org/team-b"
+    with _run(oauth=_provider(public_url=a)) as (base_a, _):
+        with _run(oauth=_provider(public_url=b)) as (base_b, _):
+            # Each backend answers only at its own root-inserted metadata path.
+            assert httpx.get(
+                base_a + "/.well-known/oauth-authorization-server/team-a", timeout=10
+            ).json()["issuer"] == a
+            assert httpx.get(
+                base_a + "/.well-known/oauth-authorization-server/team-b", timeout=10
+            ).status_code == 404
+            assert httpx.get(
+                base_b + "/.well-known/oauth-authorization-server/team-b", timeout=10
+            ).json()["issuer"] == b
+            assert httpx.get(
+                base_b + "/.well-known/oauth-authorization-server/team-a", timeout=10
+            ).status_code == 404
+
+
 def test_normalize_public_url():
-    assert server._normalize_public_url("https://gw.example.org/mcp") == "https://gw.example.org"
+    # A bare origin is unchanged (legacy behavior).
+    assert server._normalize_public_url("https://gw.example.org") == "https://gw.example.org"
     assert server._normalize_public_url("http://127.0.0.1:8080") == "http://127.0.0.1:8080"
-    # canonicalization: lowercase host, drop explicit default port
-    assert server._normalize_public_url("https://EXAMPLE.com:443/x") == "https://example.com"
+    # A path is RETAINED as the issuer prefix (#245), trailing slash stripped.
+    assert server._normalize_public_url("https://gw.example.org/team-a") == "https://gw.example.org/team-a"
+    assert server._normalize_public_url("https://gw.example.org/team-a/") == "https://gw.example.org/team-a"
+    assert server._normalize_public_url("https://gw.example.org/a/b") == "https://gw.example.org/a/b"
+    # A bare host with only a trailing slash collapses to the bare origin.
+    assert server._normalize_public_url("https://gw.example.org/") == "https://gw.example.org"
+    # canonicalization: lowercase host, drop explicit default port, keep path
+    assert server._normalize_public_url("https://EXAMPLE.com:443/x") == "https://example.com/x"
     assert server._normalize_public_url("http://LOCALHOST:80") == "http://localhost"
     for bad in ("ftp://h", "https://", 'https://h"x', "https://user@h",
-                "http://gw.example.org"):  # non-loopback http is rejected
+                "http://gw.example.org",  # non-loopback http is rejected
+                "https://gw.example.org/a?q=1",  # query forbidden in an issuer
+                "https://gw.example.org/a#f"):  # fragment forbidden in an issuer
         with pytest.raises(ValueError):
             server._normalize_public_url(bad)
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -846,7 +846,11 @@ def test_normalize_public_url():
     for bad in ("ftp://h", "https://", 'https://h"x', "https://user@h",
                 "http://gw.example.org",  # non-loopback http is rejected
                 "https://gw.example.org/a?q=1",  # query forbidden in an issuer
-                "https://gw.example.org/a#f"):  # fragment forbidden in an issuer
+                "https://gw.example.org/a#f",  # fragment forbidden in an issuer
+                "https://gw.example.org/../admin",  # traversal segment rejected
+                "https://gw.example.org/a/../b",  # interior traversal rejected
+                "https://gw.example.org/a//b",  # empty segment rejected
+                "https://gw.example.org/a/./b"):  # "." segment rejected
         with pytest.raises(ValueError):
             server._normalize_public_url(bad)
 


### PR DESCRIPTION
## Summary

Closes #245. Lets `mcp-stdio serve --enable-oauth` advertise a **path-scoped issuer**, so several embedded-AS backends can share one host behind a reverse proxy, multiplexed by path prefix (e.g. `https://host/a/mcp`, `https://host/b/mcp`).

Previously `_normalize_public_url()` stripped the path, pinning the issuer at the bare-origin root — both backends advertised the same `/authorize`, `/token`, … and the proxy could route them to only one. The **client side** already supports path-based deployments (RFC 8414 §3.1 well-known path insertion + §3.3 issuer validation, RFC 9728 §3.1 path-aware PRM), so this closes a purely **server-side** gap and makes `serve` symmetric with the bundled client.

## Change

`--public-url https://host/<prefix>` now retains its path:

- issuer = `https://host/<prefix>`
- AS endpoints under the prefix: `/<prefix>/authorize`, `/token`, `/register`
- MCP endpoint at `/<prefix>/mcp`
- well-known docs at the **root-inserted** locations (byte-symmetric with the client's `_build_well_known_url`):
  - `/.well-known/oauth-authorization-server/<prefix>`
  - `/.well-known/oauth-protected-resource/<prefix>/mcp`
- A bare-origin `--public-url` (no path) behaves **exactly as today**.

## Touch points

- `_normalize_public_url` — retain the path (strip trailing slash; reject query/fragment per RFC 8414 §2; all existing rejections kept: forbidden chars, userinfo, non-loopback http, bad port, default-port drop, host lowercase).
- New `_issuer_origin_and_prefix()` / `_mcp_wire_path()` helpers.
- `_prm_url()` now root-inserts with the full resource path (prefix + mcp_path) — the previous form was wrong for a path-scoped issuer.
- `_wrong_path()` + the AS endpoint matchers in `do_GET`/`do_POST` match the prefixed/inserted forms (reduce to the legacy root paths when the prefix is empty).
- `metadata()` and `_resource_url()` unchanged — the issuer already carries the prefix.
- `serve_main` — updated `--public-url` help; the path is now accepted, not silently dropped.

## Tests (`tests/test_server.py`)

- Path-scoped AS metadata served at the root-inserted location with prefixed endpoints; bare-origin location 404s.
- PRM root-inserted with the full resource path.
- Bare AS/MCP paths 404 under a prefix (isolation).
- Full E2E under a prefix: DCR → PKCE authorize → token → authenticated MCP call; unauthenticated call returns the root-inserted PRM hint.
- Two prefixed backends do not collide on AS-metadata paths.
- `_normalize_public_url` updated for path retention / trailing-slash / query+fragment rejection; bare origin unchanged.

Full suite: **1019 passed, 3 skipped**, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)