### PR TITLE
feat(serve): log the rejected redirect_uri on invalid_redirect_uri

### DIFF
--- a/src/mcp_stdio/server.py
+++ b/src/mcp_stdio/server.py
@@ -654,6 +654,20 @@ def _match_key(uri: str, allowed_redirects: frozenset[str]) -> tuple[Any, ...] |
     return None
 
 
+def _log_safe_uri(value: Any, *, max_len: int = 200) -> str:
+    """Render a client-proposed redirect_uri for a diagnostic log line.
+
+    ``repr`` escapes control characters (CR/LF in particular) so a hostile value
+    cannot inject a forged log line, while keeping the URL human-readable so an
+    operator can copy it into ``--allow-redirect-uri``. The length bound stops a
+    client writing an unbounded line. A rejected redirect_uri is not a secret and
+    not an issued credential, so surfacing it leaks nothing (#286).
+    """
+    if isinstance(value, str) and len(value) > max_len:
+        value = value[:max_len] + "..."
+    return repr(value)[:max_len + 8]
+
+
 def _normalize_public_url(url: str) -> str:
     """Normalize --public-url to a canonical issuer ``scheme://host[:port][/path]``.
 
@@ -1134,6 +1148,15 @@ class _OAuthProvider:
         for u in uris:
             key = _match_key(u, self.allowed_redirect_uris) if isinstance(u, str) else None
             if key is None:
+                # Surface the rejected value so an operator can see exactly what to
+                # allowlist. Without this the client only gets an opaque 400 and the
+                # server logs a bare status line, leaving the offending redirect_uri
+                # invisible (#286). It is client-proposed and non-secret.
+                log(
+                    f"warning: rejected DCR redirect_uri {_log_safe_uri(u)}: "
+                    "not an RFC 8252 loopback URI and not in the "
+                    "--allow-redirect-uri allowlist"
+                )
                 return bad_redirect(_redirect_err)
             keys.add(key)
         client_id = secrets.token_urlsafe(32)
@@ -1180,6 +1203,14 @@ class _OAuthProvider:
             return {"kind": "bad_request", "message": "unknown or missing client_id"}
         rk = _match_key(redirect_uri, self.allowed_redirect_uris)
         if rk is None or rk not in client["redirect_keys"]:
+            # Same diagnostic as register() for the /authorize path (#286): the
+            # redirect_uri is not registered for this client or no longer matches
+            # the allowlist. Value is client-proposed and non-secret.
+            log(
+                f"warning: rejected authorize redirect_uri {_log_safe_uri(redirect_uri)} "
+                f"for client {cid[:8]}...: not registered for this client or not in "
+                "the --allow-redirect-uri allowlist"
+            )
             return {"kind": "bad_request", "message": "invalid redirect_uri"}
 
         state = params.get("state", "")

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1553,6 +1553,57 @@ def test_register_still_rejects_non_allowlisted_https_redirect():
         assert r.json()["error"] == "invalid_redirect_uri"
 
 
+def test_register_logs_rejected_redirect_uri(capsys):
+    """#286: a rejected DCR redirect_uri is logged so an operator can see exactly
+    what to allowlist -- the wire response is only an opaque 400."""
+    prov = _provider(allowed_redirect_uris=frozenset({_ALLOWED_HTTPS}))
+    rejected = "https://evil.example.com/callback"
+    status, body = prov.register(json.dumps({"redirect_uris": [rejected]}).encode())
+    assert status == 400
+    assert body["error"] == "invalid_redirect_uri"
+    err = capsys.readouterr().err
+    assert "rejected DCR redirect_uri" in err
+    assert rejected in err
+
+
+def test_rejected_redirect_uri_log_is_crlf_safe(capsys):
+    """#286: a CR/LF-bearing redirect_uri is escaped (repr), so it cannot forge a
+    second log line (log injection)."""
+    prov = _provider()
+    status, _ = prov.register(
+        json.dumps({"redirect_uris": ["https://evil.example/a\r\nINJECTED line"]}).encode()
+    )
+    assert status == 400
+    err = capsys.readouterr().err
+    injected_lines = [ln for ln in err.splitlines() if "INJECTED" in ln]
+    # The raw newline is escaped, so INJECTED stays on the warning line rather
+    # than starting a forged line of its own.
+    assert injected_lines
+    assert all("rejected DCR redirect_uri" in ln for ln in injected_lines)
+
+
+def test_authorize_logs_rejected_redirect_uri(capsys):
+    """#286: the /authorize path also logs a rejected redirect_uri (registered a
+    client, then authorized with a different, non-allowlisted redirect_uri)."""
+    prov = _provider()
+    status, reg = prov.register(json.dumps({"redirect_uris": [_REDIRECT]}).encode())
+    assert status == 201
+    capsys.readouterr()  # drop registration output
+    mismatched = "https://evil.example.com/callback"
+    out = prov.authorize(
+        {
+            "client_id": reg["client_id"], "response_type": "code",
+            "redirect_uri": mismatched, "code_challenge": "x",
+            "code_challenge_method": "S256",
+        },
+        "alice", "https://gw.example",
+    )
+    assert out["kind"] == "bad_request"
+    err = capsys.readouterr().err
+    assert "rejected authorize redirect_uri" in err
+    assert mismatched in err
+
+
 def test_authorize_and_token_exchange_succeed_for_allowlisted_https_redirect():
     with _run(oauth=_provider(allowed_redirect_uris=frozenset({_ALLOWED_HTTPS}))) as (base, _):
         cid, verifier, challenge, code, tok = _full_flow(base, redirect=_ALLOWED_HTTPS)


### PR DESCRIPTION
## Summary

Closes #286.

In `serve --enable-oauth`, when the embedded AS rejects a DCR registration **or** an `/authorize` request because a `redirect_uri` is neither an RFC 8252 loopback URI nor in the `--allow-redirect-uri` allowlist, it returned an opaque `400 invalid_redirect_uri` and logged only the bare status line (`"POST /register HTTP/1.1" 400 -`). The offending value was invisible server-side, so an operator diagnosing a hosted connector whose callback isn't allowlisted had no way to recover the exact **byte-for-byte** string to add.

This logs the rejected `redirect_uri` at both rejection points:

```
[mcp-stdio] warning: rejected DCR redirect_uri 'https://client.example/oauth/cb': not an RFC 8252 loopback URI and not in the --allow-redirect-uri allowlist
[mcp-stdio] warning: rejected authorize redirect_uri 'https://client.example/oauth/cb' for client AbCdEfGh...: not registered for this client or not in the --allow-redirect-uri allowlist
```

### Safety
- New `_log_safe_uri()` helper renders the value with `repr` (escapes CR/LF, so a hostile value cannot forge a second log line = log-injection safe) and bounds the length (a client cannot write an unbounded line).
- A rejected `redirect_uri` is **client-proposed and non-secret** — only *rejected* values are logged, never issued tokens/credentials. No change to the read/validation path for accepted URIs.
- Default behavior is otherwise unchanged; this only adds a WARNING line on the (rare) rejection path.

## Tests
- `test_register_logs_rejected_redirect_uri` — rejected DCR value appears in stderr.
- `test_rejected_redirect_uri_log_is_crlf_safe` — a CR/LF-bearing value stays on one line (no forged line).
- `test_authorize_logs_rejected_redirect_uri` — the `/authorize` path logs too.
- Full suite: **1193 passed / 3 skipped**, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)