### PR TITLE
docs: scaffold GitHub Pages user guide (MkDocs Material, en/ja)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,67 @@
+name: Docs
+
+# Build the MkDocs site on every docs PR (--strict, so broken links/config
+# fail the check) and deploy it to GitHub Pages on push to main. Pages is
+# configured with Source: "GitHub Actions", so deployment goes through the
+# official pages artifact flow — no gh-pages branch.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "docs/**"
+      - "mkdocs.yml"
+      - ".github/workflows/docs.yml"
+  pull_request:
+    paths:
+      - "docs/**"
+      - "mkdocs.yml"
+      - ".github/workflows/docs.yml"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Install MkDocs
+        # Material pins a compatible MkDocs; the upper bounds keep CI off
+        # future majors (MkDocs 2.0 is currently unlicensed — see the
+        # mkdocs-material 2026-02-18 advisory) until deliberately bumped.
+        run: pip install "mkdocs-material>=9.7,<10" "mkdocs-static-i18n>=1.3,<2"
+
+      - name: Build site (strict)
+        run: mkdocs build --strict
+
+      - name: Upload Pages artifact
+        if: github.event_name == 'push'
+        uses: actions/upload-pages-artifact@v4
+        with:
+          path: site
+
+  deploy:
+    if: github.event_name == 'push'
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ dist/
 .coverage.*
 htmlcov/
 coverage.xml
+
+# MkDocs build output
+site/

--- a/README.ja.md
+++ b/README.ja.md
@@ -2,6 +2,8 @@
 
 [English](README.md) | 日本語
 
+📖 **はじめての方は[ユーザーガイド](https://shigechika.github.io/mcp-stdio/ja/)へ**——「つなぐ」「公開する」のやりたいこと別ドキュメントです。この README は網羅的なリファレンスです。
+
 Stdio-to-HTTP ゲートウェイ — MCP クライアントとリモート HTTP MCP サーバーを接続します。
 
 ## 概要

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ English | [日本語](README.ja.md)
 
 Stdio-to-HTTP gateway — connects MCP clients to remote HTTP MCP servers.
 
+📖 **New here? Start with the [user guide](https://shigechika.github.io/mcp-stdio/)** — task-oriented docs for connecting a client or publishing a server. This README is the full reference.
+
 ## Overview
 
 [MCP](https://modelcontextprotocol.io/) clients like Claude Desktop and Claude Code see mcp-stdio as a locally running self-hosted MCP server, while it relays all requests to a remote MCP server with support for various authentication methods:

--- a/docs/guides/connect-remote.ja.md
+++ b/docs/guides/connect-remote.ja.md
@@ -1,0 +1,86 @@
+# リモート MCP サーバーに接続する
+
+ゴール：リモートの HTTP MCP サーバーを、あたかもローカルサーバーの
+ように Claude Desktop / Claude Code に登場させる——ログインは処理済み、
+トークンは自動更新、トランスポートの癖は吸収済みの状態で。
+
+## 1. まず接続確認
+
+クライアント設定を触る前に、mcp-stdio がサーバーに届くことを確認します：
+
+```bash
+mcp-stdio --check --oauth https://mcp.example.com/mcp
+```
+
+`--check` は経路全体を一度だけ実行します——ディスカバリ、ブラウザでの
+OAuth ログイン、トークン交換、MCP `initialize` の往復——そして結果を表示
+します。これが成功すれば、以下のクライアント設定も動きます。
+
+サーバーに OAuth がない場合は `--oauth` を外します。静的トークンなら
+`MCP_BEARER_TOKEN` を使います（下の「バリエーション」表を参照）。
+
+## 2. クライアントに追加
+
+=== "Claude Desktop"
+
+    `claude_desktop_config.json`：
+
+    ```json
+    {
+      "mcpServers": {
+        "my-remote-server": {
+          "command": "mcp-stdio",
+          "args": ["--oauth", "https://mcp.example.com/mcp"]
+        }
+      }
+    }
+    ```
+
+=== "Claude Code"
+
+    ```bash
+    claude mcp add my-remote-server -- mcp-stdio --oauth https://mcp.example.com/mcp
+    ```
+
+クライアントを再起動します。最初のリクエストでブラウザが開いてサーバーの
+ログインページが表示されます。以後トークンは
+`~/.config/mcp-stdio/tokens.json`（パーミッション `0600`）に保存され、
+すべてのターミナル・セッションで共有されます——refresh トークン自体が
+失効・破棄されるまで再ログインは不要です。
+
+## 何もしなくても付いてくるもの
+
+- **自動トークンリフレッシュ** — `401` で即時に、加えて失効直前に
+  バックグラウンドで先回りして更新。長いセッションがアクセストークンの
+  TTL で死にません。
+- **セッション回復** — 失効した MCP セッション（`404`）は透過的に
+  再初期化されます。
+- **クライアントのバグの遮蔽** — キャンセル競合、ページネーション、
+  `Retry-After` など、実装間のギャップは中間で吸収されます。カタログは
+  [WORKAROUNDS](https://github.com/shigechika/mcp-stdio/blob/main/WORKAROUNDS.md)
+  へ。
+
+## バリエーション
+
+| こうしたい | こうする |
+|---|---|
+| OAuth なし、静的 Bearer トークン | `MCP_BEARER_TOKEN=… mcp-stdio https://…/mcp` |
+| スコープを追加したい | `--oauth-scope "openid offline_access mcp:tools"` |
+| このマシンにブラウザがない（SSH 先、コンテナ） | `--oauth-device` — 手元のスマホ / PC でユーザーコードを入力してログイン |
+| サーバーが OIDC の `id_token` を要求する（Google IAP、AWS） | `--oauth-use-id-token` |
+| legacy SSE サーバー（2024-11-05 トランスポート） | `--transport sse` |
+| 社内プロキシ | 標準の `HTTPS_PROXY` / `NO_PROXY` 環境変数がそのまま効きます |
+
+全フラグは `mcp-stdio --help` か
+[README](https://github.com/shigechika/mcp-stdio#readme) へ。
+
+## トラブルシュートの早見
+
+- **ブラウザが開かない** — authorize URL は stderr に出力されています。
+  手動で開いてください（クライアントの MCP ログに出ます）。
+- **Microsoft Entra ID でログインがループする / `AADSTS…` エラー** —
+  `--oauth-scope` を明示してください。エラーコード別の詳細は WORKAROUNDS
+  の該当項目へ。
+- **昨日まで動いていたのに今日は `401`** — サーバー側で鍵のローテートや
+  グラントの失効があったかもしれません。`~/.config/mcp-stdio/tokens.json`
+  から該当サーバーのエントリを消して、再認可させてください。

--- a/docs/guides/connect-remote.md
+++ b/docs/guides/connect-remote.md
@@ -1,0 +1,85 @@
+# Connect to a remote MCP server
+
+Goal: a remote HTTP MCP server appears in Claude Desktop or Claude Code as
+if it were a local one — login handled, tokens refreshed, transport quirks
+absorbed.
+
+## 1. Check the connection first
+
+Before touching any client config, verify mcp-stdio can reach the server:
+
+```bash
+mcp-stdio --check --oauth https://mcp.example.com/mcp
+```
+
+`--check` runs the whole path once — discovery, OAuth login in your
+browser, token exchange, an MCP `initialize` round-trip — and prints what
+happened. If this succeeds, the client config below will work.
+
+No OAuth on the server? Drop `--oauth`. Static token instead? Use
+`MCP_BEARER_TOKEN` (see [Variations](#variations)).
+
+## 2. Add it to your client
+
+=== "Claude Desktop"
+
+    `claude_desktop_config.json`:
+
+    ```json
+    {
+      "mcpServers": {
+        "my-remote-server": {
+          "command": "mcp-stdio",
+          "args": ["--oauth", "https://mcp.example.com/mcp"]
+        }
+      }
+    }
+    ```
+
+=== "Claude Code"
+
+    ```bash
+    claude mcp add my-remote-server -- mcp-stdio --oauth https://mcp.example.com/mcp
+    ```
+
+Restart the client. On the first request a browser window opens for the
+server's login page; after that, tokens live in
+`~/.config/mcp-stdio/tokens.json` (file mode `0600`) and are shared by every
+terminal and session — you will not log in again until the refresh token
+itself expires or is revoked.
+
+## What you get without asking
+
+- **Automatic token refresh** — reactively on `401`, and proactively in the
+  background shortly before expiry, so long sessions do not die at the
+  access token's TTL.
+- **Session recovery** — an expired MCP session (`404`) is re-initialized
+  transparently.
+- **Client-bug shielding** — cancellation races, pagination, `Retry-After`,
+  and other cross-implementation gaps are absorbed in the middle; see
+  [WORKAROUNDS](https://github.com/shigechika/mcp-stdio/blob/main/WORKAROUNDS.md)
+  for the catalogue.
+
+## Variations
+
+| You need… | Do this |
+|---|---|
+| Static bearer token, no OAuth | `MCP_BEARER_TOKEN=… mcp-stdio https://…/mcp` |
+| Extra scopes | `--oauth-scope "openid offline_access mcp:tools"` |
+| No browser on this machine (SSH box, container) | `--oauth-device` — login happens on your phone/laptop via a user code |
+| The server insists on the OIDC `id_token` (Google IAP, AWS) | `--oauth-use-id-token` |
+| Legacy SSE server (2024-11-05 transport) | `--transport sse` |
+| Corporate proxy | honored via standard `HTTPS_PROXY` / `NO_PROXY` env vars |
+
+Every flag: `mcp-stdio --help`, or the
+[README](https://github.com/shigechika/mcp-stdio#readme).
+
+## Troubleshooting quickies
+
+- **Browser never opens** — the authorize URL is printed to stderr; open it
+  manually (the client's MCP log shows it).
+- **Login loops or `AADSTS…` errors on Microsoft Entra ID** — set an explicit
+  `--oauth-scope`; see the WORKAROUNDS entries for the exact error code.
+- **Worked yesterday, `401` today** — the server may have rotated its keys or
+  revoked the grant. Delete the server's entry from
+  `~/.config/mcp-stdio/tokens.json` and let it re-authorize.

--- a/docs/guides/serve.ja.md
+++ b/docs/guides/serve.ja.md
@@ -1,0 +1,83 @@
+# stdio サーバーを公開する
+
+ゴール：ホスト上の stdio MCP サーバーを HTTPS の Streamable HTTP
+エンドポイントにして、リモートの MCP クライアント——Claude Desktop、
+Claude Code、さらに Claude.ai のカスタムコネクタ——から使えるようにする。
+各ユーザーは専用の子プロセスに隔離され、本物の OAuth 2.1 ログインで
+守られます。
+
+## 1. ループバックで動作確認
+
+```bash
+mcp-stdio serve --enable-oauth --public-url http://127.0.0.1:8080 \
+  --dev-user alice --port 8080 -- python -m my_mcp_server
+```
+
+別のターミナルから、mcp-stdio 自身のクライアントモードで接続します：
+
+```bash
+mcp-stdio --check --oauth http://127.0.0.1:8080/mcp
+```
+
+`--dev-user` はループバック検証専用の**非セキュアな**代用アイデンティティ
+です——本物のログインなしで OAuth フロー全体を通せます。`--check` が
+`initialize` 成功を報告すればゲートウェイは動いています。ここから先は
+デプロイの話だけです。
+
+## 2. リバースプロキシの背後にデプロイ
+
+本番ではアイデンティティは SSO から来ます。TLS 終端と認証はリバース
+プロキシ（nginx、Apache など）に任せ、ログイン済みユーザーを信頼できる
+ヘッダーで mcp-stdio に渡します：
+
+```bash
+mcp-stdio serve --enable-oauth \
+  --public-url https://mcp.example.com \
+  --trusted-user-header X-Forwarded-User \
+  --token-store /var/lib/mcp-stdio/state.json \
+  --session-idle-ttl 180 \
+  -- python -m my_mcp_server
+```
+
+- `--public-url` は OAuth issuer を公開アドレスに固定します（プロキシ
+  背後では必須）。
+- `--trusted-user-header` はプロキシが設定し、**かつクライアント由来の
+  同名ヘッダーを剥がす**ヘッダー名です——その剥がしこそが信頼の根拠です。
+- `--token-store` は発行済みトークン・クライアント登録・replay 検知の
+  台帳を永続化（`0600`）し、**再起動やデプロイで全ユーザーがログアウト
+  されるのを防ぎます**。これがないとデプロイのたびに全トークンが無効に。
+  パスは serve プロセスごとに 1 つ——sidecar の `.lock` が誤共有を起動時に
+  拒否します。
+- `--session-idle-ttl` は、切断処理なしに消えたクライアントの子プロセスを
+  回収します。
+
+接続ユーザーごとに得られるもの：専用の子プロセス（`initialize` で
+spawn、切断か idle タイムアウトで破棄）、認証済みアイデンティティに
+束縛されたセッション——他人のセッション id を提示しても `404` で、
+越境はできません。
+
+## 3. オプションの追加機能
+
+| こうしたい | こうする |
+|---|---|
+| Claude.ai カスタムコネクタ（ブラウザベースのクライアント） | `--allow-redirect-uri https://claude.ai/api/mcp/auth_callback` |
+| 1 ホストに複数バックエンド | バックエンドごとに serve プロセスを分け、パススコープ issuer を使う：`--public-url https://mcp.example.com/team-a`、`…/team-b`——AS エンドポイントと well-known もプレフィックス配下に収まります |
+| 同時ユーザー数の上限 | `--max-sessions N`（既定 100。超過した `initialize` は `503`） |
+| OAuth の代わりに静的トークン | `--enable-oauth` を外して `MCP_STDIO_SERVE_TOKEN` を設定 |
+| アクセストークンの寿命を調整 | `--access-token-ttl SECONDS`（既定 3600） |
+
+## 運用者向けメモ
+
+- 内蔵の認可サーバーは Dynamic Client Registration、PKCE（S256 のみ）、
+  replay 検知付き refresh ローテーション、RFC 8707 の audience 束縛を
+  実装しています。MCP クライアントは標準の well-known ドキュメント経由で
+  すべてを自動発見するので、クライアント側の設定は不要です。
+- `--token-store` のファイルは秘密鍵と同様に扱ってください。`0700` の
+  ディレクトリに `0600` で作成されます。
+- 全リクエストはクエリ文字列を redact した形で stderr にログされます。
+
+実運用の参照例：この構成そのままで、1 ホスト配下に複数の stdio MCP
+サーバーを公開し、定常的な再デプロイをユーザーに気づかれずに乗り切って
+います。子プロセスの*内側*でユーザーごとの資格情報が必要なら、それは
+あなたのサーバーの設計判断です——ゲートウェイは意図的にアイデンティティを
+子へ注入しません。

--- a/docs/guides/serve.md
+++ b/docs/guides/serve.md
@@ -1,0 +1,81 @@
+# Publish your stdio server
+
+Goal: a stdio MCP server on your host becomes an HTTPS Streamable HTTP
+endpoint that remote MCP clients — Claude Desktop, Claude Code, even
+Claude.ai custom connectors — can use, each user isolated in their own
+child process behind a real OAuth 2.1 login.
+
+## 1. Smoke test on loopback
+
+```bash
+mcp-stdio serve --enable-oauth --public-url http://127.0.0.1:8080 \
+  --dev-user alice --port 8080 -- python -m my_mcp_server
+```
+
+and from a second terminal, connect to it with mcp-stdio's own client mode:
+
+```bash
+mcp-stdio --check --oauth http://127.0.0.1:8080/mcp
+```
+
+`--dev-user` is an **insecure** stand-in identity for loopback testing
+only — it lets you exercise the whole OAuth flow without a real login. If
+`--check` reports a successful `initialize`, the gateway works; everything
+after this is deployment.
+
+## 2. Deploy behind your reverse proxy
+
+In production the identity comes from your SSO. Terminate TLS and
+authentication at a reverse proxy (nginx, Apache, …) and pass the logged-in
+user to mcp-stdio in a trusted header:
+
+```bash
+mcp-stdio serve --enable-oauth \
+  --public-url https://mcp.example.com \
+  --trusted-user-header X-Forwarded-User \
+  --token-store /var/lib/mcp-stdio/state.json \
+  --session-idle-ttl 180 \
+  -- python -m my_mcp_server
+```
+
+- `--public-url` pins the OAuth issuer to your public address (required
+  behind a proxy).
+- `--trusted-user-header` names the header your proxy sets **and strips
+  from client requests** — that stripping is what makes it trustworthy.
+- `--token-store` persists issued tokens, registrations, and replay
+  tombstones (`0600`) so **a restart or redeploy does not log everyone
+  out**. Without it, every deploy invalidates all tokens. One path per
+  serve process — a sidecar `.lock` refuses accidental sharing.
+- `--session-idle-ttl` reaps children whose client vanished without a
+  clean disconnect.
+
+What you get per connecting user: their own child process (spawned at
+`initialize`, destroyed on disconnect or idle timeout), their session bound
+to their authenticated identity — another user's session id is a `404`, not
+a crossover.
+
+## 3. Optional add-ons
+
+| You need… | Do this |
+|---|---|
+| Claude.ai custom connectors (browser-based clients) | `--allow-redirect-uri https://claude.ai/api/mcp/auth_callback` |
+| Several backends on one host | run one serve process per backend with path-scoped issuers: `--public-url https://mcp.example.com/team-a`, `…/team-b` — AS endpoints and well-known documents nest under each prefix |
+| Cap concurrent users | `--max-sessions N` (default 100; excess `initialize` gets `503`) |
+| Static token instead of OAuth | drop `--enable-oauth`, set `MCP_STDIO_SERVE_TOKEN` |
+| Longer / shorter access tokens | `--access-token-ttl SECONDS` (default 3600) |
+
+## Notes for operators
+
+- The embedded authorization server implements Dynamic Client Registration,
+  PKCE (S256 only), refresh rotation with replay detection, and RFC 8707
+  audience binding — MCP clients discover all of it via the standard
+  well-known documents; there is nothing to configure client-side.
+- Treat `--token-store`'s file like a private key. It is created `0600` in
+  a `0700` directory.
+- Every request is logged to stderr with query strings redacted.
+
+Real-world reference: this is the exact setup used to publish several
+stdio MCP servers under one host, surviving routine redeploys without
+users noticing. If your backend needs per-user credentials *inside* the
+child process, that is a design decision of your server — the gateway
+intentionally does not forward identity into the child.

--- a/docs/index.ja.md
+++ b/docs/index.ja.md
@@ -1,0 +1,63 @@
+# mcp-stdio
+
+MCP（Model Context Protocol）サーバーのための、最小構成の stdio ⇄ HTTP
+ゲートウェイ。小さな Python パッケージひとつ、ランタイム依存は `httpx`
+だけ。役割はふたつ：
+
+- stdio しか話せない MCP クライアント（Claude Desktop、Claude Code など）を
+  **リモートの HTTP MCP サーバーに接続**する——OAuth 2.1 ログイン、トークン
+  保存、リフレッシュ込みで。
+- ローカルの stdio MCP サーバーを、OAuth 2.1 認可サーバー内蔵の
+  **Streamable HTTP エンドポイントとして公開**する——マルチユーザー、
+  セッション分離で。
+
+どちらが必要か迷ったら、まず
+[ふたつの使い方](modes.md) へ。
+
+## インストール
+
+```bash
+# Homebrew
+brew install shigechika/tap/mcp-stdio
+
+# または PyPI
+pip install mcp-stdio
+
+# インストールせずに実行
+uvx mcp-stdio --help
+```
+
+## 30 秒クイックスタート
+
+OAuth ログインが必要なリモート MCP サーバーを Claude Desktop につなぐ——
+`claude_desktop_config.json` に次を追加するだけです：
+
+```json
+{
+  "mcpServers": {
+    "my-remote-server": {
+      "command": "mcp-stdio",
+      "args": ["--oauth", "https://mcp.example.com/mcp"]
+    }
+  }
+}
+```
+
+初回利用時にブラウザが開いてログインを求められます。トークンは
+`~/.config/mcp-stdio/tokens.json` にキャッシュされ、以後は自動で
+リフレッシュされます。
+
+これが「クライアント」側です。逆方向——自作の stdio MCP サーバーを
+HTTPS で公開する——は
+[stdio サーバーを公開する](guides/serve.md) を参照してください。
+
+## なぜ存在するのか
+
+MCP のクライアントとサーバーはトランスポートの解釈が食い違い、OAuth の
+実装も現実のデプロイを壊す形で手を抜きがちです。mcp-stdio はその中間に
+立って差異を吸収します：MCP 仕様と OAuth 関連 RFC に忠実に従い、
+[主要クライアントの既知の問題](https://github.com/shigechika/mcp-stdio/blob/main/WORKAROUNDS.md)
+を回避し、監査できる小ささを保っています。
+
+機能一覧と標準準拠の詳細は
+[README](https://github.com/shigechika/mcp-stdio#readme) へ。

--- a/docs/index.ja.md
+++ b/docs/index.ja.md
@@ -53,10 +53,11 @@ HTTPS で公開する——は
 
 ## なぜ存在するのか
 
-MCP のクライアントとサーバーはトランスポートの解釈が食い違い、OAuth の
-実装も現実のデプロイを壊す形で手を抜きがちです。mcp-stdio はその中間に
-立って差異を吸収します：MCP 仕様と OAuth 関連 RFC に忠実に従い、
-[主要クライアントの既知の問題](https://github.com/shigechika/mcp-stdio/blob/main/WORKAROUNDS.md)
+MCP のクライアントとサーバーはトランスポートの解釈が常に一致するとは
+限らず、OAuth の細部も実装ごとに異なり、その差は実際のデプロイで表面化
+します。mcp-stdio はその中間に立って差異を吸収します：MCP 仕様と OAuth
+関連 RFC に忠実に従い、
+[既知の相互運用ギャップ](https://github.com/shigechika/mcp-stdio/blob/main/WORKAROUNDS.md)
 を回避し、監査できる小ささを保っています。
 
 機能一覧と標準準拠の詳細は

--- a/docs/index.md
+++ b/docs/index.md
@@ -50,11 +50,11 @@ stdio MCP server over HTTPS — see
 
 ## Why this exists
 
-MCP clients and servers disagree about transports and cut corners around
-OAuth in ways that break real deployments. mcp-stdio sits in the middle and
-absorbs those differences: it follows the MCP spec and the OAuth RFCs
-closely, works around
-[known issues in popular clients](https://github.com/shigechika/mcp-stdio/blob/main/WORKAROUNDS.md),
+MCP clients and servers do not always agree on transports, and OAuth
+details vary between implementations in ways that surface in real
+deployments. mcp-stdio sits in the middle and absorbs those differences: it
+follows the MCP spec and the OAuth RFCs closely, works around
+[known interoperability gaps](https://github.com/shigechika/mcp-stdio/blob/main/WORKAROUNDS.md),
 and stays small enough to audit.
 
 For the full feature list and standards conformance, see the

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,61 @@
+# mcp-stdio
+
+A minimal stdio-to-HTTP gateway for MCP (Model Context Protocol) servers.
+One small Python package, one runtime dependency (`httpx`), two jobs:
+
+- **Connect** an MCP client that only speaks stdio (Claude Desktop, Claude
+  Code, …) to a **remote HTTP MCP server** — including the OAuth 2.1 login,
+  token storage, and refresh.
+- **Publish** a local stdio MCP server as a **Streamable HTTP endpoint** with
+  a built-in OAuth 2.1 authorization server — multi-user, session-isolated.
+
+Not sure which one you need? Start with
+[Two ways to use it](modes.md).
+
+## Install
+
+```bash
+# Homebrew
+brew install shigechika/tap/mcp-stdio
+
+# or PyPI
+pip install mcp-stdio
+
+# or run without installing
+uvx mcp-stdio --help
+```
+
+## 30-second quickstart
+
+Connect Claude Desktop to a remote MCP server that requires OAuth login —
+add this to `claude_desktop_config.json`:
+
+```json
+{
+  "mcpServers": {
+    "my-remote-server": {
+      "command": "mcp-stdio",
+      "args": ["--oauth", "https://mcp.example.com/mcp"]
+    }
+  }
+}
+```
+
+On first use a browser window opens for login; tokens are cached in
+`~/.config/mcp-stdio/tokens.json` and refreshed automatically from then on.
+
+That is the *client* side. To go the other direction — publish your own
+stdio MCP server over HTTPS — see
+[Publish your stdio server](guides/serve.md).
+
+## Why this exists
+
+MCP clients and servers disagree about transports and cut corners around
+OAuth in ways that break real deployments. mcp-stdio sits in the middle and
+absorbs those differences: it follows the MCP spec and the OAuth RFCs
+closely, works around
+[known issues in popular clients](https://github.com/shigechika/mcp-stdio/blob/main/WORKAROUNDS.md),
+and stays small enough to audit.
+
+For the full feature list and standards conformance, see the
+[README](https://github.com/shigechika/mcp-stdio#readme).

--- a/docs/modes.ja.md
+++ b/docs/modes.ja.md
@@ -1,0 +1,105 @@
+# ふたつの使い方
+
+mcp-stdio はひとつのコマンドにふたつの明確に異なる役割があります。この
+ドキュメントの残り全部がこの選択にぶら下がっているので、まずここで
+整理してください。
+
+|  | **クライアント側ゲートウェイ**（デフォルト） | **サーバーゲートウェイ**（`serve`） |
+|---|---|---|
+| あなたは… | 誰かのリモート MCP サーバーを*使う*側 | 自分の MCP サーバーを*公開する*側 |
+| MCP サーバーの居場所 | どこか別の場所、HTTPS の向こう | あなたのマシン上、stdio で動作 |
+| mcp-stdio の居場所 | MCP クライアントの隣（手元のマシン） | MCP サーバーの隣（公開ホスト） |
+| 変換の向き | stdio → Streamable HTTP / SSE | Streamable HTTP → stdio |
+| OAuth での役割 | **クライアント**：ログインし、トークンを保存・リフレッシュ | **認可サーバー**：クライアントを登録し、トークンを発行・検証 |
+| 典型的な利用者 | Claude Desktop / Claude Code でリモートサーバーを使う人 | stdio MCP サーバーをリモートユーザーに届けたい運用者 |
+| 次に読む | [リモート MCP サーバーに接続する](guides/connect-remote.md) | [stdio サーバーを公開する](guides/serve.md) |
+
+## クライアント側ゲートウェイとして（デフォルトモード）
+
+MCP クライアント（Claude Desktop、Claude Code など）はローカルの stdio
+プロセスしか起動できませんが、使いたいサーバーはネットワークの向こうに
+あります。mcp-stdio がそのローカルプロセス*そのもの*になります：
+クライアントは mcp-stdio と stdio で会話し、mcp-stdio がすべての
+メッセージを HTTPS でリモートサーバーへ中継します——OAuth ログイン、
+トークンキャッシュ、リフレッシュを引き受けるので、接続はアクセス
+トークンの寿命より長生きします。
+
+```mermaid
+graph TD
+    A["MCP クライアント<br/>(Claude Desktop / Claude Code)"]
+    B["mcp-stdio<br/>OAuth クライアント · トークンキャッシュ · トランスポート変換"]
+    C["リモート MCP サーバー<br/>(Streamable HTTP または legacy SSE)"]
+    A -- "stdio (JSON-RPC 行)" --> B
+    B -- "HTTPS (+ Bearer トークン)" --> C
+    C --> B
+    B --> A
+```
+
+```bash
+mcp-stdio --oauth https://mcp.example.com/mcp
+```
+
+このモードが欲しくなるのは：
+
+- ベンダーやチームがホストする MCP サーバーを Claude Desktop / Claude
+  Code から使いたいとき；
+- クライアント自身がうまく扱えない OAuth ログインをサーバーが要求する
+  とき；
+- クライアントが対応をやめた legacy SSE トランスポートをサーバーが
+  まだ話しているとき。
+
+→ **[リモート MCP サーバーに接続する](guides/connect-remote.md)** へ。
+
+## サーバーゲートウェイとして（`serve` モード）
+
+手元のマシンで stdio を話す MCP サーバーを書いた（または動かしている）。
+それをリモートユーザーが*彼らの* MCP クライアントから使えるようにしたい。
+`mcp-stdio serve` はそれを本物の Streamable HTTP エンドポイントにします：
+片側で HTTPS を受け、もう片側では**ユーザーセッションごとに**隔離された
+stdio 子プロセスを spawn し、`--enable-oauth` を付ければクライアント登録と
+トークン発行を担う OAuth 2.1 認可サーバーとしてすべてを守ります。
+
+```mermaid
+graph TD
+    A1["リモートユーザー A<br/>(Claude Desktop)"]
+    A2["リモートユーザー B<br/>(Claude.ai コネクタ)"]
+    B["mcp-stdio serve<br/>OAuth 認可サーバー · セッション管理"]
+    C1["A 用の stdio 子プロセス<br/>(あなたの MCP サーバー)"]
+    C2["B 用の stdio 子プロセス<br/>(あなたの MCP サーバー)"]
+    A1 -- "HTTPS + OAuth" --> B
+    A2 -- "HTTPS + OAuth" --> B
+    B -- "stdio" --> C1
+    B -- "stdio" --> C2
+```
+
+```bash
+mcp-stdio serve --enable-oauth \
+  --public-url https://mcp.example.com \
+  --token-store /var/lib/mcp-stdio/state.json \
+  -- python -m my_mcp_server
+```
+
+このモードが欲しくなるのは：
+
+- MCP サーバーが stdio 専用で、リモートクライアントから届かせたいとき；
+- 複数ユーザーがひとつのデプロイを**プロセスを共有せずに**使う必要が
+  あるとき——各セッションが専用の子プロセスを持ち、認証済みユーザーに
+  束縛されます；
+- 前段に本物の OAuth が必要だが、エンドポイントひとつのために Keycloak
+  を立てたくはないとき。
+
+→ **[stdio サーバーを公開する](guides/serve.md)** へ。
+
+## 両方いっぺんに
+
+ふたつの役割は組み合わせられます。よくあるパターン：運用者が社内サーバー
+を `serve` で公開し、チームの全員が手元のラップトップからクライアント
+モードの mcp-stdio で接続する——両端で同じパッケージが、それぞれ OAuth の
+自分の側を担当します。
+
+```mermaid
+graph TD
+    A["Claude Desktop"] -- "stdio" --> B["mcp-stdio<br/>（クライアントモード）"]
+    B -- "HTTPS + OAuth" --> C["mcp-stdio serve<br/>（サーバーモード）"]
+    C -- "stdio" --> D["あなたの MCP サーバー"]
+```

--- a/docs/modes.ja.md
+++ b/docs/modes.ja.md
@@ -43,7 +43,7 @@ mcp-stdio --oauth https://mcp.example.com/mcp
 
 - ベンダーやチームがホストする MCP サーバーを Claude Desktop / Claude
   Code から使いたいとき；
-- クライアント自身がうまく扱えない OAuth ログインをサーバーが要求する
+- クライアント単体では完結できない OAuth ログインをサーバーが要求する
   とき；
 - クライアントが対応をやめた legacy SSE トランスポートをサーバーが
   まだ話しているとき。

--- a/docs/modes.md
+++ b/docs/modes.md
@@ -1,0 +1,99 @@
+# Two ways to use it
+
+mcp-stdio is one command with two distinct roles. Everything else in these
+docs hangs off this choice, so take a moment here.
+
+|  | **As a client-side gateway** (default) | **As a server gateway** (`serve`) |
+|---|---|---|
+| You are… | *using* someone's remote MCP server | *publishing* your own MCP server |
+| Your MCP server runs… | somewhere else, behind HTTPS | on your machine, speaking stdio |
+| mcp-stdio runs… | next to your MCP client (laptop) | next to your MCP server (host) |
+| It translates… | stdio → Streamable HTTP / SSE | Streamable HTTP → stdio |
+| OAuth role | **client**: logs in, stores and refreshes your tokens | **authorization server**: registers clients, issues and validates tokens |
+| Typical user | anyone using Claude Desktop / Claude Code with a remote server | the operator of a stdio MCP server that remote users should reach |
+| Start here | [Connect to a remote MCP server](guides/connect-remote.md) | [Publish your stdio server](guides/serve.md) |
+
+## As a client-side gateway (default mode)
+
+Your MCP client (Claude Desktop, Claude Code, …) only launches local stdio
+processes, but the server you want lives on the network. mcp-stdio *is* that
+local process: your client talks stdio to it, and it relays every message to
+the remote server over HTTPS — handling the OAuth login, token cache, and
+refresh so the connection survives longer than an access token does.
+
+```mermaid
+graph TD
+    A["MCP client<br/>(Claude Desktop / Claude Code)"]
+    B["mcp-stdio<br/>OAuth client · token cache · transport translation"]
+    C["Remote MCP server<br/>(Streamable HTTP or legacy SSE)"]
+    A -- "stdio (JSON-RPC lines)" --> B
+    B -- "HTTPS (+ Bearer token)" --> C
+    C --> B
+    B --> A
+```
+
+```bash
+mcp-stdio --oauth https://mcp.example.com/mcp
+```
+
+You want this mode when:
+
+- a vendor / your team hosts an MCP server and you want it in Claude
+  Desktop or Claude Code;
+- the server needs an OAuth login the client itself fumbles;
+- the server still speaks the legacy SSE transport your client dropped.
+
+→ Continue with **[Connect to a remote MCP server](guides/connect-remote.md)**.
+
+## As a server gateway (`serve` mode)
+
+You wrote (or run) an MCP server that speaks stdio on your machine, and
+remote users should reach it from *their* MCP clients. `mcp-stdio serve`
+turns it into a proper Streamable HTTP endpoint: it accepts HTTPS on one
+side, spawns an isolated stdio child process **per user session** on the
+other, and — with `--enable-oauth` — acts as the OAuth 2.1 authorization
+server that registers clients and issues the tokens guarding it all.
+
+```mermaid
+graph TD
+    A1["Remote user A<br/>(Claude Desktop)"]
+    A2["Remote user B<br/>(Claude.ai connector)"]
+    B["mcp-stdio serve<br/>OAuth authorization server · sessions"]
+    C1["stdio child for A<br/>(your MCP server)"]
+    C2["stdio child for B<br/>(your MCP server)"]
+    A1 -- "HTTPS + OAuth" --> B
+    A2 -- "HTTPS + OAuth" --> B
+    B -- "stdio" --> C1
+    B -- "stdio" --> C2
+```
+
+```bash
+mcp-stdio serve --enable-oauth \
+  --public-url https://mcp.example.com \
+  --token-store /var/lib/mcp-stdio/state.json \
+  -- python -m my_mcp_server
+```
+
+You want this mode when:
+
+- your MCP server is stdio-only and remote clients need to reach it;
+- several users must share one deployment **without** sharing a process —
+  each session gets its own child, bound to its authenticated user;
+- you need real OAuth in front of it but do not want to run Keycloak for a
+  single endpoint.
+
+→ Continue with **[Publish your stdio server](guides/serve.md)**.
+
+## Both at once
+
+The two roles compose. A common pattern: an operator publishes an internal
+server with `serve` on one host, and every team member connects to it with
+plain client-mode mcp-stdio from their laptop — the same package on both
+ends, each side doing its half of the OAuth dance.
+
+```mermaid
+graph TD
+    A["Claude Desktop"] -- "stdio" --> B["mcp-stdio<br/>(client mode)"]
+    B -- "HTTPS + OAuth" --> C["mcp-stdio serve<br/>(server mode)"]
+    C -- "stdio" --> D["your MCP server"]
+```

--- a/docs/modes.md
+++ b/docs/modes.md
@@ -40,7 +40,7 @@ You want this mode when:
 
 - a vendor / your team hosts an MCP server and you want it in Claude
   Desktop or Claude Code;
-- the server needs an OAuth login the client itself fumbles;
+- the server needs an OAuth login your client cannot complete on its own;
 - the server still speaks the legacy SSE transport your client dropped.
 
 → Continue with **[Connect to a remote MCP server](guides/connect-remote.md)**.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,64 @@
+site_name: mcp-stdio
+site_description: >-
+  A minimal stdio-to-HTTP gateway for MCP servers — connect MCP clients to
+  remote servers, or publish your stdio server over Streamable HTTP + OAuth.
+site_url: https://shigechika.github.io/mcp-stdio/
+repo_url: https://github.com/shigechika/mcp-stdio
+repo_name: shigechika/mcp-stdio
+edit_uri: edit/main/docs/
+
+theme:
+  name: material
+  palette:
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      primary: indigo
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      primary: indigo
+      toggle:
+        icon: material/brightness-4
+        name: Switch to light mode
+  features:
+    - navigation.sections
+    - navigation.footer
+    - content.code.copy
+    - content.action.edit
+
+markdown_extensions:
+  - admonition
+  - tables
+  - toc:
+      permalink: true
+  - pymdownx.superfences:
+      custom_fences:
+        - name: mermaid
+          class: mermaid
+          format: !!python/name:pymdownx.superfences.fence_code_format
+  - pymdownx.highlight
+  - pymdownx.inlinehilite
+  - pymdownx.tabbed:
+      alternate_style: true
+
+plugins:
+  - search
+  - i18n:
+      docs_structure: suffix
+      languages:
+        - locale: en
+          name: English
+          default: true
+          build: true
+        - locale: ja
+          name: 日本語
+          build: true
+
+nav:
+  - Home: index.md
+  - Two ways to use it: modes.md
+  - Guides:
+      - Connect to a remote MCP server: guides/connect-remote.md
+      - Publish your stdio server: guides/serve.md


### PR DESCRIPTION
## Summary

First slice of #284 — a task-oriented user guide on GitHub Pages that complements (not duplicates) the reference README.

- **`docs/modes.md` — the requested conceptual entry page**: *using mcp-stdio as a client-side gateway* vs *publishing your server with `serve`*, with a decision table, per-mode diagrams, and a chained (client→serve) pattern; each path funnels into its guide.
- **Guides**: `connect-remote` (check → client config → variations → troubleshooting quickies) and `serve` (loopback smoke test → reverse-proxy deploy with `--trusted-user-header` / `--token-store` / `--session-idle-ttl` → Claude.ai connectors → multi-tenant path-scoped issuers).
- **English + Japanese** for all four pages (mkdocs-static-i18n, suffix layout).
- **CI**: `mkdocs build --strict` runs on docs PRs; pushes to main deploy through the official Pages artifact flow (`upload-pages-artifact` + `deploy-pages`) — matching the repo's Pages setting **Source: GitHub Actions**. Version bounds keep CI off MkDocs 2.0 (currently unlicensed per the mkdocs-material advisory).
- READMEs link to the site; `site/` gitignored. `docs:` commits stay invisible to release-please.

Site URL after merge: https://shigechika.github.io/mcp-stdio/ (Japanese at `/ja/`).

Follow-ups tracked in #284: remaining guides (device flow, id_token, SSE), troubleshooting-by-symptom (WORKAROUNDS reframed), CLI reference.

## Test plan

- `mkdocs build --strict` passes locally (en + ja, 0 warnings).
- The docs workflow's build job runs on this PR as its own check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BFkfVbjuNRKYWAKcXE1K4K