### PR TITLE
feat(oauth): --oauth-eager cold-start (local initialize + background OAuth)

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -60,6 +60,7 @@ Bearer token、カスタムヘッダー、OAuth 2.1 認証情報をリモート�
 - **401 時の自動トークンリフレッシュ** — セッション中に OAuth トークンが失効しても自動更新（OAuth モード時のみ）
 - **プロアクティブなトークンリフレッシュ** — バックグラウンドタイマーが OAuth トークンを失効直前にリフレッシュ（リード時間は `--oauth-refresh-leeway`）。トークン失効をトランスポート層の 401 ではなく HTTP 200 のツールエラーとして返すゲートウェイ（例: Atlassian の MCP ゲートウェイ）でも長時間セッションが生き残る。OAuth モードではデフォルト有効、`--no-proactive-refresh` で無効化（#242）
 - **403 時のステップアップ認可** — `Bearer error="insufficient_scope"` チャレンジを受けると、付与済みスコープと要求スコープの和集合で再認可（[RFC 9470](https://www.rfc-editor.org/rfc/rfc9470) / MCP step-up、cf. anthropics/claude-code#44652）
+- **コールドスタート（`--oauth-eager`）** — `initialize` をローカルで即答し、対話 OAuth フローはバックグラウンドスレッドで実行。30〜180 秒かかるブラウザ/SSO/MFA ログインでもクライアントの約 60 秒 initialize タイムアウトを超えない。ログイン完了まで該当メソッドは `-32002` を返し、完了後に `notifications/*/list_changed` でクライアントに再取得を促す。Streamable HTTP 限定、warm（有効/refresh 可能）キャッシュは不変（#296）
 - **Bearer token 認証** — `--bearer-token` フラグまたは `MCP_BEARER_TOKEN` 環境変数
 - **カスタムヘッダー** — `-H` / `--header` で任意のヘッダーを送信
 - **グレースフルシャットダウン** — SIGTERM/SIGINT ハンドリング
@@ -191,6 +192,11 @@ mcp-stdio [OPTIONS] URL
   --oauth-use-id-token   access_token ではなく OIDC id_token を Bearer として送信
                          （AWS Bedrock AgentCore / Cognito 向け）。id_token が
                          無ければ access_token にフォールバック（#59）
+  --oauth-eager          コールドスタート: initialize をローカル即答し対話 OAuth を
+                         バックグラウンド実行。長いブラウザ/SSO/MFA ログインでも
+                         クライアントの約 60 秒 initialize タイムアウトを超えない。
+                         Streamable HTTP 限定、--transport sse では無視。warm
+                         キャッシュは不変（#296）
   --oauth-refresh-leeway SECONDS
                          アクセストークンを expire の何秒前に proactive refresh
                          するか（デフォルト: 60、または MCP_OAUTH_REFRESH_LEEWAY 環境変数）

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ Bearer tokens, custom headers, and OAuth 2.1 credentials are forwarded to the re
 - **Token refresh on 401** — automatically refreshes expired OAuth tokens mid-session (OAuth mode only)
 - **Proactive token refresh** — a background timer refreshes the OAuth token shortly before it expires (lead time: `--oauth-refresh-leeway`), so a long-lived session survives gateways that signal token expiry as an HTTP 200 tool-error instead of a transport 401 (e.g. Atlassian's MCP gateway); on by default in OAuth mode, opt out with `--no-proactive-refresh` (#242)
 - **Step-up authorization on 403** — on a `Bearer error="insufficient_scope"` challenge, re-authorizes for the union of the granted and required scopes ([RFC 9470](https://www.rfc-editor.org/rfc/rfc9470) / MCP step-up; cf. anthropics/claude-code#44652)
+- **Cold-start (`--oauth-eager`)** — answers `initialize` locally and runs the interactive OAuth flow on a background thread, so a 30–180 s browser/SSO/MFA login does not exceed the client's ~60 s initialize timeout. Gated methods return `-32002` until login completes, then `notifications/*/list_changed` tells the client to fetch the now-available lists. Streamable HTTP only; a warm (valid/refreshable) cache is unaffected (#296)
 - **Bearer token auth** — via `--bearer-token` flag or `MCP_BEARER_TOKEN` env var
 - **Custom headers** — pass any header with `-H` / `--header`
 - **Graceful shutdown** — handles SIGTERM/SIGINT
@@ -193,6 +194,11 @@ Options:
   --oauth-use-id-token   Present the OIDC id_token as the Bearer credential
                          instead of the access_token (AWS Bedrock AgentCore /
                          Cognito); falls back to access_token if none is returned (#59)
+  --oauth-eager          Cold-start: answer initialize locally and run the
+                         interactive OAuth flow in the background, so a long
+                         browser/SSO/MFA login does not blow the client's ~60 s
+                         initialize timeout. Streamable HTTP only; ignored on
+                         --transport sse. Warm cache unaffected (#296)
   --oauth-refresh-leeway SECONDS
                          Proactively refresh tokens this many seconds before
                          expiry (default: 60, or MCP_OAUTH_REFRESH_LEEWAY)

--- a/src/mcp_stdio/cli.py
+++ b/src/mcp_stdio/cli.py
@@ -273,6 +273,68 @@ def _build_token_expiry_getter(
     return getter
 
 
+def _build_cold_start_login(
+    server_url: str,
+    headers: dict[str, str],
+    *,
+    client_id: str | None,
+    scope: str | None,
+    device_flow: bool,
+    refresh_leeway: float,
+    resource_indicator: bool,
+    oauth_timeout: float,
+    timeout_connect: float,
+    timeout_read: float,
+    use_id_token: bool,
+) -> Callable[[], dict[str, str] | None]:
+    """Build the cold-start background-OAuth callback for the relay (#296).
+
+    Returns a callable that runs the FULL interactive OAuth flow (browser /
+    device code, bounded by ``oauth_timeout``) and, on success, returns the base
+    headers with a fresh ``Authorization`` (id_token or access_token per #59), or
+    None on failure. The relay runs it on a background thread so a long login
+    does not block the locally-answered ``initialize``. Mirrors
+    ``_build_token_refresher``: a frozen header snapshot, its own short-lived
+    client with redirects pinned off, all exceptions degraded to None.
+    """
+    base_headers = dict(headers)
+
+    def login() -> dict[str, str] | None:
+        from .oauth import ensure_token
+
+        client = httpx.Client(
+            timeout=httpx.Timeout(
+                connect=timeout_connect, read=timeout_read, write=30, pool=10
+            ),
+            follow_redirects=False,
+        )
+        try:
+            data = ensure_token(
+                server_url,
+                client,
+                client_id=client_id or None,
+                scope=scope or None,
+                device_flow=device_flow,
+                refresh_leeway=refresh_leeway,
+                resource_indicator=resource_indicator,
+                timeout=oauth_timeout,
+            )
+            if data is None:  # interactive=True never returns None, but be safe
+                return None
+            new_headers = dict(base_headers)
+            new_headers["Authorization"] = _bearer_header_value(
+                _effective_bearer(data, use_id_token)
+            )
+            return new_headers
+        except Exception as e:
+            print(f"error: cold-start OAuth failed: {e}", file=sys.stderr)
+            return None
+        finally:
+            client.close()
+
+    return login
+
+
 def _main() -> None:
     """CLI body. Wrapped by ``main`` for top-level interrupt handling."""
     parser = argparse.ArgumentParser(
@@ -348,6 +410,21 @@ def _main() -> None:
             "malformed MCP_OAUTH_REFRESH_LEEWAY value aborts startup at argument "
             "parsing even on a non-OAuth run (the env default is validated eagerly "
             "so a bad value surfaces clearly rather than silently)"
+        ),
+    )
+    parser.add_argument(
+        "--oauth-eager",
+        action="store_true",
+        help=(
+            "Start serving immediately and run the interactive OAuth flow in the "
+            "background (cold-start). The relay answers the client's initialize "
+            "locally and returns -32002 for tool calls until OAuth completes, "
+            "then emits notifications/*/list_changed so the client fetches the "
+            "now-available lists. Avoids the client's ~60 s initialize timeout "
+            "when a browser/SSO/MFA login takes longer (#296). Streamable HTTP "
+            "only; ignored (blocking flow) on --transport sse. A warm cache "
+            "(valid/refreshable token) is unaffected. Only with --oauth / "
+            "--oauth-device."
         ),
     )
     parser.add_argument(
@@ -624,6 +701,7 @@ def _main() -> None:
     token_refresher: Callable[[], dict[str, str] | None] | None = None
     scope_upgrader: Callable[[str], dict[str, str] | None] | None = None
     token_expiry_getter: Callable[[], float | None] | None = None
+    cold_start_login: Callable[[], dict[str, str] | None] | None = None
     if args.oauth or args.oauth_device:
         # NOTE: this runs BEFORE the --check branch below, and
         # ensure_token only short-circuits on a valid cached/refreshable token.
@@ -632,6 +710,19 @@ def _main() -> None:
         # so a --check of the authenticated path is verified end-to-end. This is
         # documented in the --check help text; it is not a non-interactive probe.
         from .oauth import ensure_token
+
+        # --oauth-eager (cold-start) is Streamable HTTP only and meaningless for a
+        # one-shot --check/--test probe. When eligible, probe the cache
+        # NON-interactively so a cold cache defers the browser/device flow to a
+        # background thread in the relay instead of blocking startup.
+        eager = args.oauth_eager and not (args.check or args.test)
+        if eager and args.transport == "sse":
+            print(
+                "warning: --oauth-eager is ignored on --transport sse; the OAuth "
+                "flow runs before the relay starts",
+                file=sys.stderr,
+            )
+            eager = False
 
         client = httpx.Client(
             timeout=httpx.Timeout(
@@ -657,34 +748,56 @@ def _main() -> None:
                 refresh_leeway=args.oauth_refresh_leeway,
                 resource_indicator=not args.no_resource_indicator,
                 timeout=args.oauth_timeout,
+                interactive=not eager,
             )
-            # Drop any differently-cased 'authorization' header a -H supplied
-            # earlier (the -H loop ran before this block), so the OAuth token is
-            # the single Authorization sent rather than a duplicate header pair.
-            overridden = [k for k in headers if k.lower() == "authorization"]
-            if overridden:
-                # The user explicitly supplied -H 'Authorization: ...' AND an
-                # OAuth flow — warn that the OAuth token wins, instead of
-                # silently discarding their header.
-                print(
-                    "warning: explicit -H 'Authorization' header is overridden "
-                    "by the OAuth-acquired token",
-                    file=sys.stderr,
+            if eager and token_data is None:
+                # COLD path: no cached/refreshable token. Defer the interactive
+                # OAuth to a background thread in the relay (it answers initialize
+                # locally and gates until login completes). No Authorization is
+                # set now; the cold-start daemon installs it on success.
+                cold_start_login = _build_cold_start_login(
+                    args.url,
+                    headers,
+                    client_id=client_id or None,
+                    scope=args.oauth_scope or None,
+                    device_flow=args.oauth_device,
+                    refresh_leeway=args.oauth_refresh_leeway,
+                    resource_indicator=not args.no_resource_indicator,
+                    oauth_timeout=args.oauth_timeout,
+                    timeout_connect=args.timeout_connect,
+                    timeout_read=args.timeout_read,
+                    use_id_token=args.oauth_use_id_token,
                 )
-            for existing in overridden:
-                del headers[existing]
-            try:
-                headers["Authorization"] = _bearer_header_value(
-                    _effective_bearer(token_data, args.oauth_use_id_token)
-                )
-            except ValueError as e:
-                # The AS handed us a token with CR/LF/NUL — fail startup clearly
-                # rather than splitting headers on the wire.
-                print(f"error: {e}", file=sys.stderr)
-                sys.exit(1)
+            else:
+                # WARM path (token available, or non-eager blocking flow). Drop
+                # any differently-cased 'authorization' header a -H supplied
+                # earlier (the -H loop ran before this block), so the OAuth token
+                # is the single Authorization sent rather than a duplicate pair.
+                overridden = [k for k in headers if k.lower() == "authorization"]
+                if overridden:
+                    # Explicit -H 'Authorization: ...' AND an OAuth flow — warn
+                    # that the OAuth token wins instead of silently discarding it.
+                    print(
+                        "warning: explicit -H 'Authorization' header is overridden "
+                        "by the OAuth-acquired token",
+                        file=sys.stderr,
+                    )
+                for existing in overridden:
+                    del headers[existing]
+                try:
+                    headers["Authorization"] = _bearer_header_value(
+                        _effective_bearer(token_data, args.oauth_use_id_token)
+                    )
+                except ValueError as e:
+                    # The AS handed us a token with CR/LF/NUL — fail startup
+                    # clearly rather than splitting headers on the wire.
+                    print(f"error: {e}", file=sys.stderr)
+                    sys.exit(1)
             # The relay-loop 401/403 recovery callbacks are unused by the
             # one-shot --check / --test probe (check_connection never refreshes
             # or steps up), so only build them on the real relay path. See #15.
+            # They work for both warm and cold paths: the refresher/upgrader
+            # rebuild Authorization from the (eventually) cached token.
             if not (args.check or args.test):
                 token_refresher = _build_token_refresher(
                     args.url, headers, args.timeout_connect, args.timeout_read,
@@ -760,6 +873,7 @@ def _main() -> None:
             token_expiry_getter=token_expiry_getter,
             proactive_refresh=proactive_refresh,
             refresh_leeway=args.oauth_refresh_leeway,
+            cold_start_login=cold_start_login,
         )
 
 

--- a/src/mcp_stdio/cli.py
+++ b/src/mcp_stdio/cli.py
@@ -318,6 +318,7 @@ def _build_cold_start_login(
                 refresh_leeway=refresh_leeway,
                 resource_indicator=resource_indicator,
                 timeout=oauth_timeout,
+                interactive=True,  # cold-start: run the full browser/device flow
             )
             if data is None:  # interactive=True never returns None, but be safe
                 return None
@@ -624,10 +625,13 @@ def _main() -> None:
         args.client_id is not None
         or args.oauth_scope
         or args.no_resource_indicator
+        or args.oauth_use_id_token
+        or args.oauth_eager
     ):
         print(
-            "warning: --client-id / --oauth-scope / --no-resource-indicator are "
-            "ignored without --oauth or --oauth-device",
+            "warning: --client-id / --oauth-scope / --no-resource-indicator / "
+            "--oauth-use-id-token / --oauth-eager are ignored without --oauth "
+            "or --oauth-device",
             file=sys.stderr,
         )
 

--- a/src/mcp_stdio/oauth.py
+++ b/src/mcp_stdio/oauth.py
@@ -2081,7 +2081,8 @@ def ensure_token(
     device_flow: bool = False,
     refresh_leeway: float = 60.0,
     resource_indicator: bool = True,
-) -> TokenData:
+    interactive: bool = True,
+) -> TokenData | None:
     """Ensure a valid access token is available.
 
     1. Check cached token — use if not expired (with ``refresh_leeway`` margin)
@@ -2089,6 +2090,13 @@ def ensure_token(
     3. If no token or refresh fails, run OAuth flow:
        - ``device_flow=True``: Device Authorization Grant (RFC 8628)
        - ``device_flow=False``: Authorization Code flow with PKCE (default)
+
+    When ``interactive=False``, step 3 is skipped: if no cached/refreshable
+    token is available the function returns ``None`` instead of opening a
+    browser / device-code flow. The ``--oauth-eager`` cold-start uses this to
+    decide, without blocking, whether the warm path applies (token available)
+    or the cold path (run OAuth on a background thread). With the default
+    ``interactive=True`` the function always returns a TokenData or raises.
 
     ``refresh_leeway`` is the proactive-refresh window in seconds: a cached
     token is considered expired when its actual expiry is within this many
@@ -2117,6 +2125,11 @@ def ensure_token(
             # flow below isn't blocked by cached failure state
             # (cf. anthropics/claude-code#37747).
             delete_token(server_url)
+
+    if not interactive:
+        # Non-interactive probe (--oauth-eager warm check): no cached/refreshable
+        # token, and the caller does not want to block on a browser/device flow.
+        return None
 
     log("starting OAuth 2.1 authorization flow")
     # Probe the MCP server for a WWW-Authenticate resource_metadata hint

--- a/src/mcp_stdio/relay.py
+++ b/src/mcp_stdio/relay.py
@@ -1266,6 +1266,144 @@ def _paginate_and_stream(
     return _StreamResult(last_session, 200)
 
 
+# --- cold-start: answer initialize locally while OAuth runs in the background ---
+#
+# An interactive OAuth flow (browser -> SSO -> MFA -> consent -> redirect) takes
+# 30-180 s, but a client's `initialize` typically times out in ~60 s, so a cold
+# (no/expired token) --oauth start fails to attach. With --oauth-eager the relay
+# answers `initialize` locally (advertising listChanged so the client honours a
+# later refresh), gates the other methods, and runs OAuth on a background thread;
+# when it completes the gate lifts and `notifications/.../list_changed` tells the
+# client to fetch the now-available lists. Streamable HTTP only (#296 / #59-adj).
+_COLD_START_NOT_READY_CODE = -32002  # "server busy / not ready" (used by tools/call)
+
+# list-method -> the empty result body returned while gated, so a client that
+# fetches before OAuth completes sees an empty (not failed) list and re-fetches
+# on the list_changed notification.
+_COLD_START_EMPTY_LIST = {
+    "tools/list": {"tools": []},
+    "resources/list": {"resources": []},
+    "resources/templates/list": {"resourceTemplates": []},
+    "prompts/list": {"prompts": []},
+}
+_COLD_START_LIST_CHANGED = (
+    "notifications/tools/list_changed",
+    "notifications/resources/list_changed",
+    "notifications/prompts/list_changed",
+)
+
+
+def _cold_start_response(line: str, req_id: Any, has_id: bool) -> str | None:
+    """Synthesize a local reply for a pre-OAuth (gated) stdin line, or None.
+
+    Returns the JSON-RPC line to emit to stdout, or ``None`` when the line should
+    be swallowed silently (a notification that must not reach the unauthorized
+    upstream). The caller never forwards a gated line upstream.
+
+    - ``initialize`` -> a local InitializeResult echoing the client's requested
+      protocolVersion (floor 2024-11-05 if absent) and advertising listChanged
+      on tools/resources/prompts, so the client honours the later list_changed.
+    - a list method -> an empty list result (the client re-fetches on
+      list_changed once OAuth completes).
+    - ``ping`` -> an empty result.
+    - any other request (tools/call, resources/read, …) -> a ``-32002`` error
+      ("authorizing, retry shortly").
+    - any notification (incl. ``notifications/initialized``) -> swallowed.
+    """
+    try:
+        msg = json.loads(line)
+    except (json.JSONDecodeError, ValueError):
+        msg = None
+    method = msg.get("method") if isinstance(msg, dict) else None
+
+    if method == "initialize":
+        requested = None
+        if isinstance(msg, dict):
+            params = msg.get("params")
+            if isinstance(params, dict):
+                pv = params.get("protocolVersion")
+                if isinstance(pv, str) and pv:
+                    requested = pv
+        result = {
+            "protocolVersion": requested or "2024-11-05",
+            "capabilities": {
+                "tools": {"listChanged": True},
+                "resources": {"listChanged": True},
+                "prompts": {"listChanged": True},
+            },
+            "serverInfo": {"name": "mcp-stdio", "version": __version__},
+        }
+        return json.dumps({"jsonrpc": "2.0", "id": req_id, "result": result})
+
+    if not has_id:
+        # A notification (including notifications/initialized) gets no reply and
+        # must not be forwarded to the not-yet-authorized upstream — swallow it.
+        return None
+
+    if method in _COLD_START_EMPTY_LIST:
+        return json.dumps(
+            {"jsonrpc": "2.0", "id": req_id, "result": _COLD_START_EMPTY_LIST[method]}
+        )
+    if method == "ping":
+        return json.dumps({"jsonrpc": "2.0", "id": req_id, "result": {}})
+    # Any other request needs the upstream, which is not reachable until OAuth
+    # completes. Tell the client to retry shortly rather than hang.
+    return json.dumps(
+        {
+            "jsonrpc": "2.0",
+            "id": req_id,
+            "error": {
+                "code": _COLD_START_NOT_READY_CODE,
+                "message": "authorizing with the upstream server, please retry shortly",
+            },
+        }
+    )
+
+
+def _cold_start_loop(
+    *,
+    login: Callable[[], dict[str, str] | None],
+    client: httpx.Client,
+    url: str,
+    headers: dict[str, str],
+    headers_lock: threading.Lock,
+    tracker: "_CancelTracker | None",
+    state: dict[str, Any],
+    state_lock: threading.Lock,
+    ready: threading.Event,
+) -> None:
+    """Background daemon: run interactive OAuth, then open the upstream session.
+
+    On success: merge the auth headers (under ``headers_lock``), perform the
+    upstream initialize handshake (``_reinitialize`` -> session id + protocol
+    version), publish them in ``state`` (under ``state_lock``), set ``ready`` so
+    the main loop lifts the gate, and emit ``list_changed`` notifications so the
+    client fetches the now-available lists. Any failure leaves the gate closed
+    (gated requests keep returning -32002); the thread never crashes the relay.
+    """
+    try:
+        new_headers = login()
+        if not new_headers:
+            log("cold-start OAuth did not complete; gate stays closed")
+            return
+        with headers_lock:
+            headers.update(new_headers)
+            snapshot = dict(headers)
+        sid, pv = _reinitialize(client, url, snapshot, None)
+        if sid is None:
+            log("cold-start: upstream initialize failed after OAuth")
+            return
+        with state_lock:
+            state["session_id"] = sid
+            state["protocol_version"] = pv
+        ready.set()
+        log("cold-start ready: OAuth complete, upstream session established")
+        for method in _COLD_START_LIST_CHANGED:
+            _emit(json.dumps({"jsonrpc": "2.0", "method": method}), tracker)
+    except Exception as e:  # noqa: BLE001 — the daemon must never crash the relay
+        log(f"cold-start background error: {e}")
+
+
 def _reinitialize(
     client: httpx.Client,
     url: str,
@@ -1798,6 +1936,7 @@ def run(
     token_expiry_getter: Any = None,
     proactive_refresh: bool = True,
     refresh_leeway: float = 60.0,
+    cold_start_login: Any = None,
 ) -> None:
     """Run the stdio-to-HTTP relay loop.
 
@@ -1850,6 +1989,14 @@ def run(
             ``token_refresher`` / ``token_expiry_getter`` (i.e. no OAuth).
         refresh_leeway: Seconds before ``expires_at`` at which the
             proactive timer refreshes (default 60).
+        cold_start_login: Optional callable that runs the interactive OAuth
+            flow and returns updated headers (with Authorization) on success,
+            or None on failure. When set (``--oauth-eager`` with a cold cache),
+            the relay answers ``initialize`` locally and gates other methods
+            while ``cold_start_login`` runs on a background thread, then lifts
+            the gate and emits ``list_changed`` so the client fetches the
+            now-available lists — so a long OAuth flow does not blow the
+            client's initialize timeout (#296). Streamable HTTP only.
 
     Limitation — JSON-RPC batches: a top-level array (a batch) is
     treated like a notification for error synthesis. ``_extract_id_and_presence``
@@ -1931,6 +2078,33 @@ def run(
         refresh_lock=refresh_lock,
     )
 
+    # Cold-start (--oauth-eager): answer initialize locally while OAuth runs on a
+    # background thread. ``cold_gated`` stays True until OAuth completes AND the
+    # main loop has adopted the upstream session the daemon established; while
+    # gated, the stdin loop synthesizes local replies instead of POSTing upstream.
+    cold_ready = threading.Event() if cold_start_login is not None else None
+    cold_state: dict[str, Any] = {"session_id": None, "protocol_version": None}
+    cold_state_lock = threading.Lock()
+    cold_gated = cold_start_login is not None
+    cold_timer: threading.Thread | None = None
+    if cold_start_login is not None:
+        cold_timer = threading.Thread(
+            target=_cold_start_loop,
+            kwargs={
+                "login": cold_start_login,
+                "client": client,
+                "url": url,
+                "headers": headers,
+                "headers_lock": headers_lock,
+                "tracker": tracker,
+                "state": cold_state,
+                "state_lock": cold_state_lock,
+                "ready": cold_ready,
+            },
+            daemon=True,
+        )
+        cold_timer.start()
+
     try:
         for line in sys.stdin:
             line = line.strip()
@@ -1958,6 +2132,23 @@ def run(
                     # A request reusing a previously-cancelled id supersedes that
                     # cancel — untrack it so its response is delivered, not dropped.
                     tracker.discard(req_id)
+
+                # Cold-start gate (--oauth-eager): until the background OAuth flow
+                # completes, answer locally instead of POSTing to the not-yet-
+                # authorized upstream. Once ready, adopt the upstream session the
+                # daemon established and forward THIS line normally.
+                if cold_gated:
+                    if cold_ready.is_set():
+                        with cold_state_lock:
+                            session_id = cold_state["session_id"]
+                            protocol_version = cold_state["protocol_version"]
+                        cold_gated = False
+                        log("cold-start gate lifted; forwarding to upstream")
+                    else:
+                        reply = _cold_start_response(line, req_id, req_has_id)
+                        if reply is not None:
+                            _emit(reply, tracker)
+                        continue
 
                 req_headers = _prepare_headers()
 
@@ -2289,6 +2480,11 @@ def run(
                 continue
     finally:
         _stop_proactive_refresh(refresh_timer, refresh_stop)
+        # The cold-start daemon self-exits after one OAuth attempt; briefly join
+        # it so a clean shutdown does not race its final emit. daemon=True keeps
+        # process exit unblocked if it is still parked in the interactive flow.
+        if cold_timer is not None:
+            cold_timer.join(timeout=1.0)
         client.close()
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -228,6 +228,51 @@ class TestMain:
             main()
         assert mock_ensure.call_args.kwargs["refresh_leeway"] == 300.0
 
+    def test_oauth_eager_warm_cache_no_cold_start(self):
+        """#296: --oauth-eager with a warm cache probes non-interactively and
+        runs normally (cold_start_login None)."""
+        with (
+            patch("sys.argv", ["mcp-stdio", "--oauth", "--oauth-eager", "https://example.com/mcp"]),
+            patch("mcp_stdio.oauth.ensure_token") as mock_ensure,
+            patch("mcp_stdio.cli.run") as mock_run,
+        ):
+            mock_ensure.return_value.access_token = "tok"
+            mock_ensure.return_value.id_token = None
+            main()
+        # Probed non-interactively, token available -> no cold-start.
+        assert mock_ensure.call_args.kwargs["interactive"] is False
+        assert mock_run.call_args.kwargs["cold_start_login"] is None
+
+    def test_oauth_eager_cold_cache_defers_login(self):
+        """#296: --oauth-eager with a cold cache (non-interactive probe returns
+        None) defers OAuth to a background cold_start_login passed to run()."""
+        with (
+            patch("sys.argv", ["mcp-stdio", "--oauth", "--oauth-eager", "https://example.com/mcp"]),
+            patch("mcp_stdio.oauth.ensure_token", return_value=None) as mock_ensure,
+            patch("mcp_stdio.cli.run") as mock_run,
+        ):
+            main()
+        assert mock_ensure.call_args.kwargs["interactive"] is False
+        assert callable(mock_run.call_args.kwargs["cold_start_login"])
+
+    def test_oauth_eager_ignored_on_sse(self, capsys):
+        """--oauth-eager is Streamable-HTTP only: on --transport sse it warns and
+        falls back to the blocking (interactive) flow before the relay starts."""
+        with (
+            patch(
+                "sys.argv",
+                ["mcp-stdio", "--oauth", "--oauth-eager", "--transport", "sse",
+                 "https://example.com/sse"],
+            ),
+            patch("mcp_stdio.oauth.ensure_token") as mock_ensure,
+            patch("mcp_stdio.cli.run_sse"),
+        ):
+            mock_ensure.return_value.access_token = "tok"
+            mock_ensure.return_value.id_token = None
+            main()
+        assert mock_ensure.call_args.kwargs["interactive"] is True
+        assert "ignored on --transport sse" in capsys.readouterr().err
+
     def test_oauth_timeout_default_and_flag(self):
         """: the interactive-OAuth wait is configurable via
         --oauth-timeout (default 120) and propagated to ensure_token(timeout=)."""

--- a/tests/test_relay.py
+++ b/tests/test_relay.py
@@ -37,6 +37,8 @@ from mcp_stdio.relay import (
     _parse_retry_after,
     _parse_www_authenticate_scope,
     _post_and_stream,
+    _cold_start_loop,
+    _cold_start_response,
     _proactive_refresh_loop,
     _reinitialize,
     _start_proactive_refresh,
@@ -5341,6 +5343,171 @@ class TestProactiveRefresh:
             )
         assert refreshed.is_set()
         assert headers["Authorization"] == "Bearer refreshed"
+
+
+class TestColdStartResponse:
+    """#296: local replies synthesized while the cold-start gate is closed."""
+
+    def test_initialize_echoes_version_and_advertises_listchanged(self):
+        line = (
+            '{"jsonrpc":"2.0","id":1,"method":"initialize",'
+            '"params":{"protocolVersion":"2025-06-18"}}'
+        )
+        out = json.loads(_cold_start_response(line, 1, True))
+        assert out["id"] == 1
+        assert out["result"]["protocolVersion"] == "2025-06-18"
+        caps = out["result"]["capabilities"]
+        assert caps["tools"]["listChanged"] is True
+        assert caps["resources"]["listChanged"] is True
+        assert caps["prompts"]["listChanged"] is True
+        assert out["result"]["serverInfo"]["name"] == "mcp-stdio"
+
+    def test_initialize_floor_version_when_absent(self):
+        line = '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}'
+        out = json.loads(_cold_start_response(line, 1, True))
+        assert out["result"]["protocolVersion"] == "2024-11-05"
+
+    @pytest.mark.parametrize(
+        "method,key",
+        [
+            ("tools/list", "tools"),
+            ("resources/list", "resources"),
+            ("resources/templates/list", "resourceTemplates"),
+            ("prompts/list", "prompts"),
+        ],
+    )
+    def test_list_methods_return_empty(self, method, key):
+        line = f'{{"jsonrpc":"2.0","id":2,"method":"{method}"}}'
+        out = json.loads(_cold_start_response(line, 2, True))
+        assert out["result"] == {key: []}
+
+    def test_ping_returns_empty_result(self):
+        out = json.loads(_cold_start_response('{"jsonrpc":"2.0","id":3,"method":"ping"}', 3, True))
+        assert out["result"] == {}
+
+    def test_tools_call_returns_not_ready_error(self):
+        line = '{"jsonrpc":"2.0","id":4,"method":"tools/call","params":{}}'
+        out = json.loads(_cold_start_response(line, 4, True))
+        assert out["error"]["code"] == -32002
+        assert "retry" in out["error"]["message"].lower()
+
+    def test_notifications_are_swallowed(self):
+        # notifications/initialized and any other notification -> no reply.
+        assert _cold_start_response(
+            '{"jsonrpc":"2.0","method":"notifications/initialized"}', None, False
+        ) is None
+        assert _cold_start_response(
+            '{"jsonrpc":"2.0","method":"notifications/cancelled","params":{}}', None, False
+        ) is None
+
+
+class TestColdStartLoop:
+    """The cold-start background daemon: OAuth -> upstream session -> list_changed."""
+
+    URL = "https://example.com/mcp"
+
+    def test_opens_session_and_emits_list_changed(self, httpx_mock):
+        # _reinitialize: initialize POST -> 200 + session id + protocolVersion,
+        # then notifications/initialized -> 202.
+        httpx_mock.add_response(
+            url=self.URL,
+            headers={"mcp-session-id": "sess-1", "content-type": "application/json"},
+            json={"jsonrpc": "2.0", "id": 0, "result": {"protocolVersion": "2025-06-18"}},
+        )
+        httpx_mock.add_response(url=self.URL, status_code=202)
+
+        headers = {"Content-Type": "application/json"}
+        state = {"session_id": None, "protocol_version": None}
+        ready = threading.Event()
+        stdout = StringIO()
+        client = httpx.Client()
+        try:
+            with patch("sys.stdout", stdout):
+                _cold_start_loop(
+                    login=lambda: {"Authorization": "Bearer t"},
+                    client=client,
+                    url=self.URL,
+                    headers=headers,
+                    headers_lock=threading.Lock(),
+                    tracker=None,
+                    state=state,
+                    state_lock=threading.Lock(),
+                    ready=ready,
+                )
+        finally:
+            client.close()
+
+        assert ready.is_set()
+        assert state["session_id"] == "sess-1"
+        assert state["protocol_version"] == "2025-06-18"
+        assert headers["Authorization"] == "Bearer t"
+        out = stdout.getvalue()
+        assert "notifications/tools/list_changed" in out
+        assert "notifications/resources/list_changed" in out
+        assert "notifications/prompts/list_changed" in out
+
+    def test_failed_login_leaves_gate_closed(self, httpx_mock):
+        """login() returning None must not set ready or POST upstream."""
+        ready = threading.Event()
+        state = {"session_id": None, "protocol_version": None}
+        client = httpx.Client()
+        try:
+            _cold_start_loop(
+                login=lambda: None,
+                client=client,
+                url=self.URL,
+                headers={},
+                headers_lock=threading.Lock(),
+                tracker=None,
+                state=state,
+                state_lock=threading.Lock(),
+                ready=ready,
+            )
+        finally:
+            client.close()
+        assert not ready.is_set()
+        assert httpx_mock.get_requests() == []
+
+
+class TestRunColdStart:
+    """run() cold-start gate end-to-end (Streamable HTTP)."""
+
+    def _run_with_stdin(self, httpx_mock, stdin_lines, **kwargs):
+        stdin_data = "\n".join(stdin_lines) + "\n"
+        stdout = StringIO()
+        with patch("sys.stdin", StringIO(stdin_data)), patch("sys.stdout", stdout):
+            run(
+                "https://example.com/mcp",
+                {"Content-Type": "application/json"},
+                **kwargs,
+            )
+        return stdout.getvalue()
+
+    def test_gates_all_methods_until_login(self, httpx_mock):
+        """While OAuth has not completed (login returns None -> ready never set),
+        initialize is answered locally, list methods are empty, tools/call is
+        -32002, notifications are swallowed, and nothing is POSTed upstream."""
+        out = self._run_with_stdin(
+            httpx_mock,
+            [
+                '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18"}}',
+                '{"jsonrpc":"2.0","id":2,"method":"tools/list"}',
+                '{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{}}',
+                '{"jsonrpc":"2.0","method":"notifications/initialized"}',
+            ],
+            cold_start_login=lambda: None,  # OAuth never completes
+        )
+        by_id = {
+            m.get("id"): m for m in (json.loads(x) for x in out.splitlines() if x.strip())
+        }
+        assert by_id[1]["result"]["capabilities"]["tools"]["listChanged"] is True
+        assert by_id[1]["result"]["protocolVersion"] == "2025-06-18"
+        assert by_id[2]["result"] == {"tools": []}
+        assert by_id[3]["error"]["code"] == -32002
+        # The notification produced no frame (no id:null).
+        assert None not in by_id
+        # Nothing reached the upstream while gated.
+        assert httpx_mock.get_requests() == []
 
 
 class TestRunSse:


### PR DESCRIPTION
## Summary

The biggest treasure from the patrol. An interactive OAuth flow (browser → SSO → MFA → consent) takes **30–180 s**, but a client's `initialize` typically times out in **~60 s**, so a cold (no/expired token) `--oauth` start fails to attach. The [mcp-remote#296](https://github.com/geelen/mcp-remote/issues/296) reporter rebuilt mcp-stdio's design as a "POST-only stdio bridge" to work around exactly this.

## Behavior (`--oauth-eager`, cold cache, Streamable HTTP only)
- Answers `initialize` **locally** — echoes the client's `protocolVersion`, advertises `listChanged` on tools/resources/prompts, returns `serverInfo`.
- **Gates** other methods while a background daemon runs the interactive OAuth: list methods → empty result, `tools/call` etc. → `-32002` ("authorizing, retry shortly"), notifications swallowed.
- On success: merges auth headers under `headers_lock`, opens the upstream session via `_reinitialize`, **lifts the gate**, and emits `notifications/*/list_changed` so the client fetches the now-available lists.

## Wiring
- `oauth.py`: `ensure_token(interactive=False)` returns `None` instead of opening a browser/device flow — the cli uses it to **probe the cache non-interactively** and pick warm vs cold.
- `cli.py`: `--oauth-eager` flag; warm path (token available) is **unchanged blocking behavior**; cold path builds a `_build_cold_start_login` closure passed to `run()`. SSE falls back to the blocking flow with a warning.
- `relay.py`: `_cold_start_response` (pure synthesizer), `_cold_start_loop` (background daemon, mirrors the proactive-refresh start/stop pattern), and a pre-`_dispatch` gate in `run()`. Reuses `_reinitialize`, `_emit`, `headers_lock`, `_STDOUT_LOCK`.

## Known limitation (documented)
The locally-echoed `protocolVersion` may differ from the upstream-negotiated one; mcp-stdio bridges the two sides and does not translate versions.

## Tests
- `TestColdStartResponse` — initialize echo + listChanged, floor version, empty list methods, ping, `-32002`, notification swallow.
- `TestColdStartLoop` — daemon opens the upstream session, populates state, sets ready, emits all three `list_changed`; failed login leaves the gate closed and POSTs nothing.
- `TestRunColdStart` — `run()` gates all methods end-to-end while login is pending; nothing reaches upstream.
- `test_cli` — warm cache → no cold-start; cold cache → `cold_start_login` passed to `run()`; SSE → warns + blocking.

Full suite: **1058 passed, 3 skipped**, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)