### PR TITLE
feat(serve): per-session backend child for concurrent-client isolation

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -265,8 +265,8 @@ mcp-stdio --check http://127.0.0.1:8080/mcp
 ```
 
 - 標準ライブラリのみ（`http.server`）— ランタイム依存は増えません。
-- Streamable HTTP のリクエスト/レスポンス・通知のセマンティクスに加え、
-  サーバ起点メッセージ用の GET SSE チャネルを実装。
+- Streamable HTTP のリクエスト/レスポンス・通知のセマンティクス、セッション
+  管理に加え、サーバ起点メッセージ用の GET SSE チャネルを実装。
 - **認証は任意・段階的:**
   - *トークン無し* — エンドポイントは素通し（TLS 終端プロキシ背後で運用）。
   - *静的トークン*（`--auth-token` / `MCP_STDIO_SERVE_TOKEN`）— OAuth リソース
@@ -288,7 +288,13 @@ mcp-stdio --check http://127.0.0.1:8080/mcp
   （[RFC 6749](https://www.rfc-editor.org/rfc/rfc6749) §4.1.2 /
   [RFC 9700](https://www.rfc-editor.org/rfc/rfc9700) §4.14.2、正当なリトライを
   巻き込まない短い grace window 付き）。
-- 当面はシングルクライアント前提（JSON-RPC の id はそのまま透過）。
+- **セッション単位のマルチクライアント分離** — MCP セッションごとに専用の
+  バックエンド子プロセスを spawn するため、並行クライアントはプロセス境界で
+  分離される（クライアント間で JSON-RPC の id が衝突しても応答が混線しない）。
+  MCP Streamable HTTP 仕様どおり、`initialize` で `Mcp-Session-Id` を払い出し、
+  以降のリクエストはそれを携行、未知/終了済みの id には `404`（クライアントは
+  再 initialize）、`DELETE` でそのセッションの子を破棄。並行セッション数には
+  上限を設け、素通しゲートウェイでの子プロセス無制限 spawn を防ぐ。
 
 静的トークンの例（トークンは env 経由で `ps` に出さない）:
 

--- a/README.md
+++ b/README.md
@@ -267,8 +267,8 @@ mcp-stdio --check http://127.0.0.1:8080/mcp
 ```
 
 - Stdlib only (`http.server`) — adds no runtime dependency.
-- Implements the Streamable HTTP request/response and notification semantics
-  plus a GET SSE channel for server-initiated messages.
+- Implements the Streamable HTTP request/response and notification semantics,
+  session management, plus a GET SSE channel for server-initiated messages.
 - **Authentication is optional and layered:**
   - *No token* — the endpoint is open (run it behind a TLS-terminating proxy).
   - *Static token* (`--auth-token` / `MCP_STDIO_SERVE_TOKEN`) — acts as an OAuth
@@ -290,7 +290,13 @@ mcp-stdio --check http://127.0.0.1:8080/mcp
   the whole grant family ([RFC 6749](https://www.rfc-editor.org/rfc/rfc6749)
   §4.1.2 / [RFC 9700](https://www.rfc-editor.org/rfc/rfc9700) §4.14.2), with a
   brief grace window so a benign client retry is not punished.
-- Single-client assumption for now: JSON-RPC ids pass through verbatim.
+- **Multi-client isolation by session** — each MCP session gets its own spawned
+  backend child, so concurrent clients are isolated by process boundary (a
+  JSON-RPC id collision across clients can never cross responses). Per the MCP
+  Streamable HTTP spec, `initialize` mints an `Mcp-Session-Id`, every later
+  request carries it, an unknown/terminated id gets `404` (the client then
+  re-initializes), and a `DELETE` tears that session's child down. A
+  concurrent-session cap guards an open gateway against unbounded child spawns.
 
 Static-token example (token via env so it is not visible in `ps`):
 

--- a/src/mcp_stdio/server.py
+++ b/src/mcp_stdio/server.py
@@ -6,25 +6,27 @@ it spawns a local stdio MCP server as a child process and publishes it as a
 Streamable HTTP MCP endpoint, so clients that cannot spawn the server locally
 (a laptop without it installed, a remote bot) can reach it over the network.
 
-A single backend. Authentication is optional and layered: with no token the
-endpoint is open; ``--auth-token`` adds a static-bearer Resource Server gate;
-``--enable-oauth`` adds an embedded OAuth 2.1 Authorization Server. The HTTP
-surface implements the MCP Streamable HTTP transport's request/response and
-notification semantics plus a GET SSE channel for server-initiated messages.
+One backend child PER SESSION. Authentication is optional and layered: with no
+token the endpoint is open; ``--auth-token`` adds a static-bearer Resource
+Server gate; ``--enable-oauth`` adds an embedded OAuth 2.1 Authorization
+Server. The HTTP surface implements the MCP Streamable HTTP transport's
+request/response and notification semantics, session management (an
+``Mcp-Session-Id`` minted on ``initialize``, 404 on an unknown id, DELETE to
+terminate), plus a GET SSE channel for server-initiated messages.
 
 Stdlib only (``http.server`` + ``subprocess`` + ``threading``), matching the
 project's httpx-only-runtime constraint: the server path adds no dependency.
 
-Concurrency model: one long-lived backend child speaks newline-delimited
-JSON-RPC over its stdin/stdout. A single reader thread drains the child's
-stdout and routes each message — a response (id + result/error, no method)
-wakes the waiting HTTP handler keyed by the JSON-RPC id; anything
-server-initiated (carries ``method``) is queued for the GET SSE stream.
+Concurrency model: each MCP session owns a dedicated backend child (see
+:class:`SessionRegistry`) that speaks newline-delimited JSON-RPC over its
+stdin/stdout. Per child, a single reader thread drains stdout and routes each
+message — a response (id + result/error, no method) wakes the waiting HTTP
+handler keyed by the JSON-RPC id; anything server-initiated (carries
+``method``) is queued for that session's GET SSE stream.
 
-Single-client assumption: JSON-RPC ids are passed through verbatim, so two
-distinct clients that happen to reuse the same id while sharing one backend
-could cross responses. This targets one logical client (e.g. one Claude); id
-remapping for true multi-client fan-out is left for later.
+Multi-client isolation is by process boundary: concurrent clients land on
+distinct sessions and distinct children, so a JSON-RPC id collision across
+clients cannot cross responses (each id is unique within its own child).
 """
 
 from __future__ import annotations
@@ -42,7 +44,6 @@ import signal
 import subprocess
 import threading
 import time
-import uuid
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from typing import Any
 from urllib.parse import parse_qs, urlencode, urlsplit
@@ -145,7 +146,7 @@ class BackendProcess:
         # id -> single-slot holder {"event": Event, "line": str|None}
         self._pending: dict[Any, dict[str, Any]] = {}
         # Server-initiated messages (requests/notifications) awaiting an SSE
-        # consumer. Unbounded queue is acceptable for the single-client model;
+        # consumer. Unbounded queue is acceptable for one client per session;
         # a later change can bound + shed.
         self.server_initiated: "queue.Queue[str]" = queue.Queue()
         self._closed = threading.Event()
@@ -222,7 +223,7 @@ class BackendProcess:
             if self._closed.is_set():
                 return None
             # Reuse-of-an-in-flight-id is a client bug; last writer wins and the
-            # earlier waiter will time out. Acceptable for the single-client model.
+            # earlier waiter will time out. Acceptable: one client per session.
             self._pending[req_id] = slot
         if not self._write(line):
             with self._lock:
@@ -282,6 +283,97 @@ class BackendProcess:
                 proc.kill()
         except Exception as e:  # pragma: no cover - defensive
             log(f"backend shutdown error: {e}")
+
+
+# --- per-session backend registry: one child stdio server per MCP session ---
+
+# Hard cap on concurrent sessions: a fork-bomb guard for an open (no-auth)
+# gateway, since each session spawns a child process. High enough that a single
+# logical client never trips it; a configurable knob and idle eviction land in
+# a follow-up change.
+_DEFAULT_MAX_SESSIONS = 100
+
+
+class SessionRegistry:
+    """Thread-safe map of ``Mcp-Session-Id`` -> backend child process.
+
+    Each MCP session gets its OWN stdio backend, so concurrent clients are
+    isolated by process boundary rather than multiplexed onto one shared child
+    (which could cross responses on a JSON-RPC id collision). A session is
+    created when a client POSTs ``initialize`` (the gateway mints an id and
+    spawns a dedicated :class:`BackendProcess`), looked up by that header on
+    every later request, and removed on DELETE or gateway shutdown.
+
+    The slow operations — spawning a child (``Popen`` exec) and tearing one
+    down (``terminate()`` then ``wait``) — run OUTSIDE the lock; only the dict
+    mutation is guarded, so one session's lifecycle never serializes another's.
+    """
+
+    def __init__(
+        self, command: list[str], *, max_sessions: int = _DEFAULT_MAX_SESSIONS
+    ) -> None:
+        if not command:
+            raise ValueError("backend command is empty")
+        self._command = command
+        self._max = max_sessions
+        self._lock = threading.Lock()
+        self._sessions: dict[str, BackendProcess] = {}
+
+    def create(self) -> tuple[str, BackendProcess] | None:
+        """Spawn a child for a new session.
+
+        Returns ``(session_id, backend)``, or ``None`` when the concurrent-
+        session cap is reached (the caller then responds 503).
+        """
+        with self._lock:
+            if len(self._sessions) >= self._max:
+                return None
+        # Spawn outside the lock: a Popen exec must not serialize other
+        # sessions' creation or routing.
+        backend = BackendProcess(self._command)
+        # MCP spec: the session id SHOULD be globally unique and
+        # cryptographically secure, and MUST contain only visible ASCII.
+        sid = secrets.token_hex(16)
+        with self._lock:
+            # Re-check the cap: a burst of concurrent creates could have filled
+            # it while we were spawning. Over the cap -> drop the just-spawned
+            # child rather than exceed the bound.
+            if len(self._sessions) >= self._max:
+                backend.shutdown()
+                return None
+            self._sessions[sid] = backend
+        return sid, backend
+
+    def get(self, sid: str | None) -> BackendProcess | None:
+        """Resolve a session id to its backend, or None if unknown."""
+        if not sid:
+            return None
+        with self._lock:
+            return self._sessions.get(sid)
+
+    def remove(self, sid: str | None) -> BackendProcess | None:
+        """Detach a session and return its backend (or None if unknown).
+
+        The caller calls ``backend.shutdown()`` OUTSIDE the lock so a slow
+        terminate never freezes routing for other sessions.
+        """
+        if not sid:
+            return None
+        with self._lock:
+            return self._sessions.pop(sid, None)
+
+    def shutdown_all(self) -> None:
+        """Tear down every session's child (gateway shutdown)."""
+        with self._lock:
+            backends = list(self._sessions.values())
+            self._sessions.clear()
+        for backend in backends:
+            backend.shutdown()
+
+    @property
+    def count(self) -> int:
+        with self._lock:
+            return len(self._sessions)
 
 
 # --- embedded OAuth 2.1 Authorization Server (stdlib only, opaque tokens) ---
@@ -857,15 +949,18 @@ class _OAuthProvider:
 
 
 class _Handler(BaseHTTPRequestHandler):
-    """Streamable HTTP MCP endpoint backed by a single stdio child.
+    """Streamable HTTP MCP endpoint backed by a per-session stdio child.
 
-    Class attributes ``backend``, ``mcp_path`` and ``session_id`` are bound by
-    :func:`serve` before the server loop starts.
+    Class attributes ``registry`` and ``mcp_path`` are bound by
+    :func:`build_server` before the server loop starts. The session id for the
+    request in flight is held in the per-request instance attribute
+    ``_session_id`` (reset at the top of each verb handler), so response
+    helpers can echo it — or omit it for errors raised before a session is
+    resolved.
     """
 
-    backend: BackendProcess
+    registry: SessionRegistry
     mcp_path: str
-    session_id: str
     # None disables authentication. A non-None value enables the
     # static-bearer-token Resource Server gate.
     auth_token: str | None = None
@@ -886,14 +981,18 @@ class _Handler(BaseHTTPRequestHandler):
         self.send_response(status)
         self.send_header("Content-Type", "application/json")
         self.send_header("Content-Length", str(len(data)))
-        self.send_header("Mcp-Session-Id", self.session_id)
+        sid = getattr(self, "_session_id", None)
+        if sid is not None:
+            self.send_header("Mcp-Session-Id", sid)
         self.end_headers()
         self.wfile.write(data)
 
     def _send_empty(self, status: int) -> None:
         self.send_response(status)
         self.send_header("Content-Length", "0")
-        self.send_header("Mcp-Session-Id", self.session_id)
+        sid = getattr(self, "_session_id", None)
+        if sid is not None:
+            self.send_header("Mcp-Session-Id", sid)
         self.end_headers()
 
     def _send_oauth_json(self, status: int, body: str, *, no_store: bool = False) -> None:
@@ -1125,6 +1224,9 @@ class _Handler(BaseHTTPRequestHandler):
         self.end_headers()
 
     def do_POST(self) -> None:  # noqa: N802 - BaseHTTPRequestHandler API
+        # Reset the per-request session id (the handler instance is reused
+        # across keep-alive requests); responses before resolution omit it.
+        self._session_id = None
         # Read (drain) the request body BEFORE any early return. On HTTP/1.1
         # keep-alive, leaving an unread body in the socket makes the handler
         # parse those leftover bytes as the next request line ("Bad request
@@ -1165,8 +1267,12 @@ class _Handler(BaseHTTPRequestHandler):
             return
 
         kind = _classify(msg)
+        if kind not in ("request", "notification", "response"):
+            # Batches and malformed payloads are out of scope here.
+            self._send_json(400, _error_body("unsupported or invalid message"))
+            return
+        req_id = msg.get("id") if kind == "request" else None
         if kind == "request":
-            req_id = msg.get("id")
             # A JSON-RPC id is a String, Number, or null. A non-scalar id
             # (object / array) is malformed AND unhashable, so using it as the
             # pending-response dict key would raise TypeError and crash the
@@ -1175,10 +1281,43 @@ class _Handler(BaseHTTPRequestHandler):
             if req_id is not None and not isinstance(req_id, (str, int, float)):
                 self._send_json(400, _error_body("invalid JSON-RPC id"))
                 return
-            if self.backend.closed:
+
+        # --- session resolution (MCP Streamable HTTP session management) ---
+        sid_header = self.headers.get("Mcp-Session-Id")
+        if kind == "request" and msg.get("method") == "initialize":
+            # `initialize` starts a session (MCP spec item 1): spawn a fresh
+            # child and mint an id, returned via the Mcp-Session-Id response
+            # header. A presented (stale) id is dropped first.
+            if sid_header:
+                stale = self.registry.remove(sid_header)
+                if stale is not None:
+                    stale.shutdown()
+            created = self.registry.create()
+            if created is None:
+                self._send_json(503, _error_body("session limit reached", req_id))
+                return
+            self._session_id, backend = created
+        else:
+            # MCP spec item 2: a server that requires a session SHOULD reject a
+            # sessionless non-initialize request with 400.
+            if not sid_header:
+                self._send_json(400, _error_body("Mcp-Session-Id required", req_id))
+                return
+            backend = self.registry.get(sid_header)
+            if backend is None:
+                # MCP spec item 3: an unknown/terminated session id gets 404,
+                # which drives the client's re-initialize (spec item 4).
+                self._send_json(
+                    404, _error_body("unknown or expired session", req_id)
+                )
+                return
+            self._session_id = sid_header
+
+        if kind == "request":
+            if backend.closed:
                 self._send_json(503, _error_body("backend unavailable", req_id))
                 return
-            line = self.backend.send_request(
+            line = backend.send_request(
                 json.dumps(msg), req_id, _BACKEND_RESPONSE_TIMEOUT_SECS
             )
             if line is None:
@@ -1187,16 +1326,14 @@ class _Handler(BaseHTTPRequestHandler):
                 )
                 return
             self._send_json(200, line)
-        elif kind in ("notification", "response"):
+        else:
             # Fire-and-forget toward the backend; the MCP spec returns 202 for
             # a POST that carries no request needing a reply.
-            self.backend.send_oneway(json.dumps(msg))
+            backend.send_oneway(json.dumps(msg))
             self._send_empty(202)
-        else:
-            # Batches and malformed payloads are out of scope here.
-            self._send_json(400, _error_body("unsupported or invalid message"))
 
     def do_GET(self) -> None:  # noqa: N802 - BaseHTTPRequestHandler API
+        self._session_id = None
         path = self.path.split("?", 1)[0]
         # RFC 9728 metadata is unauthenticated — it is how the client discovers
         # how to authenticate — so it is checked before the auth gate. Match the
@@ -1224,6 +1361,15 @@ class _Handler(BaseHTTPRequestHandler):
             return
         if not self._require_auth():
             return
+        # The SSE stream carries a session's server-initiated messages, so it
+        # must name an existing session. Unknown/absent id -> 404 (drives the
+        # client's re-initialize), mirroring the POST path.
+        sid_header = self.headers.get("Mcp-Session-Id")
+        backend = self.registry.get(sid_header)
+        if backend is None:
+            self._send_json(404, _error_body("unknown or expired session"))
+            return
+        self._session_id = sid_header
         # Open an SSE stream carrying server-initiated messages (notifications
         # and server->client requests) until the client disconnects or the
         # backend dies. The stream has no Content-Length and is not chunked, so
@@ -1234,11 +1380,11 @@ class _Handler(BaseHTTPRequestHandler):
         self.send_header("Content-Type", "text/event-stream")
         self.send_header("Cache-Control", "no-store")
         self.send_header("Connection", "keep-alive")
-        self.send_header("Mcp-Session-Id", self.session_id)
+        self.send_header("Mcp-Session-Id", sid_header)
         self.end_headers()
-        q = self.backend.server_initiated
+        q = backend.server_initiated
         try:
-            while not self.backend.closed:
+            while not backend.closed:
                 try:
                     line = q.get(timeout=_SSE_KEEPALIVE_SECS)
                 except queue.Empty:
@@ -1254,12 +1400,25 @@ class _Handler(BaseHTTPRequestHandler):
             return
 
     def do_DELETE(self) -> None:  # noqa: N802 - BaseHTTPRequestHandler API
-        # MCP clients DELETE the endpoint to end a session. This gateway has one
-        # long-lived backend, so acknowledge without tearing it down.
+        # MCP clients DELETE the endpoint to terminate a session (spec item 5).
+        # Tear down that session's backend child.
+        self._session_id = None
         if self._wrong_path():
             return
         if not self._require_auth():
             return
+        sid_header = self.headers.get("Mcp-Session-Id")
+        if not sid_header:
+            self._send_json(400, _error_body("Mcp-Session-Id required"))
+            return
+        backend = self.registry.remove(sid_header)
+        if backend is None:
+            self._send_json(404, _error_body("unknown or expired session"))
+            return
+        # shutdown() (terminate -> wait) runs after the dict pop, off the lock.
+        backend.shutdown()
+        log(f"session {sid_header[:8]}... terminated by client")
+        self._session_id = sid_header
         self._send_empty(200)
 
 
@@ -1271,27 +1430,27 @@ def build_server(
     mcp_path: str = "/mcp",
     auth_token: str | None = None,
     oauth: _OAuthProvider | None = None,
-) -> tuple[ThreadingHTTPServer, BackendProcess]:
-    """Construct the HTTP server and backend without running the loop.
+    max_sessions: int = _DEFAULT_MAX_SESSIONS,
+) -> tuple[ThreadingHTTPServer, SessionRegistry]:
+    """Construct the HTTP server and session registry without running the loop.
 
     Separated from :func:`serve` so tests can drive the server on an ephemeral
     port (``port=0``) without installing signal handlers or blocking. The
     caller owns the lifecycle: run ``httpd.serve_forever()`` (typically in a
-    thread), then ``backend.shutdown()`` + ``httpd.server_close()``.
+    thread), then ``registry.shutdown_all()`` + ``httpd.server_close()``.
 
     ``auth_token`` (when not None) enables the static-bearer-token Resource
     Server gate. ``oauth`` (when not None) enables the embedded OAuth
     Authorization Server: /authorize /token /register + AS metadata, and
     the RS gate then also accepts issued access tokens.
     """
-    backend = BackendProcess(command)
+    registry = SessionRegistry(command, max_sessions=max_sessions)
     handler = type(
         "_BoundHandler",
         (_Handler,),
         {
-            "backend": backend,
+            "registry": registry,
             "mcp_path": mcp_path,
-            "session_id": uuid.uuid4().hex,
             "auth_token": auth_token,
             "oauth": oauth,
         },
@@ -1299,7 +1458,7 @@ def build_server(
     httpd = ThreadingHTTPServer((host, port), handler)
     # Don't let the process hang on lingering SSE handler threads at shutdown.
     httpd.daemon_threads = True
-    return httpd, backend
+    return httpd, registry
 
 
 def serve(
@@ -1318,7 +1477,7 @@ def serve(
     the backend down. ``auth_token`` enables the static-token gate;
     ``oauth`` enables the embedded Authorization Server.
     """
-    httpd, backend = build_server(
+    httpd, registry = build_server(
         command,
         host=host,
         port=port,
@@ -1353,7 +1512,7 @@ def serve(
     try:
         httpd.serve_forever()
     finally:
-        backend.shutdown()
+        registry.shutdown_all()
         httpd.server_close()
 
 

--- a/src/mcp_stdio/server.py
+++ b/src/mcp_stdio/server.py
@@ -338,10 +338,14 @@ class SessionRegistry:
             # Re-check the cap: a burst of concurrent creates could have filled
             # it while we were spawning. Over the cap -> drop the just-spawned
             # child rather than exceed the bound.
-            if len(self._sessions) >= self._max:
-                backend.shutdown()
-                return None
-            self._sessions[sid] = backend
+            over_cap = len(self._sessions) >= self._max
+            if not over_cap:
+                self._sessions[sid] = backend
+        if over_cap:
+            # shutdown() (terminate -> wait) runs OUTSIDE the lock so it never
+            # serializes other sessions' creation or routing.
+            backend.shutdown()
+            return None
         return sid, backend
 
     def get(self, sid: str | None) -> BackendProcess | None:
@@ -1223,6 +1227,26 @@ class _Handler(BaseHTTPRequestHandler):
         self.send_header("Content-Length", "0")
         self.end_headers()
 
+    def _resolve_session(self, req_id: Any = None) -> BackendProcess | None:
+        """Resolve the request's session, or emit the spec error and return None.
+
+        A missing ``Mcp-Session-Id`` -> 400 (MCP spec item 2); an unknown or
+        terminated id -> 404 (item 3, which drives the client's re-initialize).
+        On success records the id for the response header and returns the
+        backend. Shared by the POST (non-initialize) and GET paths so both
+        report the same status for the same condition.
+        """
+        sid = self.headers.get("Mcp-Session-Id")
+        if not sid:
+            self._send_json(400, _error_body("Mcp-Session-Id required", req_id))
+            return None
+        backend = self.registry.get(sid)
+        if backend is None:
+            self._send_json(404, _error_body("unknown or expired session", req_id))
+            return None
+        self._session_id = sid
+        return backend
+
     def do_POST(self) -> None:  # noqa: N802 - BaseHTTPRequestHandler API
         # Reset the per-request session id (the handler instance is reused
         # across keep-alive requests); responses before resolution omit it.
@@ -1283,13 +1307,14 @@ class _Handler(BaseHTTPRequestHandler):
                 return
 
         # --- session resolution (MCP Streamable HTTP session management) ---
-        sid_header = self.headers.get("Mcp-Session-Id")
-        if kind == "request" and msg.get("method") == "initialize":
+        is_init = kind == "request" and msg.get("method") == "initialize"
+        if is_init:
             # `initialize` starts a session (MCP spec item 1): spawn a fresh
             # child and mint an id, returned via the Mcp-Session-Id response
             # header. A presented (stale) id is dropped first.
-            if sid_header:
-                stale = self.registry.remove(sid_header)
+            stale_id = self.headers.get("Mcp-Session-Id")
+            if stale_id:
+                stale = self.registry.remove(stale_id)
                 if stale is not None:
                     stale.shutdown()
             created = self.registry.create()
@@ -1298,29 +1323,31 @@ class _Handler(BaseHTTPRequestHandler):
                 return
             self._session_id, backend = created
         else:
-            # MCP spec item 2: a server that requires a session SHOULD reject a
-            # sessionless non-initialize request with 400.
-            if not sid_header:
-                self._send_json(400, _error_body("Mcp-Session-Id required", req_id))
-                return
-            backend = self.registry.get(sid_header)
+            # MCP spec items 2/3: sessionless -> 400, unknown/terminated -> 404.
+            backend = self._resolve_session(req_id)
             if backend is None:
-                # MCP spec item 3: an unknown/terminated session id gets 404,
-                # which drives the client's re-initialize (spec item 4).
-                self._send_json(
-                    404, _error_body("unknown or expired session", req_id)
-                )
                 return
-            self._session_id = sid_header
 
         if kind == "request":
             if backend.closed:
+                # Dead child: drop the session so the slot is reclaimed and the
+                # client's next request re-initializes (404) instead of looping
+                # on 503. shutdown() reaps the already-exited child.
+                stale = self.registry.remove(self._session_id)
+                if stale is not None:
+                    stale.shutdown()
                 self._send_json(503, _error_body("backend unavailable", req_id))
                 return
             line = backend.send_request(
                 json.dumps(msg), req_id, _BACKEND_RESPONSE_TIMEOUT_SECS
             )
             if line is None:
+                if is_init:
+                    # The freshly-spawned child never answered initialize, so it
+                    # never became a usable session — don't leak its slot/child.
+                    stale = self.registry.remove(self._session_id)
+                    if stale is not None:
+                        stale.shutdown()
                 self._send_json(
                     504, _error_body("no response from backend", req_id)
                 )
@@ -1362,14 +1389,11 @@ class _Handler(BaseHTTPRequestHandler):
         if not self._require_auth():
             return
         # The SSE stream carries a session's server-initiated messages, so it
-        # must name an existing session. Unknown/absent id -> 404 (drives the
-        # client's re-initialize), mirroring the POST path.
-        sid_header = self.headers.get("Mcp-Session-Id")
-        backend = self.registry.get(sid_header)
+        # must name an existing session: sessionless -> 400, unknown/terminated
+        # -> 404 (drives the client's re-initialize), as on the POST path.
+        backend = self._resolve_session()
         if backend is None:
-            self._send_json(404, _error_body("unknown or expired session"))
             return
-        self._session_id = sid_header
         # Open an SSE stream carrying server-initiated messages (notifications
         # and server->client requests) until the client disconnects or the
         # backend dies. The stream has no Content-Length and is not chunked, so
@@ -1380,7 +1404,7 @@ class _Handler(BaseHTTPRequestHandler):
         self.send_header("Content-Type", "text/event-stream")
         self.send_header("Cache-Control", "no-store")
         self.send_header("Connection", "keep-alive")
-        self.send_header("Mcp-Session-Id", sid_header)
+        self.send_header("Mcp-Session-Id", self._session_id)
         self.end_headers()
         q = backend.server_initiated
         try:

--- a/tests/_fake_backend.py
+++ b/tests/_fake_backend.py
@@ -3,7 +3,7 @@
 Reads newline-delimited JSON-RPC from stdin and reacts:
 
 - ``initialize`` (request)      -> an InitializeResult with protocolVersion
-- ``echo`` (request)            -> result {"echoed": <params>}
+- ``echo`` (request)            -> result {"echoed": <params>, "pid": <os pid>}
 - ``noreply`` (request)         -> never responds (drives the timeout path)
 - ``trigger_push`` (notification) -> emits a server-initiated notification
 - ``exit`` (any)                -> the process exits
@@ -13,6 +13,7 @@ script path by the tests.
 """
 
 import json
+import os
 import sys
 
 
@@ -48,7 +49,15 @@ def main() -> None:
                 }
             )
         elif method == "echo" and "id" in msg:
-            _send({"jsonrpc": "2.0", "id": mid, "result": {"echoed": msg.get("params")}})
+            # pid lets a test prove two sessions hit two distinct child
+            # processes (no cross-session response leakage).
+            _send(
+                {
+                    "jsonrpc": "2.0",
+                    "id": mid,
+                    "result": {"echoed": msg.get("params"), "pid": os.getpid()},
+                }
+            )
         elif method == "noreply" and "id" in msg:
             pass  # intentionally silent -> exercises the gateway timeout path
         elif method == "trigger_push":  # a notification (no id)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -212,6 +212,13 @@ def test_get_sse_unknown_session_returns_404(gateway):
     assert resp.status_code == 404
 
 
+def test_get_sse_without_session_returns_400(gateway):
+    # MCP spec item 2: a sessionless GET (like a sessionless POST) -> 400.
+    url, _ = gateway
+    resp = httpx.get(url, timeout=10)
+    assert resp.status_code == 400
+
+
 def test_delete_reaps_session(gateway):
     url, registry = gateway
     sid, _ = _init(url)
@@ -249,6 +256,11 @@ def test_backend_death_then_request_fails(gateway):
     resp = _post(url, {"jsonrpc": "2.0", "id": 1, "method": "echo"}, sid)
     assert resp.status_code == 503
     assert resp.json()["id"] == 1
+    # The dead session is reaped, so the slot is reclaimed and the next request
+    # on that id gets 404 (the client then re-initializes) rather than 503.
+    assert registry.count == 0
+    again = _post(url, {"jsonrpc": "2.0", "id": 2, "method": "echo"}, sid)
+    assert again.status_code == 404
 
 
 def test_registry_cap_rejects_beyond_max():

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -23,26 +23,39 @@ _BACKEND = [sys.executable, os.path.join(os.path.dirname(__file__), "_fake_backe
 @pytest.fixture()
 def gateway():
     """Start the gateway on an ephemeral port; yield its base MCP URL."""
-    httpd, backend = server.build_server(_BACKEND, host="127.0.0.1", port=0)
+    httpd, registry = server.build_server(_BACKEND, host="127.0.0.1", port=0)
     host, port = httpd.server_address[0], httpd.server_address[1]
     t = threading.Thread(target=httpd.serve_forever, daemon=True)
     t.start()
     url = f"http://{host}:{port}/mcp"
     try:
-        yield url, backend
+        yield url, registry
     finally:
         httpd.shutdown()
-        backend.shutdown()
+        registry.shutdown_all()
         httpd.server_close()
 
 
-def _post(url: str, msg: dict) -> httpx.Response:
-    return httpx.post(url, content=json.dumps(msg), timeout=10)
+def _post(url: str, msg: dict, sid: str | None = None) -> httpx.Response:
+    headers = {"Mcp-Session-Id": sid} if sid else {}
+    return httpx.post(url, content=json.dumps(msg), headers=headers, timeout=10)
+
+
+def _init(url: str, headers: dict | None = None) -> tuple[str | None, httpx.Response]:
+    """POST ``initialize`` to open a session; return (session_id, response)."""
+    resp = httpx.post(
+        url,
+        content=json.dumps({"jsonrpc": "2.0", "id": "init", "method": "initialize"}),
+        headers=headers or {},
+        timeout=10,
+    )
+    return resp.headers.get("mcp-session-id"), resp
 
 
 def test_request_response(gateway):
     url, _ = gateway
-    resp = _post(url, {"jsonrpc": "2.0", "id": 1, "method": "echo", "params": {"a": 1}})
+    sid, _ = _init(url)
+    resp = _post(url, {"jsonrpc": "2.0", "id": 1, "method": "echo", "params": {"a": 1}}, sid)
     assert resp.status_code == 200
     assert resp.headers["content-type"] == "application/json"
     body = resp.json()
@@ -52,23 +65,56 @@ def test_request_response(gateway):
 
 def test_initialize_returns_protocol_version(gateway):
     url, _ = gateway
-    resp = _post(url, {"jsonrpc": "2.0", "id": "init", "method": "initialize"})
+    _, resp = _init(url)
     assert resp.status_code == 200
     assert resp.json()["result"]["protocolVersion"] == "2025-06-18"
 
 
-def test_session_id_header_present_and_stable(gateway):
+def test_initialize_assigns_session(gateway):
+    url, registry = gateway
+    sid, resp = _init(url)
+    assert resp.status_code == 200
+    assert sid  # the gateway minted an Mcp-Session-Id
+    assert registry.count == 1
+
+
+def test_session_id_per_initialize(gateway):
+    # Each initialize starts a NEW session with its own id (was a constant id
+    # under the old single-backend model).
+    url, registry = gateway
+    sid1, _ = _init(url)
+    sid2, _ = _init(url)
+    assert sid1 and sid2 and sid1 != sid2
+    assert registry.count == 2
+
+
+def test_two_initializes_distinct_children(gateway):
+    # Two sessions -> two distinct child processes (process-boundary isolation).
     url, _ = gateway
-    r1 = _post(url, {"jsonrpc": "2.0", "id": 1, "method": "echo"})
-    r2 = _post(url, {"jsonrpc": "2.0", "id": 2, "method": "echo"})
-    sid1 = r1.headers.get("mcp-session-id")
-    sid2 = r2.headers.get("mcp-session-id")
-    assert sid1 and sid1 == sid2
+    sid1, _ = _init(url)
+    sid2, _ = _init(url)
+    p1 = _post(url, {"jsonrpc": "2.0", "id": 1, "method": "echo"}, sid1).json()["result"]["pid"]
+    p2 = _post(url, {"jsonrpc": "2.0", "id": 1, "method": "echo"}, sid2).json()["result"]["pid"]
+    assert p1 != p2
+
+
+def test_no_cross_session_id_leak(gateway):
+    # Two sessions both use JSON-RPC id=1; each must get ITS OWN child's
+    # response, never the other's (the single-backend model could cross them).
+    url, _ = gateway
+    sid_a, _ = _init(url)
+    sid_b, _ = _init(url)
+    ra = _post(url, {"jsonrpc": "2.0", "id": 1, "method": "echo", "params": {"who": "A"}}, sid_a).json()
+    rb = _post(url, {"jsonrpc": "2.0", "id": 1, "method": "echo", "params": {"who": "B"}}, sid_b).json()
+    assert ra["result"]["echoed"] == {"who": "A"}
+    assert rb["result"]["echoed"] == {"who": "B"}
+    assert ra["result"]["pid"] != rb["result"]["pid"]
 
 
 def test_notification_returns_202(gateway):
     url, _ = gateway
-    resp = _post(url, {"jsonrpc": "2.0", "method": "somenotify"})
+    sid, _ = _init(url)
+    resp = _post(url, {"jsonrpc": "2.0", "method": "somenotify"}, sid)
     assert resp.status_code == 202
 
 
@@ -76,8 +122,23 @@ def test_client_response_returns_202(gateway):
     # A client answering a server-initiated request is a JSON-RPC response
     # (id + result, no method): the gateway forwards it one-way -> 202.
     url, _ = gateway
-    resp = _post(url, {"jsonrpc": "2.0", "id": 99, "result": {"ok": True}})
+    sid, _ = _init(url)
+    resp = _post(url, {"jsonrpc": "2.0", "id": 99, "result": {"ok": True}}, sid)
     assert resp.status_code == 202
+
+
+def test_sessionless_non_init_returns_400(gateway):
+    # MCP spec: a non-initialize request without an Mcp-Session-Id -> 400.
+    url, _ = gateway
+    resp = _post(url, {"jsonrpc": "2.0", "id": 1, "method": "echo"})
+    assert resp.status_code == 400
+
+
+def test_unknown_session_returns_404(gateway):
+    # MCP spec: an unknown/terminated session id -> 404 (drives re-initialize).
+    url, _ = gateway
+    resp = _post(url, {"jsonrpc": "2.0", "id": 1, "method": "echo"}, "deadbeef" * 4)
+    assert resp.status_code == 404
 
 
 def test_batch_is_rejected(gateway):
@@ -110,7 +171,8 @@ def test_wrong_path_returns_404(gateway):
 def test_backend_timeout_returns_504(gateway, monkeypatch):
     url, _ = gateway
     monkeypatch.setattr(server, "_BACKEND_RESPONSE_TIMEOUT_SECS", 0.4)
-    resp = _post(url, {"jsonrpc": "2.0", "id": 7, "method": "noreply"})
+    sid, _ = _init(url)
+    resp = _post(url, {"jsonrpc": "2.0", "id": 7, "method": "noreply"}, sid)
     assert resp.status_code == 504
     assert resp.json()["id"] == 7
     assert resp.json()["error"]["code"] == -32000
@@ -118,11 +180,14 @@ def test_backend_timeout_returns_504(gateway, monkeypatch):
 
 def test_get_sse_delivers_server_initiated(gateway):
     url, _ = gateway
+    sid, _ = _init(url)
     received: list[str] = []
     ready = threading.Event()
 
     def reader():
-        with httpx.stream("GET", url, timeout=10) as r:
+        with httpx.stream(
+            "GET", url, headers={"Mcp-Session-Id": sid}, timeout=10
+        ) as r:
             ready.set()
             for line in r.iter_lines():
                 if line.startswith("data: "):
@@ -133,7 +198,7 @@ def test_get_sse_delivers_server_initiated(gateway):
     t.start()
     ready.wait(5)
     time.sleep(0.2)  # let the GET stream attach before we trigger a push
-    _post(url, {"jsonrpc": "2.0", "method": "trigger_push"})
+    _post(url, {"jsonrpc": "2.0", "method": "trigger_push"}, sid)
     t.join(5)
     assert received, "no SSE message received"
     msg = json.loads(received[0])
@@ -141,23 +206,82 @@ def test_get_sse_delivers_server_initiated(gateway):
     assert msg["params"] == {"hello": "world"}
 
 
-def test_delete_returns_200(gateway):
+def test_get_sse_unknown_session_returns_404(gateway):
+    url, _ = gateway
+    resp = httpx.get(url, headers={"Mcp-Session-Id": "nope" * 8}, timeout=10)
+    assert resp.status_code == 404
+
+
+def test_delete_reaps_session(gateway):
+    url, registry = gateway
+    sid, _ = _init(url)
+    assert registry.count == 1
+    resp = httpx.request("DELETE", url, headers={"Mcp-Session-Id": sid}, timeout=10)
+    assert resp.status_code == 200
+    assert registry.count == 0
+    # The terminated session id is now unknown -> 404.
+    again = _post(url, {"jsonrpc": "2.0", "id": 1, "method": "echo"}, sid)
+    assert again.status_code == 404
+
+
+def test_delete_without_session_id_returns_400(gateway):
     url, _ = gateway
     resp = httpx.request("DELETE", url, timeout=10)
-    assert resp.status_code == 200
+    assert resp.status_code == 400
+
+
+def test_delete_unknown_session_returns_404(gateway):
+    url, _ = gateway
+    resp = httpx.request("DELETE", url, headers={"Mcp-Session-Id": "x" * 32}, timeout=10)
+    assert resp.status_code == 404
 
 
 def test_backend_death_then_request_fails(gateway):
-    url, backend = gateway
+    url, registry = gateway
+    sid, _ = _init(url)
+    backend = registry.get(sid)
     # Tell the backend to exit, then give the reader thread a moment to notice.
-    _post(url, {"jsonrpc": "2.0", "method": "exit"})
+    _post(url, {"jsonrpc": "2.0", "method": "exit"}, sid)
     deadline = time.time() + 5
     while not backend.closed and time.time() < deadline:
         time.sleep(0.05)
     assert backend.closed
-    resp = _post(url, {"jsonrpc": "2.0", "id": 1, "method": "echo"})
+    resp = _post(url, {"jsonrpc": "2.0", "id": 1, "method": "echo"}, sid)
     assert resp.status_code == 503
     assert resp.json()["id"] == 1
+
+
+def test_registry_cap_rejects_beyond_max():
+    # Unit-level: the registry returns None past the concurrent-session cap.
+    reg = server.SessionRegistry(_BACKEND, max_sessions=2)
+    try:
+        assert reg.create() is not None
+        assert reg.create() is not None
+        assert reg.create() is None  # cap reached
+        assert reg.count == 2
+    finally:
+        reg.shutdown_all()
+    assert reg.count == 0
+
+
+def test_session_cap_returns_503():
+    # HTTP-level: an initialize past the cap gets 503.
+    httpd, registry = server.build_server(
+        _BACKEND, host="127.0.0.1", port=0, max_sessions=1
+    )
+    host, port = httpd.server_address[0], httpd.server_address[1]
+    t = threading.Thread(target=httpd.serve_forever, daemon=True)
+    t.start()
+    url = f"http://{host}:{port}/mcp"
+    try:
+        sid1, r1 = _init(url)
+        assert r1.status_code == 200 and sid1
+        _, r2 = _init(url)
+        assert r2.status_code == 503
+    finally:
+        httpd.shutdown()
+        registry.shutdown_all()
+        httpd.server_close()
 
 
 # --- unit-level checks that don't need the HTTP server ---
@@ -191,7 +315,7 @@ _TOKEN = "s3cr3t-token"
 @pytest.fixture()
 def auth_gateway():
     """A gateway protected by a static bearer token."""
-    httpd, backend = server.build_server(
+    httpd, registry = server.build_server(
         _BACKEND, host="127.0.0.1", port=0, auth_token=_TOKEN
     )
     host, port = httpd.server_address[0], httpd.server_address[1]
@@ -199,10 +323,10 @@ def auth_gateway():
     t.start()
     url = f"http://{host}:{port}/mcp"
     try:
-        yield url, backend
+        yield url, registry
     finally:
         httpd.shutdown()
-        backend.shutdown()
+        registry.shutdown_all()
         httpd.server_close()
 
 
@@ -233,12 +357,14 @@ def test_auth_wrong_token_returns_401(auth_gateway):
 
 def test_auth_valid_token_returns_200(auth_gateway):
     url, _ = auth_gateway
+    auth = {"Authorization": f"Bearer {_TOKEN}"}
+    sid, _ = _init(url, headers=auth)
     resp = httpx.post(
         url,
         content=json.dumps(
             {"jsonrpc": "2.0", "id": 1, "method": "echo", "params": {"a": 1}}
         ),
-        headers={"Authorization": f"Bearer {_TOKEN}"},
+        headers={**auth, "Mcp-Session-Id": sid},
         timeout=10,
     )
     assert resp.status_code == 200
@@ -299,7 +425,7 @@ def test_prm_honors_forwarded_headers(auth_gateway):
 def test_no_auth_fixture_still_open(gateway):
     # The default fixture has no token: a request without Authorization is 200.
     url, _ = gateway
-    resp = _post(url, {"jsonrpc": "2.0", "id": 1, "method": "echo"})
+    _, resp = _init(url)
     assert resp.status_code == 200
 
 
@@ -332,18 +458,18 @@ _REDIRECT = "http://127.0.0.1:5555/callback"
 
 @contextlib.contextmanager
 def _run(*, auth_token=None, oauth=None):
-    """Start a gateway with the given auth config; yield (base_url, backend)."""
-    httpd, backend = server.build_server(
+    """Start a gateway with the given auth config; yield (base_url, registry)."""
+    httpd, registry = server.build_server(
         _BACKEND, host="127.0.0.1", port=0, auth_token=auth_token, oauth=oauth
     )
     host, port = httpd.server_address[0], httpd.server_address[1]
     t = threading.Thread(target=httpd.serve_forever, daemon=True)
     t.start()
     try:
-        yield f"http://{host}:{port}", backend
+        yield f"http://{host}:{port}", registry
     finally:
         httpd.shutdown()
-        backend.shutdown()
+        registry.shutdown_all()
         httpd.server_close()
 
 
@@ -357,8 +483,8 @@ def _provider(**kw):
 @pytest.fixture()
 def oauth_gateway():
     """A gateway with the embedded AS enabled and --dev-user=alice."""
-    with _run(oauth=_provider()) as (base, backend):
-        yield base, backend
+    with _run(oauth=_provider()) as (base, registry):
+        yield base, registry
 
 
 def _register(base, redirect=_REDIRECT):
@@ -401,10 +527,15 @@ def _token(base, data):
 
 
 def _authed_mcp(base, token, mid=1):
-    """An authenticated MCP echo call with the given bearer token."""
+    """An authenticated MCP call with the given bearer token.
+
+    Uses ``initialize`` so a valid token gets 200 (and opens a session) while
+    an invalid one is rejected by the auth gate (401) before session creation —
+    exactly the status distinction these tests assert.
+    """
     return httpx.post(
         base + "/mcp",
-        content=json.dumps({"jsonrpc": "2.0", "id": mid, "method": "echo"}),
+        content=json.dumps({"jsonrpc": "2.0", "id": mid, "method": "initialize"}),
         headers={"Authorization": f"Bearer {token}"},
         timeout=10,
     )
@@ -546,9 +677,11 @@ def test_full_auth_code_flow_and_use_token(oauth_gateway):
     assert body["refresh_token"]
     assert tok.headers.get("cache-control") == "no-store"
     # use the issued token on an MCP request
+    auth = {"Authorization": f"Bearer {body['access_token']}"}
+    sid, _ = _init(base + "/mcp", headers=auth)
     r = httpx.post(base + "/mcp",
                    content=json.dumps({"jsonrpc": "2.0", "id": 1, "method": "echo", "params": {"x": 1}}),
-                   headers={"Authorization": f"Bearer {body['access_token']}"}, timeout=10)
+                   headers={**auth, "Mcp-Session-Id": sid}, timeout=10)
     assert r.status_code == 200
     assert r.json()["result"]["echoed"] == {"x": 1}
     # without the token -> 401
@@ -718,7 +851,7 @@ def test_issued_token_expires():
         _, _, _, _, tok = _full_flow(base)
         at = tok.json()["access_token"]
         ok = httpx.post(base + "/mcp",
-                        content=json.dumps({"jsonrpc": "2.0", "id": 1, "method": "echo"}),
+                        content=json.dumps({"jsonrpc": "2.0", "id": 1, "method": "initialize"}),
                         headers={"Authorization": f"Bearer {at}"}, timeout=10)
         assert ok.status_code == 200
         clock[0] += 100  # advance past TTL
@@ -734,14 +867,14 @@ def test_coexistence_static_and_oauth():
     with _run(auth_token="static-tok", oauth=_provider()) as (base, _):
         # static token authorizes
         r1 = httpx.post(base + "/mcp",
-                        content=json.dumps({"jsonrpc": "2.0", "id": 1, "method": "echo"}),
+                        content=json.dumps({"jsonrpc": "2.0", "id": 1, "method": "initialize"}),
                         headers={"Authorization": "Bearer static-tok"}, timeout=10)
         assert r1.status_code == 200
         # issued token authorizes
         _, _, _, _, tok = _full_flow(base)
         at = tok.json()["access_token"]
         r2 = httpx.post(base + "/mcp",
-                        content=json.dumps({"jsonrpc": "2.0", "id": 2, "method": "echo"}),
+                        content=json.dumps({"jsonrpc": "2.0", "id": 2, "method": "initialize"}),
                         headers={"Authorization": f"Bearer {at}"}, timeout=10)
         assert r2.status_code == 200
         # PRM advertises authorization_servers
@@ -862,7 +995,7 @@ def test_path_scoped_full_flow():
         # The issued token authorizes a real MCP call at the prefixed path.
         r = httpx.post(
             base + prefix + "/mcp",
-            content=json.dumps({"jsonrpc": "2.0", "id": 1, "method": "echo"}),
+            content=json.dumps({"jsonrpc": "2.0", "id": 1, "method": "initialize"}),
             headers={"Authorization": f"Bearer {access}"},
             timeout=10,
         )
@@ -972,7 +1105,7 @@ def test_real_client_ensure_token(monkeypatch, tmp_path):
         assert td.access_token
         # the obtained token authorizes a real MCP call
         r = httpx.post(base + "/mcp",
-                       content=json.dumps({"jsonrpc": "2.0", "id": 1, "method": "echo"}),
+                       content=json.dumps({"jsonrpc": "2.0", "id": 1, "method": "initialize"}),
                        headers={"Authorization": f"Bearer {td.access_token}"}, timeout=10)
         assert r.status_code == 200
 


### PR DESCRIPTION
## What

`serve` mode shared one long-lived backend child across all HTTP clients (single-client target; a JSON-RPC id collision across clients could cross responses). This spawns a **dedicated backend child per MCP session**, so concurrent clients are isolated by process boundary.

## How (per MCP Streamable HTTP session management, 2025-06-18)

- `initialize` spawns a fresh child and mints an `Mcp-Session-Id` (returned on the response); every later request carries it and routes to its child.
- Sessionless non-initialize request → `400` (spec item 2); unknown/terminated id → `404` (item 3) → client re-initializes (item 4, symmetric with `relay.py`'s 404 recovery).
- `DELETE` with the id terminates the session and tears its child down (item 5) — previously a no-op ack.

A new `SessionRegistry` layers above `BackendProcess` (unchanged): spawns/teardowns run **outside** its lock so one session's lifecycle never serializes another's, and a concurrent-session cap guards an open gateway against unbounded child spawns. The GET SSE stream routes to the requested session's child.

## Observable changes

- The `Mcp-Session-Id` is now **per-`initialize`** (was a constant).
- A stale/unknown id → `404`; a sessionless non-initialize POST → `400`; `DELETE` now reaps the child.

Real clients are unaffected: relay always `initialize`s first, adopts the id, and self-heals on 404.

## Tests

New: per-session distinct children, **no cross-session id leakage** (distinct child PIDs), unknown-session 404, sessionless 400, DELETE reaping, registry cap (unit + HTTP 503). Existing transport/OAuth tests migrated to establish a session first. Full suite: 1068 passed, 3 skipped; `ruff` clean.

## Follow-up (not in this PR)

Resource governance (configurable cap, idle eviction) and OAuth session→user binding.

Closes #257

🤖 Generated with [Claude Code](https://claude.com/claude-code)