### PR TITLE
feat(serve): RFC 9207 iss, RFC 7591 invalid_redirect_uri + DCR no-store

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -264,8 +264,11 @@ mcp-stdio --check http://127.0.0.1:8080/mcp
     Metadata（`/.well-known/oauth-protected-resource`）を広告。
   - *埋め込み OAuth AS*（`--enable-oauth`）— 最小 OAuth 2.1 認可サーバ
     （PKCE 認可コード・[RFC 7591](https://www.rfc-editor.org/rfc/rfc7591) 動的
-    クライアント登録・refresh・不透明インメモリトークン・stdlib のみ）。
-    mcp-stdio クライアントの `--oauth` がこのゲートウェイ相手に通ります。
+    クライアント登録〔§3.2.2 の `invalid_redirect_uri` エラー対応〕・refresh・
+    不透明インメモリトークン・stdlib のみ）。https issuer のときは認可レスポンスに
+    [RFC 9207](https://www.rfc-editor.org/rfc/rfc9207) `iss` パラメータを付与
+    （mix-up 対策）し metadata でも広告。mcp-stdio クライアントの `--oauth` が
+    このゲートウェイ相手に通ります。
 - 当面はシングルクライアント前提（JSON-RPC の id はそのまま透過）。
 
 静的トークンの例（トークンは env 経由で `ps` に出さない）:

--- a/README.md
+++ b/README.md
@@ -266,7 +266,10 @@ mcp-stdio --check http://127.0.0.1:8080/mcp
     Resource Metadata at `/.well-known/oauth-protected-resource`.
   - *Embedded OAuth AS* (`--enable-oauth`) — a minimal OAuth 2.1 Authorization
     Server (PKCE auth-code, [RFC 7591](https://www.rfc-editor.org/rfc/rfc7591)
-    dynamic client registration, refresh, opaque in-memory tokens, stdlib only).
+    dynamic client registration with the `invalid_redirect_uri` error per §3.2.2,
+    refresh, opaque in-memory tokens, stdlib only). An https issuer echoes the
+    [RFC 9207](https://www.rfc-editor.org/rfc/rfc9207) `iss` parameter on the
+    authorization response (mix-up defence) and advertises it in metadata.
     The mcp-stdio client's `--oauth` flow then works against the gateway.
 - Single-client assumption for now: JSON-RPC ids pass through verbatim.
 

--- a/src/mcp_stdio/server.py
+++ b/src/mcp_stdio/server.py
@@ -485,8 +485,12 @@ class _OAuthProvider:
         if not isinstance(body, dict):
             return bad("body must be a JSON object")
         uris = body.get("redirect_uris")
+        # RFC 7591 Sec. 3.2.2: a missing / empty / non-array redirect_uris is a
+        # STRUCTURAL metadata error (invalid_client_metadata). invalid_redirect_uri
+        # is reserved for the case where a present VALUE is invalid (the loopback
+        # check below).
         if not isinstance(uris, list) or not uris:
-            return bad_redirect("redirect_uris must be a non-empty array")
+            return bad("redirect_uris must be a non-empty array")
         keys = set()
         for u in uris:
             if not isinstance(u, str) or _redirect_key(u) is None:

--- a/src/mcp_stdio/server.py
+++ b/src/mcp_stdio/server.py
@@ -449,7 +449,7 @@ class _OAuthProvider:
     # -- metadata --------------------------------------------------------
 
     def metadata(self, issuer: str) -> dict[str, Any]:
-        return {
+        md: dict[str, Any] = {
             "issuer": issuer,
             "authorization_endpoint": issuer + _AUTHORIZE_PATH,
             "token_endpoint": issuer + _TOKEN_PATH,
@@ -459,12 +459,24 @@ class _OAuthProvider:
             "code_challenge_methods_supported": ["S256"],
             "token_endpoint_auth_methods_supported": ["none"],
         }
+        # RFC 9207 Sec. 2.3: advertise iss support only when we actually emit it
+        # — i.e. for an https issuer, since Sec. 2 requires the iss value to be an
+        # https URL. A loopback http dev issuer neither advertises the flag nor
+        # sends iss (see authorize()), keeping the two consistent.
+        if issuer.startswith("https://"):
+            md["authorization_response_iss_parameter_supported"] = True
+        return md
 
     # -- dynamic client registration (RFC 7591) --------------------------
 
     def register(self, raw: bytes) -> tuple[int, dict[str, Any]]:
         def bad(desc: str) -> tuple[int, dict[str, Any]]:
             return 400, {"error": "invalid_client_metadata", "error_description": desc}
+
+        def bad_redirect(desc: str) -> tuple[int, dict[str, Any]]:
+            # RFC 7591 Sec. 3.2.2 defines a dedicated error code for an invalid
+            # redirection URI value; prefer it over the generic metadata error.
+            return 400, {"error": "invalid_redirect_uri", "error_description": desc}
 
         try:
             body = json.loads(raw.decode("utf-8"))
@@ -474,11 +486,11 @@ class _OAuthProvider:
             return bad("body must be a JSON object")
         uris = body.get("redirect_uris")
         if not isinstance(uris, list) or not uris:
-            return bad("redirect_uris must be a non-empty array")
+            return bad_redirect("redirect_uris must be a non-empty array")
         keys = set()
         for u in uris:
             if not isinstance(u, str) or _redirect_key(u) is None:
-                return bad("redirect_uris must be loopback http URLs")
+                return bad_redirect("redirect_uris must be loopback http URLs")
             keys.add(_redirect_key(u))
         client_id = secrets.token_urlsafe(32)
         now = self._now()
@@ -502,13 +514,18 @@ class _OAuthProvider:
 
     # -- authorization endpoint (RFC 6749 4.1 + RFC 7636) ----------------
 
-    def authorize(self, params: dict[str, str], user: str | None) -> dict[str, str]:
+    def authorize(
+        self, params: dict[str, str], user: str | None, issuer: str
+    ) -> dict[str, str]:
         """Return an instruction dict for the handler.
 
         ``{"kind": "bad_request", "message": ...}`` -> direct 400 (NO redirect,
         per RFC 6749 4.1.2.1 for client_id/redirect_uri errors).
         ``{"kind": "redirect", "location": ...}`` -> 302 (success, or an in-band
         error whose Location carries error= + the echoed state).
+
+        ``issuer`` is the effective AS issuer; an https issuer is echoed back as
+        the RFC 9207 ``iss`` parameter on every redirect (mix-up defence).
         """
         cid = params.get("client_id", "")
         redirect_uri = params.get("redirect_uri", "")
@@ -525,6 +542,14 @@ class _OAuthProvider:
         def redirect(query: dict[str, str]) -> dict[str, str]:
             if state:
                 query = {**query, "state": state}
+            # RFC 9207 Sec. 2: include the issuer identifier in BOTH success and
+            # error authorization responses so a client talking to multiple ASes
+            # can detect a mix-up attack. Sec. 2 requires an https value, so a
+            # loopback http dev issuer is left without iss (and metadata() omits
+            # the support flag to match). Placed after state so a hostile state
+            # cannot shadow it (urlencode emits both verbatim regardless).
+            if issuer.startswith("https://"):
+                query = {**query, "iss": issuer}
             return {"kind": "redirect", "location": redirect_uri + "?" + urlencode(query)}
 
         if params.get("response_type") != "code":
@@ -905,7 +930,10 @@ class _Handler(BaseHTTPRequestHandler):
 
     def _handle_register(self, raw: bytes) -> None:
         status, body = self.oauth.register(raw)
-        self._send_oauth_json(status, json.dumps(body))
+        # RFC 7591 Sec. 3.2.1's response example carries Cache-Control: no-store;
+        # send it for symmetry with the token endpoint (and in case a future
+        # registration response ever carries a credential).
+        self._send_oauth_json(status, json.dumps(body), no_store=True)
 
     def _handle_token(self, raw: bytes) -> None:
         try:
@@ -924,7 +952,7 @@ class _Handler(BaseHTTPRequestHandler):
         parsed = parse_qs(query, keep_blank_values=True)
         params = {k: v[0] for k, v in parsed.items()}
         user = self._resolve_user()
-        result = self.oauth.authorize(params, user)
+        result = self.oauth.authorize(params, user, self._effective_issuer())
         if result["kind"] == "bad_request":
             self._send_oauth_json(
                 400,

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -439,6 +439,54 @@ def test_prm_has_authorization_servers_when_oauth(oauth_gateway):
     assert prm["authorization_servers"] == [prm["resource"].rsplit("/mcp", 1)[0]]
 
 
+def test_as_metadata_no_iss_flag_for_http_issuer(oauth_gateway):
+    """RFC 9207 Sec. 2 requires an https iss; a loopback http issuer must NOT
+    advertise iss support (it also never emits iss — see authorize tests)."""
+    base, _ = oauth_gateway
+    md = httpx.get(base + "/.well-known/oauth-authorization-server", timeout=10).json()
+    assert "authorization_response_iss_parameter_supported" not in md
+
+
+def test_https_issuer_advertises_and_emits_iss():
+    """RFC 9207: an https issuer advertises iss support AND echoes iss on the
+    authorization redirect (success path), so a multi-AS client can detect
+    a mix-up attack."""
+    issuer = "https://gw.example.org"
+    with _run(oauth=_provider(public_url=issuer)) as (base, _):
+        md = httpx.get(
+            base + "/.well-known/oauth-authorization-server", timeout=10
+        ).json()
+        assert md["authorization_response_iss_parameter_supported"] is True
+        cid = _register(base).json()["client_id"]
+        _, challenge = client_oauth.generate_pkce()
+        az = _authorize(base, cid, challenge)
+        assert az.status_code == 302, az.text
+        params = _redirect_params(az)
+        assert params["iss"] == issuer
+        assert "code" in params  # success response still carries the code
+
+
+def test_https_issuer_emits_iss_on_error_redirect():
+    """RFC 9207 Sec. 2: iss appears on error authorization responses too."""
+    issuer = "https://gw.example.org"
+    with _run(oauth=_provider(public_url=issuer)) as (base, _):
+        cid = _register(base).json()["client_id"]
+        _, challenge = client_oauth.generate_pkce()
+        az = _authorize(base, cid, challenge, response_type="token")
+        assert az.status_code == 302, az.text
+        params = _redirect_params(az)
+        assert params["error"] == "unsupported_response_type"
+        assert params["iss"] == issuer
+
+
+def test_register_response_is_no_store(oauth_gateway):
+    """RFC 7591 Sec. 3.2.1: the registration response carries no-store."""
+    base, _ = oauth_gateway
+    r = _register(base)
+    assert r.status_code == 201
+    assert "no-store" in r.headers.get("cache-control", "")
+
+
 def test_register_public_client(oauth_gateway):
     base, _ = oauth_gateway
     r = _register(base)
@@ -453,7 +501,8 @@ def test_register_rejects_non_loopback(oauth_gateway):
     base, _ = oauth_gateway
     r = _register(base, redirect="https://evil.example.com/callback")
     assert r.status_code == 400
-    assert r.json()["error"] == "invalid_client_metadata"
+    # RFC 7591 Sec. 3.2.2: an invalid redirect URI uses the dedicated error code.
+    assert r.json()["error"] == "invalid_redirect_uri"
 
 
 def test_register_rejects_non_json(oauth_gateway):
@@ -947,7 +996,8 @@ def test_register_rejects_query_bearing_redirect(oauth_gateway):
     base, _ = oauth_gateway
     r = _register(base, redirect="http://127.0.0.1:5555/callback?next=x")
     assert r.status_code == 400
-    assert r.json()["error"] == "invalid_client_metadata"
+    # RFC 7591 Sec. 3.2.2: an invalid redirect URI uses the dedicated error code.
+    assert r.json()["error"] == "invalid_redirect_uri"
 
 
 def test_refresh_wrong_client_id_preserves_token(oauth_gateway):

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -505,6 +505,18 @@ def test_register_rejects_non_loopback(oauth_gateway):
     assert r.json()["error"] == "invalid_redirect_uri"
 
 
+def test_register_missing_redirect_uris_is_client_metadata_error(oauth_gateway):
+    """RFC 7591 Sec. 3.2.2: a missing/empty redirect_uris is a STRUCTURAL
+    metadata error (invalid_client_metadata), not invalid_redirect_uri."""
+    base, _ = oauth_gateway
+    r = httpx.post(base + "/register", json={"client_name": "x"}, timeout=10)
+    assert r.status_code == 400
+    assert r.json()["error"] == "invalid_client_metadata"
+    r2 = httpx.post(base + "/register", json={"redirect_uris": []}, timeout=10)
+    assert r2.status_code == 400
+    assert r2.json()["error"] == "invalid_client_metadata"
+
+
 def test_register_rejects_non_json(oauth_gateway):
     base, _ = oauth_gateway
     r = httpx.post(base + "/register", content="not json", timeout=10)


### PR DESCRIPTION
## Summary

Embedded OAuth Authorization Server compliance fixes from the RFC audit (server mode, "advertise / register / authorize" surface).

| Fix | RFC (verified) | Level |
|---|---|---|
| Authorization response echoes `iss`; metadata advertises `authorization_response_iss_parameter_supported` | RFC 9207 §2 / §2.3 | SHOULD (mix-up defence) |
| DCR returns `invalid_redirect_uri` for a bad redirect URI value | RFC 7591 §3.2.2 | SHOULD |
| DCR response carries `Cache-Control: no-store` | RFC 7591 §3.2.1 | best-practice |

### RFC 9207 `iss` details
- Echoed on **both** success and error authorization redirects so a client talking to multiple ASes can detect a mix-up attack — the bundled client already validates this.
- **Gated on an https issuer** (RFC 9207 §2 requires the `iss` value to be an https URL): a loopback http dev issuer neither advertises the metadata flag nor emits `iss`, keeping the two consistent.
- `authorize()` now receives the effective issuer from the handler.

### Intentionally omitted
`scopes_supported` / `resource_name` (RFC 8414 §2 / RFC 9728 §2, both RECOMMENDED): the embedded AS has no scope model and no operator-supplied resource display name, so advertising empty values would be misleading rather than compliant.

## Tests
- `test_https_issuer_advertises_and_emits_iss` / `test_https_issuer_emits_iss_on_error_redirect` — https issuer advertises + emits iss on success and error.
- `test_as_metadata_no_iss_flag_for_http_issuer` — loopback http issuer does NOT advertise it.
- `test_register_response_is_no_store` — DCR no-store header.
- Updated `test_register_rejects_non_loopback` / `test_register_rejects_query_bearing_redirect` to assert the new `invalid_redirect_uri` code.

Full suite: **1023 passed, 3 skipped**, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)