### PR TITLE
feat(oauth): --oauth-use-id-token to present the OIDC id_token as Bearer (#59)

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -188,6 +188,9 @@ mcp-stdio [OPTIONS] URL
   --oauth-device         OAuth 2.1 Device Authorization Grant（RFC 8628）— ヘッドレス環境向け
   --client-id ID         事前登録済み OAuth クライアント ID（MCP_OAUTH_CLIENT_ID 環境変数でも指定可）
   --oauth-scope SCOPE    要求する OAuth スコープ
+  --oauth-use-id-token   access_token ではなく OIDC id_token を Bearer として送信
+                         （AWS Bedrock AgentCore / Cognito 向け）。id_token が
+                         無ければ access_token にフォールバック（#59）
   --oauth-refresh-leeway SECONDS
                          アクセストークンを expire の何秒前に proactive refresh
                          するか（デフォルト: 60、または MCP_OAUTH_REFRESH_LEEWAY 環境変数）

--- a/README.md
+++ b/README.md
@@ -190,6 +190,9 @@ Options:
   --oauth-device         Enable OAuth 2.1 Device Authorization Grant (RFC 8628, headless)
   --client-id ID         Pre-registered OAuth client ID (or set MCP_OAUTH_CLIENT_ID)
   --oauth-scope SCOPE    OAuth scope to request
+  --oauth-use-id-token   Present the OIDC id_token as the Bearer credential
+                         instead of the access_token (AWS Bedrock AgentCore /
+                         Cognito); falls back to access_token if none is returned (#59)
   --oauth-refresh-leeway SECONDS
                          Proactively refresh tokens this many seconds before
                          expiry (default: 60, or MCP_OAUTH_REFRESH_LEEWAY)

--- a/src/mcp_stdio/cli.py
+++ b/src/mcp_stdio/cli.py
@@ -7,12 +7,15 @@ import math
 import os
 import re
 import sys
-from typing import Callable
+from typing import TYPE_CHECKING, Callable
 
 import httpx
 
 from . import __version__
 from .relay import check_connection, run, run_sse
+
+if TYPE_CHECKING:
+    from .token_store import TokenData
 
 def _non_negative_float(value: str) -> float:
     """argparse type for non-negative floats (rejects negative leeway)."""
@@ -76,6 +79,25 @@ def _bearer_header_value(token: str) -> str:
     return f"Bearer {token}"
 
 
+def _effective_bearer(data: TokenData, use_id_token: bool) -> str:
+    """Pick the credential to present as Bearer: id_token or access_token (#59).
+
+    With --oauth-use-id-token, the OIDC id_token is the Bearer (AWS Bedrock
+    AgentCore / Cognito expect it). Falls back to access_token when the AS
+    returned no id_token, with a one-line warning, rather than presenting an
+    empty credential.
+    """
+    if use_id_token:
+        if data.id_token:
+            return data.id_token
+        print(
+            "warning: --oauth-use-id-token set but the token response carried no "
+            "id_token; falling back to access_token",
+            file=sys.stderr,
+        )
+    return data.access_token
+
+
 def _parse_header(header: str) -> tuple[str, str]:
     """Parse a header string 'Key: Value' into a tuple.
 
@@ -115,6 +137,8 @@ def _build_token_refresher(
     headers: dict[str, str],
     timeout_connect: float,
     timeout_read: float,
+    *,
+    use_id_token: bool = False,
 ) -> Callable[[], dict[str, str] | None]:
     """Build a token refresher callback for the relay loop.
 
@@ -151,7 +175,9 @@ def _build_token_refresher(
             if data is None:
                 return None
             new_headers = dict(base_headers)
-            new_headers["Authorization"] = _bearer_header_value(data.access_token)
+            new_headers["Authorization"] = _bearer_header_value(
+                _effective_bearer(data, use_id_token)
+            )
             return new_headers
         except Exception as e:
             # Mirror upgrader(): a refresh failure beyond the network call
@@ -173,6 +199,8 @@ def _build_scope_upgrader(
     timeout_connect: float,
     timeout_read: float,
     oauth_timeout: float,
+    *,
+    use_id_token: bool = False,
 ) -> Callable[[str], dict[str, str] | None]:
     """Build a scope-upgrade callback for the relay loop.
 
@@ -206,7 +234,9 @@ def _build_scope_upgrader(
                 server_url, client, required_scope, timeout=oauth_timeout
             )
             new_headers = dict(base_headers)
-            new_headers["Authorization"] = _bearer_header_value(data.access_token)
+            new_headers["Authorization"] = _bearer_header_value(
+                _effective_bearer(data, use_id_token)
+            )
         except Exception as e:
             print(f"error: step-up authorization failed: {e}", file=sys.stderr)
             return None
@@ -318,6 +348,17 @@ def _main() -> None:
             "malformed MCP_OAUTH_REFRESH_LEEWAY value aborts startup at argument "
             "parsing even on a non-OAuth run (the env default is validated eagerly "
             "so a bad value surfaces clearly rather than silently)"
+        ),
+    )
+    parser.add_argument(
+        "--oauth-use-id-token",
+        action="store_true",
+        help=(
+            "Present the OIDC id_token as the Bearer credential instead of the "
+            "access_token. Required for servers that validate the id_token (e.g. "
+            "AWS Bedrock AgentCore / Cognito). Falls back to the access_token if "
+            "the AS returns no id_token. Only used with --oauth / --oauth-device "
+            "(#59)."
         ),
     )
     parser.add_argument(
@@ -634,7 +675,7 @@ def _main() -> None:
                 del headers[existing]
             try:
                 headers["Authorization"] = _bearer_header_value(
-                    token_data.access_token
+                    _effective_bearer(token_data, args.oauth_use_id_token)
                 )
             except ValueError as e:
                 # The AS handed us a token with CR/LF/NUL — fail startup clearly
@@ -646,7 +687,8 @@ def _main() -> None:
             # or steps up), so only build them on the real relay path. See #15.
             if not (args.check or args.test):
                 token_refresher = _build_token_refresher(
-                    args.url, headers, args.timeout_connect, args.timeout_read
+                    args.url, headers, args.timeout_connect, args.timeout_read,
+                    use_id_token=args.oauth_use_id_token,
                 )
                 scope_upgrader = _build_scope_upgrader(
                     args.url,
@@ -654,6 +696,7 @@ def _main() -> None:
                     args.timeout_connect,
                     args.timeout_read,
                     args.oauth_timeout,
+                    use_id_token=args.oauth_use_id_token,
                 )
                 token_expiry_getter = _build_token_expiry_getter(args.url)
         except Exception as e:

--- a/src/mcp_stdio/oauth.py
+++ b/src/mcp_stdio/oauth.py
@@ -2007,6 +2007,10 @@ def _run_device_authorization_flow(
                 # token response (RFC 6749 §5.1) — mirrors the auth-code and
                 # refresh paths so a device-flow token's scope is not wiped.
                 previous_scope=scope,
+                # Likewise keep a cached id_token when the device-flow response
+                # omits one, so --oauth-use-id-token survives a device re-auth
+                # (symmetric with the auth-code / refresh paths; #59).
+                previous_id_token=cached.id_token if cached else None,
                 client_secret_expires_at=cse_at,
                 auth_method=auth_method,
                 no_resource_indicator=not resource_indicator,

--- a/src/mcp_stdio/oauth.py
+++ b/src/mcp_stdio/oauth.py
@@ -1344,6 +1344,7 @@ def _token_response_to_data(
     *,
     previous_refresh_token: str | None = None,
     previous_scope: str | None = None,
+    previous_id_token: str | None = None,
     client_secret_expires_at: float | None = None,
     auth_method: str = "none",
     no_resource_indicator: bool = False,
@@ -1357,6 +1358,8 @@ def _token_response_to_data(
     may be omitted when identical to the requested scope, which refreshes
     routinely do), so ``previous_scope`` is preserved — otherwise a refresh
     would wipe the granted scope and a later step-up could not union it.
+    The OIDC ``id_token`` is likewise commonly omitted on a refresh response,
+    so ``previous_id_token`` is preserved for --oauth-use-id-token (#59).
     """
     if not raw.get("access_token"):
         # RFC 6749 §5.1 makes access_token REQUIRED. A response missing it is
@@ -1414,11 +1417,19 @@ def _token_response_to_data(
             f"mcp-stdio sends it as a Bearer credential anyway"
         )
 
+    # OIDC id_token is a string JWT; tolerate a non-string / empty value (treat
+    # as absent) and preserve the previous one when the response omits it, so a
+    # refresh that does not re-issue the id_token keeps --oauth-use-id-token
+    # working.
+    _idt = raw.get("id_token")
+    id_token = _idt if isinstance(_idt, str) and _idt else previous_id_token
+
     return TokenData(
         access_token=raw["access_token"],
         token_type=token_type,
         expires_at=expires_at,
         refresh_token=raw.get("refresh_token") or previous_refresh_token,
+        id_token=id_token,
         scope=raw.get("scope") or previous_scope,
         client_id=client_id,
         client_secret=client_secret,
@@ -1508,6 +1519,7 @@ def refresh_cached_token(
             cached.client_secret,
             previous_refresh_token=cached.refresh_token,
             previous_scope=cached.scope,
+            previous_id_token=cached.id_token,
             client_secret_expires_at=cached.client_secret_expires_at,
             auth_method=auth_method,
             no_resource_indicator=no_resource_indicator,
@@ -1736,6 +1748,9 @@ def _run_authorization_flow(
         # through, mirroring the refresh path (refresh_cached_token). Harmless on
         # initial auth, where `cached` is None or carries no refresh_token.
         previous_refresh_token=cached.refresh_token if cached else None,
+        # Preserve a cached id_token when the step-up/credential response omits
+        # one, mirroring refresh_token, so --oauth-use-id-token survives a step-up.
+        previous_id_token=cached.id_token if cached else None,
         # RFC 6749 §5.1 lets the AS omit `scope` when it equals the requested
         # scope — exactly what a step-up does (requested == merged union). Fall
         # back to the requested `scope` so the stored TokenData.scope is not

--- a/src/mcp_stdio/token_store.py
+++ b/src/mcp_stdio/token_store.py
@@ -131,6 +131,11 @@ class TokenData:
     token_type: str = "Bearer"
     expires_at: float | None = None
     refresh_token: str | None = None
+    # OIDC id_token (a JWT), captured so it can be used as the Bearer credential
+    # instead of access_token when --oauth-use-id-token is set (AWS Bedrock
+    # AgentCore / Cognito expect the id_token; #59). Not signature-verified —
+    # mcp-stdio relays it as an opaque bearer, same as access_token.
+    id_token: str | None = None
     scope: str | None = None
     # Dynamic client registration credentials
     client_id: str | None = None
@@ -859,6 +864,7 @@ def load_token(server_url: str) -> TokenData | None:
     for field in (
         "token_type",
         "refresh_token",
+        "id_token",
         "scope",
         "client_id",
         "client_secret",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -8,6 +8,7 @@ from mcp_stdio.cli import (
     _bearer_header_value,
     _build_scope_upgrader,
     _build_token_refresher,
+    _effective_bearer,
     _parse_header,
     main,
 )
@@ -28,6 +29,27 @@ class TestBearerHeaderValue:
     def test_control_char_token_rejected(self, bad):
         with pytest.raises(ValueError, match="forbidden control character"):
             _bearer_header_value(bad)
+
+
+class TestEffectiveBearer:
+    """#59: --oauth-use-id-token selects the OIDC id_token as the Bearer."""
+
+    def _data(self, **kw):
+        kw.setdefault("access_token", "acc")
+        return TokenData(**kw)
+
+    def test_access_token_by_default(self):
+        data = self._data(id_token="idt")
+        assert _effective_bearer(data, use_id_token=False) == "acc"
+
+    def test_id_token_when_flag_set(self):
+        data = self._data(id_token="idt")
+        assert _effective_bearer(data, use_id_token=True) == "idt"
+
+    def test_falls_back_to_access_token_when_no_id_token(self, capsys):
+        data = self._data(id_token=None)
+        assert _effective_bearer(data, use_id_token=True) == "acc"
+        assert "no id_token" in capsys.readouterr().err
 
 
 class TestParseHeader:

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -5764,6 +5764,24 @@ class TestDeviceAuthorizationFlow:
         # SEP-837: the headless device-flow client is also "native".
         assert body["application_type"] == "native"
 
+    def test_device_flow_preserves_cached_id_token(self, httpx_mock, tmp_path, monkeypatch):
+        """#59: a device-flow re-auth whose token response omits id_token keeps the
+        cached id_token, so --oauth-use-id-token survives (matches refresh path)."""
+        self._patch_store(tmp_path, monkeypatch)
+        httpx_mock.add_response(url=REG_URL, json={"client_id": "cid"})
+        httpx_mock.add_response(url=DEVICE_AUTH_URL, json=_da_response())
+        httpx_mock.add_response(
+            url=TOKEN_URL,
+            json={"access_token": "acc", "token_type": "Bearer"},  # no id_token
+        )
+        cached = TokenData(access_token="old", id_token="cached-idt")
+        client = httpx.Client()
+        data = _run_device_authorization_flow(
+            MCP_URL, client, metadata=_device_meta(), cached=cached
+        )
+        assert data.access_token == "acc"
+        assert data.id_token == "cached-idt"
+
     def test_da_request_includes_resource_indicator(self, httpx_mock, tmp_path, monkeypatch):
         """Device Authorization Request must include resource parameter (RFC 8707)."""
         self._patch_store(tmp_path, monkeypatch)

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -2051,6 +2051,41 @@ class TestTokenResponseToData:
         with pytest.raises(RuntimeError, match="access_token"):
             _token_response_to_data({"token_type": "Bearer"}, self.META, "cid", None)
 
+    def test_captures_id_token(self):
+        """#59: the OIDC id_token from the response is captured into TokenData."""
+        raw = {"access_token": "at", "id_token": "eyJhbGc.payload.sig"}
+        data = _token_response_to_data(raw, self.META, "cid", None)
+        assert data.id_token == "eyJhbGc.payload.sig"
+
+    def test_preserves_previous_id_token_when_omitted(self):
+        """#59: a refresh response that omits id_token keeps the previous one
+        (mirrors refresh_token), so --oauth-use-id-token survives a refresh."""
+        raw = {"access_token": "at2"}  # refresh response without id_token
+        data = _token_response_to_data(
+            raw, self.META, "cid", None, previous_id_token="prev-idt"
+        )
+        assert data.id_token == "prev-idt"
+
+    def test_response_id_token_overrides_previous(self):
+        raw = {"access_token": "at2", "id_token": "fresh-idt"}
+        data = _token_response_to_data(
+            raw, self.META, "cid", None, previous_id_token="prev-idt"
+        )
+        assert data.id_token == "fresh-idt"
+
+    def test_non_string_id_token_falls_back_to_previous(self):
+        """A non-string / empty id_token is treated as absent (not crashed on)."""
+        raw = {"access_token": "at", "id_token": 123}
+        data = _token_response_to_data(
+            raw, self.META, "cid", None, previous_id_token="prev-idt"
+        )
+        assert data.id_token == "prev-idt"
+        # No previous either -> None, not the integer.
+        data2 = _token_response_to_data(
+            {"access_token": "at", "id_token": 123}, self.META, "cid", None
+        )
+        assert data2.id_token is None
+
     def test_persists_iss_parameter_supported_from_metadata(self):
         """: the RFC 9207 §3 flag from the discovered metadata is
         written into TokenData so a later step-up can rehydrate it. A round-trip

--- a/tests/test_token_store.py
+++ b/tests/test_token_store.py
@@ -154,6 +154,29 @@ class TestLoadSaveDelete:
         assert loaded.access_token == "tok123"
         assert loaded.refresh_token == "ref456"
 
+    def test_id_token_round_trips(self, tmp_path, monkeypatch):
+        """#59: the OIDC id_token survives a save/load round-trip and a
+        non-string id_token from a corrupted store degrades to None."""
+        store_file = tmp_path / "tokens.json"
+        monkeypatch.setattr("mcp_stdio.token_store._STORE_DIR", tmp_path)
+        monkeypatch.setattr("mcp_stdio.token_store._STORE_FILE", store_file)
+
+        save_token(
+            "https://example.com/mcp",
+            TokenData(access_token="tok", id_token="eyJ.payload.sig"),
+        )
+        loaded = load_token("https://example.com/mcp")
+        assert loaded is not None and loaded.id_token == "eyJ.payload.sig"
+
+        # A type-broken id_token in the store rejects the whole entry (load None).
+        import json as _json
+
+        raw = _json.loads(store_file.read_text())
+        key = next(iter(raw))
+        raw[key]["id_token"] = 123
+        store_file.write_text(_json.dumps(raw))
+        assert load_token("https://example.com/mcp") is None
+
     def test_load_missing(self, tmp_path, monkeypatch):
         store_file = tmp_path / "tokens.json"
         monkeypatch.setattr("mcp_stdio.token_store._STORE_DIR", tmp_path)


### PR DESCRIPTION
## Summary

Closes #59. AWS Bedrock AgentCore, Cognito, and other OIDC servers validate the **id_token** rather than the access_token, so mcp-stdio's always-access_token Bearer fails against them.

## Change
- **`token_store.py`** — `TokenData.id_token: str | None`; added to the `load_token` string-field validation.
- **`oauth.py`** — `_token_response_to_data` captures `id_token`, with `previous_id_token` preserved when a refresh/step-up response omits it (mirrors `refresh_token`/`scope`). Wired on the refresh and step-up/credential paths. A non-string/empty `id_token` degrades to absent (no crash).
- **`cli.py`** — `--oauth-use-id-token` flag; new `_effective_bearer(data, use_id_token)` picks `id_token` vs `access_token` at the **three** header build sites (initial, reactive 401 refresher, 403 step-up upgrader). Falls back to `access_token` with a warning if the AS returns no id_token.

Not signature-verified — relayed as an opaque bearer, same as the access_token (per mcp-remote #219).

## Tests
- `TestTokenResponseToData`: id_token capture, previous-preservation on refresh, response-overrides-previous, non-string fallback.
- `TestEffectiveBearer` (test_cli): access_token by default, id_token when flagged, fallback + warning when none.
- `test_token_store`: id_token save/load round-trip; type-broken id_token rejects the entry.

Full suite: **1042 passed, 3 skipped**, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)