### PR TITLE
test: guard cross-SDK OAuth/transport edge cases

### DIFF
--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -103,6 +103,10 @@ class TestResourceIndicator:
             ("https://api.example.com/mcp", "https://api.example.com/mcp"),
             # port + query kept; userinfo stripped
             ("https://u:p@host:8443/mcp?a=1", "https://host:8443/mcp?a=1"),
+            # bare host stays slash-free: URL-normalizing to "https://host/"
+            # is the cross-SDK failure class of typescript-sdk#1968 /
+            # python-sdk#2883 / claude-code#52871 (Entra AADSTS9010010)
+            ("https://host", "https://host"),
             # fragment dropped (RFC 8707 §2 MUST NOT)
             ("https://api.example.com/mcp#frag", "https://api.example.com/mcp"),
             # unparseable / non-http stays unchanged
@@ -4663,6 +4667,84 @@ class TestStateCsrfCheck:
         assert ("attacker-state", sent["state"]) in calls
 
 
+class TestScopeOmittedWhenUnset:
+    """No configured scope -> the authorize URL carries no ``scope`` param at
+    all (never an empty ``scope=``). Guards the failure class of
+    claude-code#72440 (AADSTS900144 on Microsoft Entra ID). The device-flow
+    twin lives in TestDeviceAuthorizationFlow."""
+
+    SERVER_URL = "https://example.com/mcp"
+
+    def test_authorize_url_has_no_scope_param(
+        self, tmp_path, monkeypatch, httpx_mock
+    ):
+        from urllib.parse import parse_qs, urlparse
+        from urllib.request import urlopen
+
+        store_file = tmp_path / "tokens.json"
+        monkeypatch.setattr("mcp_stdio.token_store._STORE_DIR", tmp_path)
+        monkeypatch.setattr("mcp_stdio.token_store._STORE_FILE", store_file)
+
+        httpx_mock.add_response(url="https://example.com/mcp", status_code=401)
+        httpx_mock.add_response(
+            url=(
+                "https://example.com/.well-known/"
+                "oauth-protected-resource/mcp"
+            ),
+            status_code=404,
+        )
+        httpx_mock.add_response(
+            url="https://example.com/.well-known/oauth-protected-resource",
+            status_code=404,
+        )
+        httpx_mock.add_response(
+            url="https://example.com/.well-known/oauth-authorization-server",
+            json={
+                "authorization_endpoint": "https://example.com/authorize",
+                "token_endpoint": "https://example.com/token",
+                "registration_endpoint": "https://example.com/register",
+            },
+        )
+        httpx_mock.add_response(
+            url="https://example.com/register",
+            json={"client_id": "cid"},
+        )
+        httpx_mock.add_response(
+            url="https://example.com/token",
+            json={"access_token": "at", "token_type": "Bearer"},
+        )
+
+        captured_auth_urls: list[str] = []
+
+        def fake_open(auth_url: str) -> bool:
+            captured_auth_urls.append(auth_url)
+            q = parse_qs(urlparse(auth_url).query)
+            redirect_uri = q["redirect_uri"][0]
+            state = q["state"][0]
+
+            def hit_callback() -> None:
+                cb_url = f"{redirect_uri}?code=ok_code&state={state}"
+                try:
+                    urlopen(cb_url, timeout=5).read()
+                except Exception:
+                    pass
+
+            threading.Thread(target=hit_callback, daemon=True).start()
+            return True
+
+        monkeypatch.setattr("mcp_stdio.oauth.webbrowser.open", fake_open)
+
+        client = httpx.Client()
+        data = ensure_token(self.SERVER_URL, client, timeout=5)
+        assert data is not None and data.access_token == "at"
+
+        assert len(captured_auth_urls) == 1
+        q = parse_qs(urlparse(captured_auth_urls[0]).query)
+        assert "scope" not in q
+        # Positive control: the URL is fully formed otherwise.
+        assert q["resource"] == [self.SERVER_URL]
+
+
 class TestAuthorizationFlowFailurePaths:
     """End-to-end failure paths of `_run_authorization_flow`: the callback
     timeout and the server-returned-error branch (both clean up the server)."""
@@ -6179,6 +6261,33 @@ class TestDeviceAuthorizationFlow:
         from urllib.parse import parse_qs
         body = parse_qs(da_req.content.decode())
         assert body.get("resource") == [MCP_URL]
+
+    def test_da_request_omits_scope_when_unset(
+        self, httpx_mock, tmp_path, monkeypatch
+    ):
+        """No scope configured -> no scope param at all (never an empty
+        ``scope=``). Guards the failure class of claude-code#72440, where a
+        v2.1.196 regression sent no scope on the unset path and Microsoft
+        Entra ID rejected the request with AADSTS900144."""
+        self._patch_store(tmp_path, monkeypatch)
+
+        httpx_mock.add_response(url=REG_URL, json={"client_id": "cid"})
+        httpx_mock.add_response(url=DEVICE_AUTH_URL, json=_da_response())
+        httpx_mock.add_response(
+            url=TOKEN_URL,
+            json={"access_token": "acc", "token_type": "Bearer"},
+        )
+
+        client = httpx.Client()
+        _run_device_authorization_flow(
+            MCP_URL, client, metadata=_device_meta(), cached=None
+        )
+
+        reqs = httpx_mock.get_requests()
+        da_req = next(r for r in reqs if str(r.url).startswith(DEVICE_AUTH_URL))
+        from urllib.parse import parse_qs
+        body = parse_qs(da_req.content.decode())
+        assert "scope" not in body
 
     def test_metadata_discovers_device_endpoint(self, httpx_mock):
         """device_authorization_endpoint is read from RFC 8414 metadata."""

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -4739,7 +4739,11 @@ class TestScopeOmittedWhenUnset:
         assert data is not None and data.access_token == "at"
 
         assert len(captured_auth_urls) == 1
-        q = parse_qs(urlparse(captured_auth_urls[0]).query)
+        # keep_blank_values: parse_qs would otherwise DROP an empty `scope=`,
+        # letting exactly the empty-param regression this test pins slip by.
+        q = parse_qs(
+            urlparse(captured_auth_urls[0]).query, keep_blank_values=True
+        )
         assert "scope" not in q
         # Positive control: the URL is fully formed otherwise.
         assert q["resource"] == [self.SERVER_URL]
@@ -6286,7 +6290,9 @@ class TestDeviceAuthorizationFlow:
         reqs = httpx_mock.get_requests()
         da_req = next(r for r in reqs if str(r.url).startswith(DEVICE_AUTH_URL))
         from urllib.parse import parse_qs
-        body = parse_qs(da_req.content.decode())
+        # keep_blank_values: parse_qs would otherwise DROP an empty `scope=`,
+        # letting exactly the empty-param regression this test pins slip by.
+        body = parse_qs(da_req.content.decode(), keep_blank_values=True)
         assert "scope" not in body
 
     def test_metadata_discovers_device_endpoint(self, httpx_mock):

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -2115,3 +2115,31 @@ def test_token_store_allowlist_drop_warning_names_client(tmp_path, capsys):
     err = capsys.readouterr().err
     assert "dropping persisted client registration" in err
     assert reg["client_id"] in err
+
+# --- cross-SDK guard tests (#273) ---
+
+
+def test_register_ignores_application_type(oauth_gateway):
+    # SEP-837 clients send RFC 7591 `application_type: "native"`; per RFC 7591
+    # Sec. 2 a server ignores client metadata it does not understand, so
+    # registration must still return 201. Guards against ever rejecting
+    # unknown metadata fields.
+    base, _ = oauth_gateway
+    r = httpx.post(
+        base + "/register",
+        json={"redirect_uris": [_REDIRECT], "application_type": "native"},
+        timeout=10,
+    )
+    assert r.status_code == 201, r.text
+    assert r.json()["client_id"]
+
+
+def test_token_response_is_identity_encoded(oauth_gateway):
+    # No Content-Encoding on /token responses: a compressed body breaks
+    # clients that JSON.parse the raw bytes (the typescript-sdk#2408 failure
+    # class). httpx headers are case-insensitive.
+    base, _ = oauth_gateway
+    _, _, _, _, tok = _full_flow(base)
+    assert tok.status_code == 200, tok.text
+    assert "content-encoding" not in tok.headers
+    assert tok.headers["content-type"] == "application/json"


### PR DESCRIPTION
## Summary

Closes #273 — pins four behaviors that the 2026-07 cross-SDK audit confirmed mcp-stdio already handles correctly but had no regression test protecting. Test-only; no production code change.

| Guard | Failure class it pins against |
|---|---|
| `_resource_indicator("https://host")` stays slash-free | typescript-sdk#1968 / python-sdk#2883 / claude-code#52871 (URL-normalized trailing slash → Entra `AADSTS9010010`) |
| No `scope` param sent when none configured (authorize URL **and** device-authorization request) | claude-code#72440 (v2.1.196 no-scope regression → Entra `AADSTS900144`) |
| serve DCR ignores unknown RFC 7591 metadata (`application_type: "native"`, SEP-837) → still 201 | clients start sending SEP-837 fields; RFC 7591 §2 says ignore-unknown |
| serve `/token` has no `Content-Encoding` | typescript-sdk#2408 (client `JSON.parse` on compressed bytes) |

The authorize-URL scope test drives a full `ensure_token` flow (discovery → DCR → browser-open spy → loopback callback with the correct state → token exchange) and asserts on the captured URL, with `resource` presence as the positive control.

## Test plan

- 5 new assertions (1 parametrize row + 4 tests) in `tests/test_oauth.py` / `tests/test_server.py`.
- Full suite: **1170 passed / 3 skipped**, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BFkfVbjuNRKYWAKcXE1K4K