### PR TITLE
feat(serve): session resource governance — max-sessions, idle eviction

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -316,11 +316,14 @@ mcp-stdio --oauth http://127.0.0.1:8080/mcp
 
 オプション: `--host`（既定 `127.0.0.1`）、`--port`（既定 `8080`）、`--path`
 （既定 `/mcp`）、`--auth-token TOKEN`（または `MCP_STDIO_SERVE_TOKEN`、推奨）;
-埋め込み AS 用: `--enable-oauth`、`--public-url URL`（issuer 固定・プロキシ背後
-で推奨）、`--trusted-user-header HEADER`、`--dev-user USER`（非セキュア・検証用）、
-`--access-token-ttl SECONDS`。インメモリなので再起動で発行済みトークンは失効
-（クライアントは `--oauth` を再実行）。バックエンドコマンドはオプションの後に
-置きます（`--` 区切りも可）。
+セッション上限 `--max-sessions N`（既定 `100`、cap 超過の `initialize` は `503`）
+と `--session-idle-ttl SECONDS`（無活動がこの秒数続いたセッションと子プロセスを
+破棄。`DELETE` せず切断したクライアントが slot を占有し続けるのを防ぐ。`0`＝既定
+で無効）; 埋め込み AS 用: `--enable-oauth`、`--public-url URL`（issuer 固定・
+プロキシ背後で推奨）、`--trusted-user-header HEADER`、`--dev-user USER`
+（非セキュア・検証用）、`--access-token-ttl SECONDS`。インメモリなので再起動で
+発行済みトークンは失効（クライアントは `--oauth` を再実行）。バックエンド
+コマンドはオプションの後に置きます（`--` 区切りも可）。
 
   - *パススコープ issuer* — `--public-url` がパスを保持するので、1 ホスト配下で
     複数の `--enable-oauth` バックエンドをパスプレフィックスで多重化できる

--- a/README.md
+++ b/README.md
@@ -318,11 +318,15 @@ mcp-stdio --oauth http://127.0.0.1:8080/mcp
 
 Options: `--host` (default `127.0.0.1`), `--port` (default `8080`), `--path`
 (default `/mcp`), `--auth-token TOKEN` (or `MCP_STDIO_SERVE_TOKEN`, preferred);
-and for the embedded AS: `--enable-oauth`, `--public-url URL` (pins the issuer;
-recommended behind a proxy), `--trusted-user-header HEADER`, `--dev-user USER`
-(insecure, testing only), `--access-token-ttl SECONDS`. In-memory tokens mean a
-restart invalidates issued tokens (the client re-runs `--oauth`). The backend
-command follows the options (an optional `--` separator is supported).
+session limits `--max-sessions N` (default `100`; an `initialize` past the cap
+gets `503`) and `--session-idle-ttl SECONDS` (evict a session and its child
+after this much inactivity so a client that disconnects without `DELETE` does
+not pin a slot; `0` = disabled, the default); and for the embedded AS:
+`--enable-oauth`, `--public-url URL` (pins the issuer; recommended behind a
+proxy), `--trusted-user-header HEADER`, `--dev-user USER` (insecure, testing
+only), `--access-token-ttl SECONDS`. In-memory tokens mean a restart
+invalidates issued tokens (the client re-runs `--oauth`). The backend command
+follows the options (an optional `--` separator is supported).
 
   - *Path-scoped issuer* — `--public-url` retains a path, so several
     `--enable-oauth` backends can share one host behind a reverse proxy, each

--- a/src/mcp_stdio/server.py
+++ b/src/mcp_stdio/server.py
@@ -289,9 +289,22 @@ class BackendProcess:
 
 # Hard cap on concurrent sessions: a fork-bomb guard for an open (no-auth)
 # gateway, since each session spawns a child process. High enough that a single
-# logical client never trips it; a configurable knob and idle eviction land in
-# a follow-up change.
+# logical client never trips it; override with ``--max-sessions``.
 _DEFAULT_MAX_SESSIONS = 100
+
+# Longest a reaper tick waits between idle sweeps. A small TTL is swept more
+# often; a large one no less than once a minute.
+_MAX_REAP_INTERVAL_SECS = 60.0
+
+
+class _Session:
+    """A live MCP session: its backend child plus last-activity timestamp."""
+
+    __slots__ = ("backend", "last_active")
+
+    def __init__(self, backend: BackendProcess, last_active: float) -> None:
+        self.backend = backend
+        self.last_active = last_active
 
 
 class SessionRegistry:
@@ -307,17 +320,32 @@ class SessionRegistry:
     The slow operations — spawning a child (``Popen`` exec) and tearing one
     down (``terminate()`` then ``wait``) — run OUTSIDE the lock; only the dict
     mutation is guarded, so one session's lifecycle never serializes another's.
+
+    When ``idle_ttl`` is set (``> 0``), a background reaper (started by
+    :meth:`start_reaper`) sweeps sessions whose last activity is older than the
+    TTL — and any whose child has already exited — so a client that disconnects
+    without DELETE does not pin a slot forever. ``now`` is injectable so tests
+    can drive eviction on a fake clock.
     """
 
     def __init__(
-        self, command: list[str], *, max_sessions: int = _DEFAULT_MAX_SESSIONS
+        self,
+        command: list[str],
+        *,
+        max_sessions: int = _DEFAULT_MAX_SESSIONS,
+        idle_ttl: float = 0.0,
+        now: Any = time.monotonic,
     ) -> None:
         if not command:
             raise ValueError("backend command is empty")
         self._command = command
         self._max = max_sessions
+        self._idle_ttl = idle_ttl
+        self._now = now
         self._lock = threading.Lock()
-        self._sessions: dict[str, BackendProcess] = {}
+        self._sessions: dict[str, _Session] = {}
+        self._reaper: threading.Thread | None = None
+        self._reaper_stop = threading.Event()
 
     def create(self) -> tuple[str, BackendProcess] | None:
         """Spawn a child for a new session.
@@ -340,7 +368,7 @@ class SessionRegistry:
             # child rather than exceed the bound.
             over_cap = len(self._sessions) >= self._max
             if not over_cap:
-                self._sessions[sid] = backend
+                self._sessions[sid] = _Session(backend, self._now())
         if over_cap:
             # shutdown() (terminate -> wait) runs OUTSIDE the lock so it never
             # serializes other sessions' creation or routing.
@@ -349,11 +377,28 @@ class SessionRegistry:
         return sid, backend
 
     def get(self, sid: str | None) -> BackendProcess | None:
-        """Resolve a session id to its backend, or None if unknown."""
+        """Resolve a session id to its backend, or None if unknown.
+
+        Touches the session's last-activity timestamp so an actively used
+        session is never idle-reaped.
+        """
         if not sid:
             return None
         with self._lock:
-            return self._sessions.get(sid)
+            sess = self._sessions.get(sid)
+            if sess is None:
+                return None
+            sess.last_active = self._now()
+            return sess.backend
+
+    def touch(self, sid: str | None) -> None:
+        """Mark a session active without resolving it (e.g. on SSE traffic)."""
+        if not sid:
+            return
+        with self._lock:
+            sess = self._sessions.get(sid)
+            if sess is not None:
+                sess.last_active = self._now()
 
     def remove(self, sid: str | None) -> BackendProcess | None:
         """Detach a session and return its backend (or None if unknown).
@@ -364,15 +409,58 @@ class SessionRegistry:
         if not sid:
             return None
         with self._lock:
-            return self._sessions.pop(sid, None)
+            sess = self._sessions.pop(sid, None)
+        return sess.backend if sess is not None else None
+
+    def reap_idle(self) -> int:
+        """Drop sessions idle past the TTL — or whose child has exited — and
+        shut their backends down outside the lock. Returns the count reaped."""
+        ttl = self._idle_ttl
+        now = self._now()
+        victims: list[tuple[str, BackendProcess]] = []
+        with self._lock:
+            for sid, sess in list(self._sessions.items()):
+                if sess.backend.closed or (ttl > 0 and now - sess.last_active > ttl):
+                    del self._sessions[sid]
+                    victims.append((sid, sess.backend))
+        for sid, backend in victims:
+            backend.shutdown()
+            log(f"reaped idle session {sid[:8]}...")
+        return len(victims)
 
     def shutdown_all(self) -> None:
         """Tear down every session's child (gateway shutdown)."""
+        self.stop_reaper()
         with self._lock:
-            backends = list(self._sessions.values())
+            backends = [s.backend for s in self._sessions.values()]
             self._sessions.clear()
         for backend in backends:
             backend.shutdown()
+
+    def start_reaper(self) -> None:
+        """Start the background idle-eviction thread (no-op if TTL disabled)."""
+        if self._idle_ttl <= 0 or self._reaper is not None:
+            return
+        interval = max(1.0, min(self._idle_ttl, _MAX_REAP_INTERVAL_SECS))
+
+        def _loop() -> None:
+            while not self._reaper_stop.wait(interval):
+                try:
+                    self.reap_idle()
+                except Exception as e:  # pragma: no cover - defensive
+                    log(f"session reaper error: {e}")
+
+        self._reaper = threading.Thread(
+            target=_loop, name="session-reaper", daemon=True
+        )
+        self._reaper.start()
+
+    def stop_reaper(self) -> None:
+        self._reaper_stop.set()
+        reaper = self._reaper
+        if reaper is not None:
+            reaper.join(timeout=2)
+            self._reaper = None
 
     @property
     def count(self) -> int:
@@ -1409,6 +1497,9 @@ class _Handler(BaseHTTPRequestHandler):
         q = backend.server_initiated
         try:
             while not backend.closed:
+                # An open SSE stream is activity: keep the session warm so the
+                # idle reaper does not evict a connected-but-quiet client.
+                self.registry.touch(self._session_id)
                 try:
                     line = q.get(timeout=_SSE_KEEPALIVE_SECS)
                 except queue.Empty:
@@ -1455,6 +1546,7 @@ def build_server(
     auth_token: str | None = None,
     oauth: _OAuthProvider | None = None,
     max_sessions: int = _DEFAULT_MAX_SESSIONS,
+    idle_ttl: float = 0.0,
 ) -> tuple[ThreadingHTTPServer, SessionRegistry]:
     """Construct the HTTP server and session registry without running the loop.
 
@@ -1466,9 +1558,13 @@ def build_server(
     ``auth_token`` (when not None) enables the static-bearer-token Resource
     Server gate. ``oauth`` (when not None) enables the embedded OAuth
     Authorization Server: /authorize /token /register + AS metadata, and
-    the RS gate then also accepts issued access tokens.
+    the RS gate then also accepts issued access tokens. ``idle_ttl`` (when
+    ``> 0``) arms idle session eviction; the caller starts the reaper with
+    ``registry.start_reaper()``.
     """
-    registry = SessionRegistry(command, max_sessions=max_sessions)
+    registry = SessionRegistry(
+        command, max_sessions=max_sessions, idle_ttl=idle_ttl
+    )
     handler = type(
         "_BoundHandler",
         (_Handler,),
@@ -1493,13 +1589,16 @@ def serve(
     mcp_path: str = "/mcp",
     auth_token: str | None = None,
     oauth: _OAuthProvider | None = None,
+    max_sessions: int = _DEFAULT_MAX_SESSIONS,
+    idle_ttl: float = 0.0,
 ) -> None:
     """Run the reverse gateway until interrupted.
 
     Spawns ``command`` as the backend stdio MCP server and serves it at
     ``http://host:port{mcp_path}``. Blocks until SIGINT/SIGTERM, then tears
     the backend down. ``auth_token`` enables the static-token gate;
-    ``oauth`` enables the embedded Authorization Server.
+    ``oauth`` enables the embedded Authorization Server. ``max_sessions`` caps
+    concurrent sessions; ``idle_ttl`` (when ``> 0``) evicts idle sessions.
     """
     httpd, registry = build_server(
         command,
@@ -1508,7 +1607,10 @@ def serve(
         mcp_path=mcp_path,
         auth_token=auth_token,
         oauth=oauth,
+        max_sessions=max_sessions,
+        idle_ttl=idle_ttl,
     )
+    registry.start_reaper()
 
     stopping = threading.Event()
 
@@ -1529,9 +1631,11 @@ def serve(
     if oauth is not None:
         modes.append("embedded OAuth AS")
     auth_state = " + ".join(modes) if modes else "no auth"
+    ttl_state = f"idle-ttl {idle_ttl:g}s" if idle_ttl > 0 else "no idle eviction"
     log(
         f"serving {' '.join(command)} at "
-        f"http://{host}:{port}{mcp_path} ({auth_state})"
+        f"http://{host}:{port}{mcp_path} ({auth_state}; "
+        f"max {max_sessions} sessions, {ttl_state})"
     )
     try:
         httpd.serve_forever()
@@ -1621,6 +1725,28 @@ def serve_main(argv: list[str]) -> None:
         help="Issued access-token lifetime in seconds (default: 3600).",
     )
     parser.add_argument(
+        "--max-sessions",
+        type=int,
+        default=_DEFAULT_MAX_SESSIONS,
+        metavar="N",
+        help=(
+            "Maximum concurrent MCP sessions, each backed by its own child "
+            f"process (default: {_DEFAULT_MAX_SESSIONS}). An initialize past "
+            "the cap gets 503 — a fork-bomb guard for an open gateway."
+        ),
+    )
+    parser.add_argument(
+        "--session-idle-ttl",
+        type=float,
+        default=0.0,
+        metavar="SECONDS",
+        help=(
+            "Evict a session (and its child) after this many seconds with no "
+            "activity, so a client that disconnects without DELETE does not "
+            "pin a slot. 0 (default) disables idle eviction."
+        ),
+    )
+    parser.add_argument(
         "command",
         nargs=argparse.REMAINDER,
         help="backend stdio MCP server command (after the options)",
@@ -1662,6 +1788,10 @@ def serve_main(argv: list[str]) -> None:
         parser.error("--trusted-user-header must be a valid header name")
     if args.access_token_ttl <= 0:
         parser.error("--access-token-ttl must be > 0")
+    if args.max_sessions < 1:
+        parser.error("--max-sessions must be >= 1")
+    if args.session_idle_ttl < 0:
+        parser.error("--session-idle-ttl must be >= 0")
     if args.enable_oauth:
         public_url = None
         if args.public_url is not None:
@@ -1697,4 +1827,6 @@ def serve_main(argv: list[str]) -> None:
         mcp_path=args.path,
         auth_token=auth_token,
         oauth=oauth,
+        max_sessions=args.max_sessions,
+        idle_ttl=args.session_idle_ttl,
     )

--- a/src/mcp_stdio/server.py
+++ b/src/mcp_stdio/server.py
@@ -36,6 +36,7 @@ import base64
 import hashlib
 import hmac
 import json
+import math
 import os
 import queue
 import re
@@ -269,6 +270,12 @@ class BackendProcess:
     def closed(self) -> bool:
         return self._closed.is_set()
 
+    @property
+    def has_pending(self) -> bool:
+        """True while at least one request is awaiting a backend response."""
+        with self._lock:
+            return bool(self._pending)
+
     def shutdown(self) -> None:
         """Terminate the backend child, escalating to kill if needed."""
         self._fail_all("gateway shutting down")
@@ -420,9 +427,17 @@ class SessionRegistry:
         victims: list[tuple[str, BackendProcess]] = []
         with self._lock:
             for sid, sess in list(self._sessions.items()):
-                if sess.backend.closed or (ttl > 0 and now - sess.last_active > ttl):
+                backend = sess.backend
+                # Don't idle-reap a session with a request in flight: a slow
+                # tool call (up to the backend-response timeout) is not idleness.
+                idle = (
+                    ttl > 0
+                    and now - sess.last_active > ttl
+                    and not backend.has_pending
+                )
+                if backend.closed or idle:
                     del self._sessions[sid]
-                    victims.append((sid, sess.backend))
+                    victims.append((sid, backend))
         for sid, backend in victims:
             backend.shutdown()
             log(f"reaped idle session {sid[:8]}...")
@@ -437,10 +452,20 @@ class SessionRegistry:
         for backend in backends:
             backend.shutdown()
 
+    def keepalive_interval(self) -> float:
+        """SSE keepalive/touch cadence — short enough that an open stream
+        refreshes its activity before the idle reaper could evict it (so a
+        connected client is never reaped even when the TTL is below the default
+        keepalive)."""
+        if self._idle_ttl > 0:
+            return max(1.0, min(_SSE_KEEPALIVE_SECS, self._idle_ttl / 2))
+        return _SSE_KEEPALIVE_SECS
+
     def start_reaper(self) -> None:
         """Start the background idle-eviction thread (no-op if TTL disabled)."""
         if self._idle_ttl <= 0 or self._reaper is not None:
             return
+        self._reaper_stop.clear()  # allow a restart after a prior stop_reaper
         interval = max(1.0, min(self._idle_ttl, _MAX_REAP_INTERVAL_SECS))
 
         def _loop() -> None:
@@ -1495,13 +1520,15 @@ class _Handler(BaseHTTPRequestHandler):
         self.send_header("Mcp-Session-Id", self._session_id)
         self.end_headers()
         q = backend.server_initiated
+        keepalive = self.registry.keepalive_interval()
         try:
             while not backend.closed:
                 # An open SSE stream is activity: keep the session warm so the
-                # idle reaper does not evict a connected-but-quiet client.
+                # idle reaper does not evict a connected-but-quiet client. The
+                # cadence tracks the TTL so this holds even for a small TTL.
                 self.registry.touch(self._session_id)
                 try:
-                    line = q.get(timeout=_SSE_KEEPALIVE_SECS)
+                    line = q.get(timeout=keepalive)
                 except queue.Empty:
                     # SSE comment keepalive — also how we notice backend death.
                     self.wfile.write(b": keepalive\n\n")
@@ -1790,8 +1817,8 @@ def serve_main(argv: list[str]) -> None:
         parser.error("--access-token-ttl must be > 0")
     if args.max_sessions < 1:
         parser.error("--max-sessions must be >= 1")
-    if args.session_idle_ttl < 0:
-        parser.error("--session-idle-ttl must be >= 0")
+    if args.session_idle_ttl < 0 or not math.isfinite(args.session_idle_ttl):
+        parser.error("--session-idle-ttl must be a non-negative, finite number")
     if args.enable_oauth:
         public_url = None
         if args.public_url is not None:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -375,6 +375,83 @@ def test_serve_main_rejects_negative_idle_ttl():
         server.serve_main(["--session-idle-ttl", "-1", "--", "true"])
 
 
+def test_serve_main_rejects_non_finite_idle_ttl():
+    # inf/nan parse as floats but would arm a reaper that never evicts.
+    for bad in ("inf", "nan"):
+        with pytest.raises(SystemExit):
+            server.serve_main(["--session-idle-ttl", bad, "--", "true"])
+
+
+def test_idle_eviction_disabled_keeps_live_session():
+    # ttl=0 disables idle eviction: a live, arbitrarily-idle session survives.
+    clock = [1000.0]
+    reg = server.SessionRegistry(_BACKEND, idle_ttl=0, now=lambda: clock[0])
+    try:
+        reg.create()
+        clock[0] += 10_000
+        assert reg.reap_idle() == 0
+        assert reg.count == 1
+    finally:
+        reg.shutdown_all()
+
+
+def test_in_flight_request_not_reaped():
+    # A session with a request in flight is not idle, even past the TTL.
+    clock = [1000.0]
+    reg = server.SessionRegistry(_BACKEND, idle_ttl=10, now=lambda: clock[0])
+    try:
+        _, backend = reg.create()
+        done = threading.Event()
+
+        def slow():
+            backend.send_request(
+                '{"jsonrpc": "2.0", "id": 1, "method": "noreply"}', 1, 2.0
+            )
+            done.set()
+
+        threading.Thread(target=slow, daemon=True).start()
+        for _ in range(100):
+            if backend.has_pending:
+                break
+            time.sleep(0.02)
+        assert backend.has_pending
+        clock[0] += 100  # well past the TTL
+        assert reg.reap_idle() == 0  # the in-flight request protects it
+        assert reg.count == 1
+        assert done.wait(5)  # the request times out -> pending cleared
+        assert not backend.has_pending
+        clock[0] += 100
+        assert reg.reap_idle() == 1  # now genuinely idle
+    finally:
+        reg.shutdown_all()
+
+
+def test_build_server_idle_ttl_evicts_http_session():
+    # End-to-end: idle_ttl threaded through build_server + start_reaper evicts
+    # an idle HTTP session, after which its id 404s.
+    httpd, registry = server.build_server(
+        _BACKEND, host="127.0.0.1", port=0, idle_ttl=0.5
+    )
+    host, port = httpd.server_address[0], httpd.server_address[1]
+    t = threading.Thread(target=httpd.serve_forever, daemon=True)
+    t.start()
+    registry.start_reaper()
+    url = f"http://{host}:{port}/mcp"
+    try:
+        sid, r = _init(url)
+        assert r.status_code == 200 and registry.count == 1
+        deadline = time.time() + 5
+        while registry.count > 0 and time.time() < deadline:
+            time.sleep(0.05)
+        assert registry.count == 0
+        again = _post(url, {"jsonrpc": "2.0", "id": 1, "method": "echo"}, sid)
+        assert again.status_code == 404
+    finally:
+        httpd.shutdown()
+        registry.shutdown_all()
+        httpd.server_close()
+
+
 # --- unit-level checks that don't need the HTTP server ---
 
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -296,6 +296,85 @@ def test_session_cap_returns_503():
         httpd.server_close()
 
 
+def test_reap_idle_evicts_after_ttl():
+    # Unit-level with an injected clock: a session idle past the TTL is evicted
+    # and its child shut down.
+    clock = [1000.0]
+    reg = server.SessionRegistry(_BACKEND, idle_ttl=30, now=lambda: clock[0])
+    try:
+        _, backend = reg.create()
+        assert reg.count == 1
+        clock[0] += 20  # within TTL
+        assert reg.reap_idle() == 0
+        assert reg.count == 1
+        clock[0] += 20  # 40s since last activity > 30s TTL
+        assert reg.reap_idle() == 1
+        assert reg.count == 0
+        assert backend.closed
+    finally:
+        reg.shutdown_all()
+
+
+def test_active_session_survives_reap():
+    # get() touches last_active, so an actively-used session is never reaped.
+    clock = [1000.0]
+    reg = server.SessionRegistry(_BACKEND, idle_ttl=30, now=lambda: clock[0])
+    try:
+        sid, _ = reg.create()
+        clock[0] += 25
+        assert reg.get(sid) is not None  # touch -> last_active = 1025
+        clock[0] += 10  # only 10s since the touch
+        assert reg.reap_idle() == 0
+        assert reg.count == 1
+    finally:
+        reg.shutdown_all()
+
+
+def test_reap_idle_drops_dead_child_even_without_ttl():
+    # A child that has exited is reaped regardless of TTL (slot reclaimed).
+    reg = server.SessionRegistry(_BACKEND, idle_ttl=0)
+    try:
+        _, backend = reg.create()
+        backend.shutdown()  # simulate the child dying
+        assert backend.closed
+        assert reg.reap_idle() == 1
+        assert reg.count == 0
+    finally:
+        reg.shutdown_all()
+
+
+def test_start_reaper_noop_when_ttl_disabled():
+    reg = server.SessionRegistry(_BACKEND, idle_ttl=0)
+    reg.start_reaper()
+    assert reg._reaper is None  # no thread when eviction is disabled
+    reg.stop_reaper()  # safe no-op
+
+
+def test_reaper_thread_evicts_idle_session():
+    # The background reaper thread evicts an idle session on its own.
+    reg = server.SessionRegistry(_BACKEND, idle_ttl=0.5)
+    reg.start_reaper()
+    try:
+        reg.create()
+        assert reg.count == 1
+        deadline = time.time() + 5
+        while reg.count > 0 and time.time() < deadline:
+            time.sleep(0.05)
+        assert reg.count == 0
+    finally:
+        reg.shutdown_all()
+
+
+def test_serve_main_rejects_zero_max_sessions():
+    with pytest.raises(SystemExit):
+        server.serve_main(["--max-sessions", "0", "--", "true"])
+
+
+def test_serve_main_rejects_negative_idle_ttl():
+    with pytest.raises(SystemExit):
+        server.serve_main(["--session-idle-ttl", "-1", "--", "true"])
+
+
 # --- unit-level checks that don't need the HTTP server ---
 
 


### PR DESCRIPTION
## What

Follow-up to per-session backends (#258). Makes an open `serve` gateway bounded and self-cleaning.

- **`--max-sessions N`** (default 100) — wires the registry's concurrent-session cap to a CLI flag; an `initialize` past the cap returns `503` (fork-bomb guard).
- **`--session-idle-ttl SECONDS`** (default `0` = disabled) — a background reaper evicts a session and its child after this much inactivity, so a client that disconnects without `DELETE` doesn't pin a slot forever. An open SSE stream counts as activity; the reaper also drops sessions whose child already exited.

## How

`SessionRegistry` wraps each backend in a `_Session` with a last-activity timestamp. `get()` touches it; `reap_idle()` sweeps idle/dead sessions (shutting children down outside the lock); `start_reaper`/`stop_reaper` manage the daemon sweep thread (started by `serve()`, stopped in `shutdown_all()`). The clock is injectable (`now=`) so eviction is tested deterministically.

## Compatibility

Default behavior unchanged: TTL defaults to `0` (no eviction); cap defaults to the prior hardcoded 100.

## Tests

Injected-clock eviction-after-TTL, active-session-survives (touch), dead-child reaped without TTL, reaper no-op when disabled, live reaper-thread eviction, and flag validation (`--max-sessions 0` / `--session-idle-ttl -1` → error). Full suite: 1076 passed, 3 skipped; `ruff` clean.

## Follow-up

OAuth session→user binding (next PR).

Closes #260

🤖 Generated with [Claude Code](https://claude.com/claude-code)