### PR TITLE
feat(oauth): send application_type "native" in DCR (SEP-837 / RFC 8252)

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -43,6 +43,7 @@ Bearer token、カスタムヘッダー、OAuth 2.1 認証情報をリモート�
   - [RFC 7591](https://www.rfc-editor.org/rfc/rfc7591) Dynamic Client Registration
     - §3 クライアント登録リクエスト。AS メタデータの `token_endpoint_auth_methods_supported` から最適な認証方式を選択（`none` → `client_secret_post` → `client_secret_basic` の優先順）
     - §3.2.1 `client_secret_expires_at` に対応、期限切れ時に自動再登録
+    - DCR に `application_type: "native"`（[RFC 8252](https://www.rfc-editor.org/rfc/rfc8252) §8.4 / MCP SEP-837）。loopback 認可コード・ヘッドレス device フローは native クライアントなので、RFC 7591 既定の `"web"` 扱いで loopback redirect が拒否されるのを防ぐ
   - [RFC 6749](https://www.rfc-editor.org/rfc/rfc6749) OAuth 2.0
     - §2.3.1 `client_secret_basic`：percent-encode した認証情報を `Authorization: Basic` ヘッダーで送信（コード交換・トークンリフレッシュ・Device Authorization Grant ポーリングに適用）
   - [RFC 6750](https://www.rfc-editor.org/rfc/rfc6750) Bearer Token の利用

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Bearer tokens, custom headers, and OAuth 2.1 credentials are forwarded to the re
   - [RFC 7591](https://www.rfc-editor.org/rfc/rfc7591) Dynamic Client Registration
     - §3 client registration request; `token_endpoint_auth_method` chosen from `token_endpoint_auth_methods_supported` in AS metadata (prefers `none` → `client_secret_post` → `client_secret_basic`)
     - §3.2.1 `client_secret_expires_at` handling — auto re-register on expiry
+    - `application_type: "native"` in DCR ([RFC 8252](https://www.rfc-editor.org/rfc/rfc8252) §8.4 / MCP SEP-837): the loopback auth-code and headless device flows are native clients, so the loopback redirect is not rejected as the RFC 7591 default `"web"`
   - [RFC 6749](https://www.rfc-editor.org/rfc/rfc6749) OAuth 2.0
     - §2.3.1 `client_secret_basic`: `Authorization: Basic` header with percent-encoded credentials (applied to code exchange, token refresh, and Device Authorization Grant polling)
   - [RFC 6750](https://www.rfc-editor.org/rfc/rfc6750) Bearer Token usage

--- a/src/mcp_stdio/oauth.py
+++ b/src/mcp_stdio/oauth.py
@@ -889,15 +889,23 @@ def register_client(
     auth_method = _pick_token_endpoint_auth_method(
         metadata.token_endpoint_auth_methods_supported
     )
+    # SEP-837 / RFC 8252 §8.4: mcp-stdio is a NATIVE client — the auth-code flow
+    # uses a loopback (http://127.0.0.1:<port>/callback) redirect and the device
+    # flow is a headless native grant. SEP-837 requires DCR to specify an
+    # appropriate application_type (loopback/localhost -> "native"); the RFC 7591
+    # default is "web", so omitting it lets an AS reject or mis-treat the loopback
+    # redirect. Send "native" explicitly on both paths.
     if device_flow:
         body: dict[str, object] = {
             "client_name": "mcp-stdio",
+            "application_type": "native",
             "grant_types": ["urn:ietf:params:oauth:grant-type:device_code", "refresh_token"],
             "token_endpoint_auth_method": auth_method,
         }
     else:
         body = {
             "client_name": "mcp-stdio",
+            "application_type": "native",
             "redirect_uris": [redirect_uri],
             "response_types": ["code"],
             "grant_types": ["authorization_code", "refresh_token"],

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -1198,6 +1198,8 @@ class TestRegisterClient:
         assert body["client_name"] == "mcp-stdio"
         assert "http://127.0.0.1:9999/callback" in body["redirect_uris"]
         assert body["token_endpoint_auth_method"] == "none"
+        # SEP-837 / RFC 8252: a loopback-redirect client is "native".
+        assert body["application_type"] == "native"
 
     def test_success_without_client_secret(self, httpx_mock):
         """Some servers return only client_id (public client)."""
@@ -5724,6 +5726,8 @@ class TestDeviceAuthorizationFlow:
         body = json.loads(dcr_req.content)
         assert "urn:ietf:params:oauth:grant-type:device_code" in body["grant_types"]
         assert "redirect_uris" not in body
+        # SEP-837: the headless device-flow client is also "native".
+        assert body["application_type"] == "native"
 
     def test_da_request_includes_resource_indicator(self, httpx_mock, tmp_path, monkeypatch):
         """Device Authorization Request must include resource parameter (RFC 8707)."""


### PR DESCRIPTION
## Summary

From the RFC-compliance audit follow-up. MCP **SEP-837** (and **RFC 8252 §8.4**) require Dynamic Client Registration to specify an appropriate `application_type`. mcp-stdio is a **native** client — the auth-code flow uses a loopback (`http://127.0.0.1:<port>/callback`) redirect and the device flow is a headless native grant — but DCR omitted `application_type`, so an AS applies the RFC 7591 default `"web"` and may reject or mis-treat the loopback redirect.

## Change
Send `"application_type": "native"` on **both** DCR bodies (auth-code and device-flow) in `register_client`.

## Tests
- `TestRegisterClient::test_success` asserts `application_type == "native"` on the auth-code DCR body.
- The device-flow DCR test asserts `application_type == "native"` too.

Full suite: **1034 passed, 3 skipped**, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)