### PR TITLE
docs: serve mode multi-user deployment guide

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -340,6 +340,66 @@ mcp-stdio --oauth http://127.0.0.1:8080/mcp
     パス対応ディスカバリとバイト単位で対称。パスなしの `--public-url` は従来通り
     動作します（#245）。
 
+### マルチユーザ運用
+
+`serve` は複数ユーザの同時利用を前提に設計されています。MCP セッションごとに
+専用のバックエンド子プロセスを spawn し、OAuth 有効時は各セッションを認証ユーザに
+束縛するので、ユーザは**プロセス境界**で分離され、漏れた session id がテナントを
+またげません。
+
+エンドユーザのログインは前段リバースプロキシに委譲します。プロキシが実際の SSO を
+行い、`--trusted-user-header` でユーザを主張します（クライアント由来の同名ヘッダを
+プロキシが除去するからこそ信頼できる）。埋め込み AS がユーザごとのトークンを発行し、
+ゲートウェイが各セッションをそのユーザに束縛します。
+
+```mermaid
+flowchart TD
+    UA["User A<br>mcp-stdio --oauth"]
+    UB["User B<br>mcp-stdio --oauth"]
+    RP["リバースプロキシ<br>SSO ログイン, X-Forwarded-User 付与<br>クライアント由来コピーは除去"]
+    GW["mcp-stdio serve --enable-oauth<br>--trusted-user-header X-Forwarded-User"]
+    CA["stdio 子プロセス<br>A のセッション"]
+    CB["stdio 子プロセス<br>B のセッション"]
+    UA == "Streamable HTTP<br>OAuth 2.1 (PKCE)" ==> RP
+    UB == "Streamable HTTP<br>OAuth 2.1 (PKCE)" ==> RP
+    RP ==> GW
+    GW -- "セッションごとに spawn" --> CA
+    GW -- "セッションごとに spawn" --> CB
+```
+
+ゲートウェイ（プロキシ背後の loopback にバインド）:
+
+```bash
+mcp-stdio serve --enable-oauth \
+  --public-url https://mcp.example.org \
+  --trusted-user-header X-Forwarded-User \
+  --max-sessions 200 --session-idle-ttl 900 \
+  --host 127.0.0.1 --port 8080 -- python -m my_mcp_server
+```
+
+- `--public-url` は issuer をプロキシが配信する外部 HTTPS URL に固定。
+- `--trusted-user-header` はプロキシがログイン後に付与するヘッダ。プロキシが
+  クライアント由来コピーを除去するからこそ信頼する。
+- `--max-sessions` はユーザごとの子プロセス数の上限、`--session-idle-ttl` は
+  ユーザが `DELETE` せず切断した子プロセスを回収。
+
+各ユーザはクライアントをゲートウェイに向け、一度 OAuth フローを通せば専用の
+子プロセスで処理されます:
+
+```bash
+mcp-stdio --oauth https://mcp.example.org/mcp
+```
+
+注意:
+
+- **分離はプロセス境界による** — ユーザ A と B は子プロセスを共有しないので、
+  接続ごとのバックエンド状態（や JSON-RPC id 衝突）が相互に漏れない。
+- バックエンドコマンドは**テンプレート**です。セッションごとに同じコマンドを
+  新しい子として spawn します。identity はゲートウェイ側で強制（セッション→ユーザ
+  束縛）され、子プロセスには注入されません。ユーザ固有のコンテキストが必要な
+  バックエンドはリクエストから導出するか、バックエンド構成ごとに 1 ゲートウェイを
+  立てて（必要ならパスで多重化、上記*パススコープ issuer*）運用してください。
+
 ## ワークアラウンド
 
 Claude Code・mcp-remote・MCP SDK・Windows の既知の問題については [WORKAROUNDS.md](WORKAROUNDS.md) を参照してください。

--- a/README.md
+++ b/README.md
@@ -344,6 +344,67 @@ follows the options (an optional `--` separator is supported).
     the client's path-aware discovery. A bare-origin `--public-url` behaves
     exactly as before (#245).
 
+### Multi-user deployment
+
+`serve` is built for multiple concurrent users. Each MCP session gets its own
+spawned backend child and — with OAuth enabled — is bound to the authenticated
+user, so users are isolated by **process boundary** and a leaked session id
+cannot cross tenants.
+
+End-user login is delegated to a fronting reverse proxy that performs the real
+SSO and asserts the user via `--trusted-user-header` (trusted ONLY because the
+proxy strips any client-supplied copy). The embedded AS then mints per-user
+tokens, and the gateway binds each session to that user.
+
+```mermaid
+flowchart TD
+    UA["User A<br>mcp-stdio --oauth"]
+    UB["User B<br>mcp-stdio --oauth"]
+    RP["Reverse proxy<br>SSO login, sets X-Forwarded-User<br>strips any client-supplied copy"]
+    GW["mcp-stdio serve --enable-oauth<br>--trusted-user-header X-Forwarded-User"]
+    CA["stdio child<br>session of A"]
+    CB["stdio child<br>session of B"]
+    UA == "Streamable HTTP<br>OAuth 2.1 (PKCE)" ==> RP
+    UB == "Streamable HTTP<br>OAuth 2.1 (PKCE)" ==> RP
+    RP ==> GW
+    GW -- "spawn per session" --> CA
+    GW -- "spawn per session" --> CB
+```
+
+Gateway (bound to loopback, behind the proxy):
+
+```bash
+mcp-stdio serve --enable-oauth \
+  --public-url https://mcp.example.org \
+  --trusted-user-header X-Forwarded-User \
+  --max-sessions 200 --session-idle-ttl 900 \
+  --host 127.0.0.1 --port 8080 -- python -m my_mcp_server
+```
+
+- `--public-url` pins the issuer to the external HTTPS URL the proxy serves.
+- `--trusted-user-header` is the header the proxy sets after login; the gateway
+  trusts it only because the proxy strips any client-supplied copy.
+- `--max-sessions` caps concurrent per-user children; `--session-idle-ttl`
+  reclaims a child after a user disconnects without sending `DELETE`.
+
+Each user points their client at the gateway, runs the OAuth flow once, and is
+served by a dedicated child:
+
+```bash
+mcp-stdio --oauth https://mcp.example.org/mcp
+```
+
+Notes:
+
+- **Isolation is by process boundary** — user A and user B never share a child,
+  so per-connection backend state (or a JSON-RPC id collision) cannot leak
+  across them.
+- The backend command is a **template**: every session spawns the same command
+  as a fresh child. Identity is enforced at the gateway (session→user binding);
+  it is not injected into the child today, so a backend that needs per-user
+  context should derive it from the request, or run one gateway per backend
+  configuration (optionally multiplexed by path — see *Path-scoped issuer*).
+
 ## Workarounds
 
 See [WORKAROUNDS.md](WORKAROUNDS.md) for known issues in Claude Code, mcp-remote, the MCP SDKs, and Windows that mcp-stdio addresses.


### PR DESCRIPTION
## What

Adds a **Multi-user deployment** subsection to the `serve`-mode docs (README.md + README.ja.md), now that per-session backends (#258), resource governance (#261), and OAuth session→user binding (#263) make `serve` a full multi-user gateway.

Covers:
- The reverse-proxy + `--trusted-user-header` topology (proxy does SSO, asserts the user; gateway mints per-user tokens and binds each session), with a vertical mermaid diagram.
- A concrete per-tenant gateway config wiring `--enable-oauth` / `--public-url` / `--max-sessions` / `--session-idle-ttl`.
- The isolation model (process boundary per user) and the honest boundary that the backend command is a template — identity is enforced at the gateway, not injected into the child.

Docs-only; `docs:` is hidden in release-please so no version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)