### PR TITLE
docs: add Xquik remote MCP example

### DIFF
--- a/docs/guides/connect-remote.ja.md
+++ b/docs/guides/connect-remote.ja.md
@@ -74,6 +74,24 @@ OAuth ログイン、トークン交換、MCP `initialize` の往復——そし
 全フラグは `mcp-stdio --help` か
 [README](https://github.com/shigechika/mcp-stdio#readme) へ。
 
+## 例：Xquik
+
+Xquik は X/Twitter の検索、抽出、アカウント監視、webhook、投稿ワークフローに
+対応するリモート MCP サーバーです。静的 Bearer トークンの経路を使うため、
+まず次のように確認します：
+
+```bash
+MCP_BEARER_TOKEN=YOUR_XQUIK_API_KEY mcp-stdio --check https://xquik.com/mcp
+```
+
+Claude Code：
+
+```bash
+claude mcp add xquik \
+  -e MCP_BEARER_TOKEN=YOUR_XQUIK_API_KEY \
+  -- mcp-stdio https://xquik.com/mcp
+```
+
 ## トラブルシュートの早見
 
 - **ブラウザが開かない** — authorize URL は stderr に出力されています。

--- a/docs/guides/connect-remote.md
+++ b/docs/guides/connect-remote.md
@@ -74,6 +74,24 @@ itself expires or is revoked.
 Every flag: `mcp-stdio --help`, or the
 [README](https://github.com/shigechika/mcp-stdio#readme).
 
+## Example: Xquik
+
+Xquik is a remote X/Twitter MCP server for search, extraction, account
+monitoring, webhooks, and write workflows. It uses the static bearer-token
+path, so check it first with:
+
+```bash
+MCP_BEARER_TOKEN=YOUR_XQUIK_API_KEY mcp-stdio --check https://xquik.com/mcp
+```
+
+Claude Code:
+
+```bash
+claude mcp add xquik \
+  -e MCP_BEARER_TOKEN=YOUR_XQUIK_API_KEY \
+  -- mcp-stdio https://xquik.com/mcp
+```
+
 ## Troubleshooting quickies
 
 - **Browser never opens** — the authorize URL is printed to stderr; open it


### PR DESCRIPTION
## Summary
- Add Xquik as a concrete static bearer-token example in the remote connection guide.
- Include both English and Japanese guide entries to match the existing docs structure.
- Show `--check` and Claude Code setup with `MCP_BEARER_TOKEN` placeholders.

## Validation
- `git diff --check`
- Confirmed `https://xquik.com/mcp` responds with 401 when no bearer token is provided, which is expected for the documented authenticated endpoint.
