### PR TITLE
docs: fix inaccuracies in Troubleshooting and Reference pages

### DIFF
--- a/docs/guides/connect-remote.ja.md
+++ b/docs/guides/connect-remote.ja.md
@@ -78,9 +78,9 @@ OAuth ログイン、トークン交換、MCP `initialize` の往復——そし
 
 - **ブラウザが開かない** — authorize URL は stderr に出力されています。
   手動で開いてください（クライアントの MCP ログに出ます）。
-- **Microsoft Entra ID でログインがループする / `AADSTS…` エラー** —
-  `--oauth-scope` を明示してください。エラーコード別の詳細は WORKAROUNDS
-  の該当項目へ。
+- **Microsoft Entra ID で `AADSTS9010010`** — 一部の Entra ID 構成は
+  `resource` パラメータそのものを拒否します。`--no-resource-indicator` を
+  追加してください。詳細は[トラブルシューティング](../troubleshooting.ja.md#microsoft-entra-id-aadsts9010010)を参照。
 - **昨日まで動いていたのに今日は `401`** — サーバー側で鍵のローテートや
   グラントの失効があったかもしれません。`~/.config/mcp-stdio/tokens.json`
   から該当サーバーのエントリを消して、再認可させてください。

--- a/docs/guides/connect-remote.md
+++ b/docs/guides/connect-remote.md
@@ -78,8 +78,9 @@ Every flag: `mcp-stdio --help`, or the
 
 - **Browser never opens** — the authorize URL is printed to stderr; open it
   manually (the client's MCP log shows it).
-- **Login loops or `AADSTS…` errors on Microsoft Entra ID** — set an explicit
-  `--oauth-scope`; see the WORKAROUNDS entries for the exact error code.
+- **`AADSTS9010010` on Microsoft Entra ID** — some Entra ID configurations
+  reject the `resource` parameter outright; add `--no-resource-indicator`.
+  See [Troubleshooting](../troubleshooting.md#aadsts9010010-on-microsoft-entra-id).
 - **Worked yesterday, `401` today** — the server may have rotated its keys or
   revoked the grant. Delete the server's entry from
   `~/.config/mcp-stdio/tokens.json` and let it re-authorize.

--- a/docs/reference.ja.md
+++ b/docs/reference.ja.md
@@ -20,7 +20,7 @@ Arguments:
 | `--oauth-device` | — | OAuth 2.1 デバイス認可グラント（RFC 8628、ヘッドレス） |
 | `--client-id ID` | `MCP_OAUTH_CLIENT_ID` | 事前登録済み OAuth クライアント ID（Dynamic Client Registration をスキップ） |
 | `--client-metadata-url URL` | — | Dynamic Client Registration の代わりに使用するクライアント ID メタデータドキュメントの HTTPS URL |
-| `--oauth-scope SCOPE` | — | リクエストする OAuth スコープ（繰り返し可能） |
+| `--oauth-scope SCOPE` | — | リクエストする OAuth スコープ。複数指定する場合は1つの値の中でスペース区切り（例：`"openid offline_access"`） |
 | `--oauth-use-id-token` | — | アクセストークンの代わりに OIDC id_token をベアラー認証情報として提示（AWS Bedrock / Cognito） |
 | `--oauth-eager` | — | コールドスタート：initialize をローカルで応答し、バックグラウンドでインタラクティブ OAuth を実行。長いログインがクライアントの約 60 秒のタイムアウトを超えない |
 | `--oauth-refresh-leeway SECONDS` | `MCP_OAUTH_REFRESH_LEEWAY` | トークン有効期限の何秒前にプロアクティブにリフレッシュするか（デフォルト: 60） |
@@ -113,10 +113,9 @@ mcp-stdio は以下の仕様を実装しています：
 
 ### MCP（Model Context Protocol）
 
-- [MCP 2025-11-25 仕様](https://modelcontextprotocol.io/specification/2025-11-25/)
-  - Streamable HTTP トランスポート（現在）
-  - SSE トランスポート（レガシー、MCP 2024-11-05）
-  - 認可仕様
+- Streamable HTTP トランスポート（現行、spec rev 2025-06-18）— `initialize` でネゴシエートされた `MCP-Protocol-Version` を以後のすべてのリクエストに付与
+- SSE トランスポート（レガシー、MCP 2024-11-05）
+- クライアント ID メタデータドキュメント（MCP 2025-11-25 のドラフト拡張）— 詳細は下記 OAuth セクションを参照
 
 ### OAuth 2.1 & OpenID Connect
 
@@ -158,8 +157,8 @@ mcp-stdio は以下の仕様を実装しています：
 
 ### HTTP & レジリエンス
 
-- [RFC 7230](https://www.rfc-editor.org/rfc/rfc7230) HTTP/1.1 メッセージ構文とルーティング
-  - Retry-After ヘッダーの解析（delta-seconds および HTTP-date 形式）
+- [RFC 9110](https://www.rfc-editor.org/rfc/rfc9110) HTTP セマンティクス
+  - §10.2.3 `Retry-After` ヘッダーの解析（delta-seconds および HTTP-date 形式；旧 RFC 7231 §7.1.3）
 
 - HTTP 429（Too Many Requests）および 503（Service Unavailable）— 最大 60 秒まで Retry-After を尊重
 
@@ -211,13 +210,13 @@ mcp-stdio は可能な限りワイヤーレベルでこれらの問題を回避�
 | コード | 意味 |
 |--------|------|
 | `0` | 成功 |
-| `1` | 一般エラー（無効な引数、接続失敗など） |
-| `2` | OAuth タイムアウトまたはユーザーがキャンセル |
+| `1` | 実行時エラー（接続失敗、OAuth 認証失敗、起動時に検出された設定不備など） |
+| `2` | コマンドライン引数が不正（標準的な `argparse` の使用方法エラー） |
+| `130` | 中断（Ctrl-C / `SIGINT`） |
 
 ---
 
 ## ログ
 
-- すべてのエラーと診断情報は stderr に書き込まれます
-- リモートサーバーへのリクエストはクエリ文字列を編集してログされます
-- トークン交換の詳細は詳細出力でログされます
+- 診断情報はすべて stderr に書き込まれます。relay 自身の接続・リトライ・再接続メッセージには `[mcp-stdio]` プレフィックスが付きますが、起動時や OAuth のエラー・警告メッセージは `error: ...` / `warning: ...` という素のプレフィックスで出力されます
+- 現時点で個別の verbose/debug ログモードはありません — 上記の stderr 出力がすべてです

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -20,7 +20,7 @@ Arguments:
 | `--oauth-device` | — | Enable OAuth 2.1 Device Authorization Grant (RFC 8628, headless) |
 | `--client-id ID` | `MCP_OAUTH_CLIENT_ID` | Pre-registered OAuth client ID (skips Dynamic Client Registration) |
 | `--client-metadata-url URL` | — | HTTPS URL of a Client ID Metadata Document to use as client_id instead of DCR |
-| `--oauth-scope SCOPE` | — | OAuth scope to request (repeatable) |
+| `--oauth-scope SCOPE` | — | OAuth scope(s) to request, space-separated in one value (e.g. `"openid offline_access"`) |
 | `--oauth-use-id-token` | — | Present the OIDC id_token as the Bearer credential instead of access_token (AWS Bedrock / Cognito) |
 | `--oauth-eager` | — | Cold-start: answer initialize locally and run interactive OAuth in the background, so a long login does not exceed the client's ~60 s timeout |
 | `--oauth-refresh-leeway SECONDS` | `MCP_OAUTH_REFRESH_LEEWAY` | Proactively refresh tokens this many seconds before expiry (default: 60) |
@@ -113,10 +113,9 @@ mcp-stdio implements the following specifications:
 
 ### MCP (Model Context Protocol)
 
-- [MCP 2025-11-25 Specification](https://modelcontextprotocol.io/specification/2025-11-25/)
-  - Streamable HTTP transport (current)
-  - SSE transport (legacy, MCP 2024-11-05)
-  - Authorization spec
+- Streamable HTTP transport (current, spec rev 2025-06-18) — negotiated `MCP-Protocol-Version` is captured from `initialize` and sent on every subsequent request
+- SSE transport (legacy, MCP 2024-11-05)
+- Client ID Metadata Documents (MCP 2025-11-25 draft extension) — see the OAuth section below
 
 ### OAuth 2.1 & OpenID Connect
 
@@ -158,8 +157,8 @@ mcp-stdio implements the following specifications:
 
 ### HTTP & Resilience
 
-- [RFC 7230](https://www.rfc-editor.org/rfc/rfc7230) HTTP/1.1 Message Syntax and Routing
-  - Retry-After header parsing (delta-seconds and HTTP-date formats)
+- [RFC 9110](https://www.rfc-editor.org/rfc/rfc9110) HTTP Semantics
+  - §10.2.3 `Retry-After` header parsing (delta-seconds and HTTP-date formats; formerly RFC 7231 §7.1.3)
 
 - HTTP 429 (Too Many Requests) and 503 (Service Unavailable) — honors Retry-After up to 60 seconds
 
@@ -211,13 +210,13 @@ mcp-stdio works around these issues at the wire level where possible.
 | Code | Meaning |
 |------|---------|
 | `0` | Success |
-| `1` | General error (invalid arguments, connection failure, etc.) |
-| `2` | OAuth timeout or user cancelled |
+| `1` | Runtime error (connection failure, OAuth authentication failure, misconfiguration detected at startup) |
+| `2` | Invalid command-line arguments (standard `argparse` usage error) |
+| `130` | Interrupted (Ctrl-C / `SIGINT`) |
 
 ---
 
 ## Logging
 
-- All errors and diagnostics are written to stderr
-- Requests to the remote server are logged with query strings redacted
-- Token exchange details are logged in verbose output
+- All diagnostics are written to stderr. The relay's own connection/retry/reconnect messages are prefixed `[mcp-stdio]`; startup and OAuth error/warning messages print as bare `error: ...` / `warning: ...` lines instead
+- There is currently no separate verbose/debug logging mode — the stderr output above is all there is

--- a/docs/troubleshooting.ja.md
+++ b/docs/troubleshooting.ja.md
@@ -9,26 +9,9 @@
 **問題：** `mcp-stdio --oauth` を実行しましたが、ブラウザウィンドウが開きません。
 
 **解決方法：**
-1. 標準エラー出力（stderr）から認可 URL を確認してください。ブラウザが自動的に開けない場合、そこに出力されます。
+1. 標準エラー出力（stderr）を確認してください。ブラウザが自動的に開くかどうかにかかわらず、mcp-stdio は認可 URL を常にそこへ出力します。
 2. その URL をブラウザに手動で貼り付けます。
 3. ログインフローを完了してください。認可コードはループバックコールバックで取得されます。
-
-Claude Code の [#28293](https://github.com/anthropics/claude-code/issues/28293) を参照。
-
-### Microsoft Entra ID のログインループまたは AADSTS エラー
-
-**問題：** Microsoft Entra ID 上のサーバーに接続すると、ログインプロンプトが繰り返されるか、`AADSTS9010010` のようなエラーが表示されます。
-
-**解決方法：**
-`openid` と `offline_access` を含む明示的な OAuth スコープを設定してください：
-
-```bash
-mcp-stdio --oauth --oauth-scope "openid offline_access" https://your-server.example.com/mcp
-```
-
-異なる Entra ID テナントには異なるスコープが必要です。サーバーのドキュメントまたはエラーメッセージで必要なスコープを確認してください。
-
-Claude Code の [#39271](https://github.com/anthropics/claude-code/issues/39271) を参照。
 
 ### `401 Unauthorized` — 「昨日は動いていたのに今日は動かない」
 
@@ -45,64 +28,70 @@ rm ~/.config/mcp-stdio/tokens.json
 
 その後、クライアントを再度実行してください。初回利用時にブラウザが開いてログインを求められます。以後はトークンがキャッシュされ、自動的にリフレッシュされます。
 
-### 接続が 24 時間後または固定時刻に切れる
+### リフレッシュトークンが有効なのに「接続の有効期限切れ」が繰り返される
 
-**問題：** アクティブに使用中でも、毎日同じ時刻に接続が途切れます。
+**問題：** `mcp-stdio` は有効なリフレッシュトークンを保持しているのに、MCP クライアント側は繰り返し接続を期限切れとして報告します。
 
-**原因：** OAuth アクセストークンが有効期限切れになり、mcp-stdio がプロアクティブにリフレッシュしていません。
+**原因：** mcp-stdio はデフォルトでアクセストークンの有効期限が切れる少し前にプロアクティブにリフレッシュします（`--oauth-refresh-leeway`、デフォルト 60 秒）。ただしこれが効くのは、MCP クライアントが `mcp-stdio` 経由の接続を実際に使い回している場合に限られます。
 
 **解決方法：**
-mcp-stdio を長時間実行セッション（例：Claude Code を一日中動かす）で使用している場合、トークンは有効期限の直前にリフレッシュされるはずです。リフレッシュされていない場合：
+1. `--no-proactive-refresh` を渡していないことを確認してください（プロアクティブリフレッシュはデフォルトで有効です）。
+2. サーバーが有効期限切れをトランスポートレベルの `401` ではなく HTTP 200 応答＋ツール結果のエラーで通知する場合（一部のエンタープライズ MCP ゲートウェイなど）、mcp-stdio はリアクティブには検知できないことがあります。プロアクティブリフレッシュが主な防御策です。それでも古いセッションが残る場合は、ゲートウェイの挙動とあわせて [issue を作成](https://github.com/shigechika/mcp-stdio/issues/new)してください（このクラスの問題の最初の報告は [shigechika/mcp-stdio#242](https://github.com/shigechika/mcp-stdio/issues/242) を参照）。
+3. サーバーが `expires_in` を一切送信しない場合は、前置時間を明示的に設定します：
+   ```bash
+   mcp-stdio --oauth --oauth-refresh-leeway 300 https://your-server.example.com/mcp
+   ```
 
-1. `--no-proactive-refresh` を渡していないことを確認してください（デフォルトではプロアクティブにリフレッシュします）。
-2. サーバーのトークンレスポンスに `expires_in` フィールド（または JWT の `exp`）が含まれていることを確認してください。
-3. サーバーが `expires_in` を送信しない場合、リフレッシュ前置時間を手動で設定します：
+一部の MCP クライアントには、セッション途中でトークンが失効しても認証ヘッダーのコールバックを再実行しないという既知の問題があります（Claude Code の [#53267](https://github.com/anthropics/claude-code/issues/53267)、[#65036](https://github.com/anthropics/claude-code/issues/65036) を参照）。mcp-stdio のプロアクティブ／リアクティブなリフレッシュは、まさにこのクラスの問題を回避するために存在します。トークンのライフサイクル全体を MCP クライアントではなく mcp-stdio 自身が管理しているためです。
 
+### Microsoft Entra ID で `AADSTS9010010`
+
+**問題：** `api://` スコープを使う Microsoft Entra ID 経由の接続で、認可が `AADSTS9010010`（audience 検証失敗）で失敗します。
+
+**原因：** 一部の Entra ID 構成は RFC 8707 の `resource` パラメータそのものを拒否します。
+
+**解決方法：**
 ```bash
-mcp-stdio --oauth --oauth-refresh-leeway 300 https://your-server.example.com/mcp
+mcp-stdio --oauth --no-resource-indicator https://your-server.example.com/mcp
 ```
 
-デフォルトの 60 秒の代わりに、有効期限切れの 5 分前にリフレッシュします。
-
-Claude Code の [#242](https://github.com/anthropics/claude-code/issues/242) を参照。
+これにより、認可・トークン交換・リフレッシュ・デバイスフローのすべての OAuth リクエストから `resource` パラメータが省略されます。
 
 ## ツールとリソースの問題
-
-### 接続後にツールが突然消える
-
-**問題：** 正常に接続され、ツールがリストされていますが、その後消えてしまいます。
-
-**原因：** ほぼ確実に以下のいずれかです：
-1. MCP セッションが失われました（例：サーバーが再起動）。mcp-stdio は次のリクエストでセッションを回復しますが、クライアントを再起動するまでツールは再リストされません。
-2. Claude Code が後続のリクエストで `Mcp-Session-Id` ヘッダーを送信していません（下記の問題を参照）。
-
-**解決方法：**
-1. MCP クライアント（Claude Desktop / Claude Code）を再起動してください。
-2. 頻繁に発生する場合は、サーバーログでセッションドロップを確認してください。
-
-Claude Code の [#34498](https://github.com/anthropics/claude-code/issues/34498) を参照。
-
-### ツール呼び出しで `404` が返される（リストされた後）
-
-**問題：** ツールがリストに表示されていますが、呼び出すと `404` が返されます。
-
-**原因：** Claude Code がツール呼び出しで `Mcp-Session-Id` ヘッダーをエコーバックしていないため、サーバーがセッションを見つけられません。
-
-**解決方法：**
-これは Claude Code のバグです。mcp-stdio は回避できません。Claude Code を再起動してセッションを再同期してください。
-
-Claude Code の [#34008](https://github.com/anthropics/claude-code/issues/34008) を参照。
 
 ### 最初のページ以降のツールが見えない
 
 **問題：** 数十個のツールが定義されていますが、クライアントには最初の約 20 個だけが表示されます。
 
-**原因：** Claude Code は `tools/list` と `resources/list` のページネーションを無視し、最初のページだけを取得します。MCP サーバーが `nextCursor` を使用している場合、2 ページ目以降のツールは失われます。
+**原因：** Claude Code は最初の `tools/list` リクエストのみを送信し、`nextCursor` を無視するため、2 ページ目以降のツールはクライアントに届きません。
 
 **解決方法：**
-これは Claude Code の HTTP トランスポートの制限です。mcp-stdio はクライアント側で回避できません。回避方法はツールの総数を 1 ページ以下に保つことです。
+設定は不要です。mcp-stdio は Streamable HTTP トランスポート上で `tools/list`・`resources/list`・`resources/templates/list`・`prompts/list` の `nextCursor` を透過的に辿り、すべてのページを 1 つのレスポンスにまとめてからクライアントに渡します。ただし `--transport sse`（レガシートランスポート）では自動ページネーションされないため、その場合はツール総数を 1 ページ以内に収めてください。
 
-Claude Code の [#42470](https://github.com/anthropics/claude-code/issues/42470) を参照。
+Claude Code の [#39586](https://github.com/anthropics/claude-code/issues/39586) を参照。
+
+### 接続直後は成功するのに `tools/list` が「Invalid session ID」で失敗する
+
+**問題：** 接続は確立され `initialize` も成功しますが、続く `tools/list` やツール呼び出しがセッション不正・不明として拒否されます。
+
+**原因：** 一部の MCP クライアント（一部の Claude Code バージョンを含む）は、`initialize` で返された `Mcp-Session-Id` ヘッダーを以後のリクエストでエコーバックしません。そのため mcp-grafana や mcp-go のようなセッション対応サーバーが拒否します。
+
+**解決方法：**
+設定は不要です。mcp-stdio は `initialize` のレスポンス自身から `Mcp-Session-Id` を取得し、MCP クライアントの挙動にかかわらず以後のすべてのリクエストに付与します。それでも発生する場合は、サーバー側でセッションが本当に失効している可能性があります。クライアントを再起動して新しい `initialize` を強制してください。
+
+Claude Code の [#70386](https://github.com/anthropics/claude-code/issues/70386) を参照。
+
+### 短時間のネットワーク断や再接続後にツールが消える
+
+**問題：** ツールは正常にリストされていたのに、短い切断・再接続の後に動かなくなる、あるいはリストから消える。
+
+**原因：** MCP セッションが失われた（バックエンドサーバーの再起動、接続の中断など）か、一部の Claude Code バージョンでは Streamable HTTP の再接続処理自体に regression があったことがあります。
+
+**解決方法：**
+1. mcp-stdio はサーバーからの `404`（セッション未検出）応答を受けて自動的にセッションを再初期化します。
+2. それでもツールが利用できない場合は、MCP クライアント（Claude Desktop / Claude Code）を再起動して新しいセッションを強制してください。
+
+Claude Code の [#34498](https://github.com/anthropics/claude-code/issues/34498)、[#38631](https://github.com/anthropics/claude-code/issues/38631) を参照。
 
 ## 認証の問題
 
@@ -110,12 +99,12 @@ Claude Code の [#42470](https://github.com/anthropics/claude-code/issues/42470)
 
 **問題：** `--bearer-token` または `MCP_BEARER_TOKEN` を設定しましたが、サーバーはトークンがないか無効だと報告します。
 
-**原因：** 可能性は低い — mcp-stdio はすべてのリクエストにトークンを追加します。むしろ、サーバーがトークンを間違った場所で探している可能性が高いです（例：`Authorization` ヘッダーではなくクエリパラメータ）。
+**原因：** mcp-stdio はすべての送信リクエストの `Authorization` ヘッダーにトークンを付与します。拒否される場合は、トークンが誤っている・失効している、あるいはサーバーが `Authorization` ヘッダー以外の場所（クエリパラメータや独自ヘッダーなど）で資格情報を期待している可能性が高いです。
 
 **解決方法：**
-1. mcp-stdio をフォアグラウンドで実行し、stderr で送信されているリクエストをチェックして、詳細ログを有効にしてください。
-2. トークンが正しく、有効期限が切れていないことを確認してください。
-3. サーバーの認証ドキュメントを確認して、`Authorization: Bearer` ヘッダーを期待しているか確認してください。
+1. トークンが正しく、有効期限が切れていないことを確認してください。
+2. サーバーの認証ドキュメントを確認し、`Authorization: Bearer` ヘッダーを期待しているか確認してください。異なるヘッダーを期待する場合は `-H 'ヘッダー名: 値'` で明示的に渡してください。
+3. mcp-stdio をフォアグラウンドで実行し、stderr で接続・リトライの診断出力を確認してください。
 
 ### OAuth スコープが反映されない
 
@@ -124,9 +113,9 @@ Claude Code の [#42470](https://github.com/anthropics/claude-code/issues/42470)
 **原因：** 認可サーバーがリクエストされたスコープを拒否し、より小さいものを付与した可能性があります。
 
 **解決方法：**
-1. 実際に付与されたスコープを確認してください。サーバーのトークンレスポンスの `scope` フィールドを確認します（詳細ログがある場合は mcp-stdio のログに出力されます）。
+1. 実際に付与されたスコープは、認可サーバー自身のログや管理コンソールで確認してください。mcp-stdio 自体は現時点で付与されたスコープを出力しません。
 2. サーバーがスコープをダウングレードした場合は、認可サーバーのポリシーを確認するか、サーバーオペレーターに連絡してください。
-3. 一部のサーバーは**ステップアップ認可**をサポートしています。ツールがより広いスコープを必要とする場合、`403 insufficient_scope` で必要なスコープをリストして返します。mcp-stdio は付与されたスコープと必要なスコープの和集合で自動的に再認可します。
+3. 一部のサーバーは**ステップアップ認可**をサポートしています。ツール呼び出しがより広いスコープを必要とする場合、サーバーは `403 insufficient_scope` とともに必要なスコープを返し、mcp-stdio は付与済みスコープと必要スコープの和集合で自動的に再認可（RFC 9470）してから呼び出しを再試行します。一部の MCP クライアントは、mcp-stdio がバックグラウンドでステップアップを完了した後にツール呼び出しを自動再試行しません（Claude Code [#44652](https://github.com/anthropics/claude-code/issues/44652)）。エラーが表示された場合はもう一度呼び出してみてください。
 
 ## トランスポートの問題
 
@@ -141,10 +130,11 @@ Claude Code の [#42470](https://github.com/anthropics/claude-code/issues/42470)
    ```bash
    mcp-stdio --timeout-read 300 https://your-server.example.com/mcp
    ```
-2. 企業プロキシの背後にいないか確認し、プロキシ環境変数を設定してください：
+2. mcp-stdio は標準的なプロキシ環境変数を尊重します：
    ```bash
    HTTPS_PROXY=http://proxy.example.com:8080 mcp-stdio --oauth https://your-server.example.com/mcp
    ```
+   （`NO_PROXY` も同様に尊重されます。これは mcp-stdio 自身の HTTP クライアントを使うことで、一部の MCP クライアント内蔵トランスポートの既知の不具合を回避できるケースです。Claude Code の [#34804](https://github.com/anthropics/claude-code/issues/34804) を参照。）
 3. 手動で接続をテストしてください：
    ```bash
    curl -v https://your-server.example.com/mcp
@@ -161,7 +151,7 @@ Claude Code の [#42470](https://github.com/anthropics/claude-code/issues/42470)
    ```bash
    curl -v https://your-server.example.com/mcp
    ```
-2. curl は機能するが mcp-stdio は機能しない場合、mcp-stdio でデバッグログを有効にしてください（stderr をチェック）。
+2. curl は機能するが mcp-stdio は機能しない場合、mcp-stdio をフォアグラウンドで実行し stderr で実際のエラーを確認してください。
 3. 証明書が自己署名で、サーバーを信頼する場合：
    - macOS：証明書をシステムキーチェーンに追加します。
    - Linux：`SSL_CERT_FILE` 環境変数を CA バンドルを指すように設定します。
@@ -169,12 +159,12 @@ Claude Code の [#42470](https://github.com/anthropics/claude-code/issues/42470)
 
 ### SSE ストリームがリクエスト途中にドロップ
 
-**問題：** レガシー SSE サーバー（`--transport sse`）を使用しており、長いツール呼び出しがハングします。
+**問題：** レガシー SSE サーバー（`--transport sse`）を使用しており、ツール呼び出しの途中で接続が切れました。
 
-**原因：** SSE GET ストリームが応答途中にドロップし、クライアントが応答を受信しませんでした。
+**原因：** 1 件以上のリクエストが応答待ちのまま、SSE GET ストリームが切断されました。
 
 **解決方法：**
-mcp-stdio は自動的に再接続されますが、処理中のリクエストは失われます。これは SSE トランスポートの制限です。可能であれば、サーバーを Streamable HTTP（現在の MCP 仕様）にアップグレードしてください。
+設定は不要です。mcp-stdio は自動的に再接続し、切断時に応答待ちだったすべてのリクエストに対して JSON-RPC のエラー（「SSE stream disconnected before response arrived; please retry」）を合成します。クライアントを永久にハングさせる代わりに、エラーを見たら呼び出しを再試行してください。これは Claude Code の [#60061](https://github.com/anthropics/claude-code/issues/60061) で報告された故障モードと同種のものです。可能であれば、この故障モード自体が存在しない Streamable HTTP（現在の MCP 仕様）へのアップグレードを検討してください。
 
 ## ヘッドレス / SSH 環境
 
@@ -191,14 +181,12 @@ mcp-stdio --oauth-device https://your-server.example.com/mcp
 
 ユーザーコード（例：`ABCD-1234`）が出力されます。任意のデバイスのブラウザでそれを開いて確認します。その後、mcp-stdio は SSH ボックスで OAuth フローを完了します（ローカルディスプレイは不要）。
 
-Claude Code の [#34804](https://github.com/anthropics/claude-code/issues/34804) を参照。
-
 ## それでも解決しない場合
 
 1. クライアント設定に追加する前に、`--check` で接続を検証してください：
    ```bash
    mcp-stdio --check --oauth https://your-server.example.com/mcp
    ```
-2. stderr で詳細なエラーメッセージと issue リファレンスを確認してください。
+2. stderr で詳細なエラーメッセージを確認してください。
 3. [GitHub Issues](https://github.com/shigechika/mcp-stdio/issues) でエラーを検索してください。
 4. それでも解決しない場合は、[issue を作成](https://github.com/shigechika/mcp-stdio/issues/new)してください。完全なコマンドとエラー出力を含めてください。

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -9,26 +9,9 @@ Common issues and how to resolve them. For the full list of known workarounds in
 **Problem:** You ran `mcp-stdio --oauth` but no browser window appeared.
 
 **Solution:**
-1. Check stderr for the authorization URL — it's printed there if the browser cannot open automatically.
+1. Check stderr — mcp-stdio always prints the authorization URL there, whether or not the browser opened automatically.
 2. Copy and paste that URL into your browser manually.
 3. Complete the login flow; the authorization code is captured on the loopback callback.
-
-See Claude Code [#28293](https://github.com/anthropics/claude-code/issues/28293).
-
-### Login loops or AADSTS errors on Microsoft Entra ID
-
-**Problem:** You see repeated login prompts or errors like `AADSTS9010010` when connecting to a server on Microsoft Entra ID.
-
-**Solution:**
-Set an explicit OAuth scope that includes `openid` and `offline_access`:
-
-```bash
-mcp-stdio --oauth --oauth-scope "openid offline_access" https://your-server.example.com/mcp
-```
-
-Different Entra ID tenants require different scopes. Check your server's documentation or the error message for the exact scope.
-
-See Claude Code [#39271](https://github.com/anthropics/claude-code/issues/39271).
 
 ### `401 Unauthorized` — "Worked yesterday, broken today"
 
@@ -45,64 +28,70 @@ rm ~/.config/mcp-stdio/tokens.json
 
 Then run your client again. On first use, a browser window opens for login; after that, tokens are cached and refreshed automatically.
 
-### Connection expires after 24 hours or at a fixed time
+### Repeated "Connection expired" prompts despite a valid refresh token
 
-**Problem:** The connection dies at the same time each day, even if you're actively using it.
+**Problem:** Your MCP client keeps reporting the connection as expired, even though `mcp-stdio` holds a working refresh token.
 
-**Cause:** Your OAuth access token expires and mcp-stdio is not refreshing it proactively.
+**Cause:** By default `mcp-stdio` refreshes the access token proactively, shortly before it expires (`--oauth-refresh-leeway`, default 60 s) — but this only helps if your MCP client actually reuses the connection through `mcp-stdio`.
 
 **Solution:**
-If you are using mcp-stdio in a long-lived session (e.g., Claude Code running all day), mcp-stdio should refresh the token shortly before it expires. If it is not:
+1. Make sure you are not passing `--no-proactive-refresh` (proactive refresh is on by default).
+2. If the server signals expiry with an HTTP 200 response and a tool-result error instead of a transport `401` (e.g. some enterprise MCP gateways), mcp-stdio may not detect it reactively — proactive refresh is the primary defense here; if you still see stale sessions, please [file an issue](https://github.com/shigechika/mcp-stdio/issues/new) with the gateway's behavior (see [shigechika/mcp-stdio#242](https://github.com/shigechika/mcp-stdio/issues/242) for the original report of this class of gateway).
+3. If your server does not send `expires_in` at all, set the leeway explicitly:
+   ```bash
+   mcp-stdio --oauth --oauth-refresh-leeway 300 https://your-server.example.com/mcp
+   ```
 
-1. Make sure you are not passing `--no-proactive-refresh` (default is to refresh proactively).
-2. Check that the server's token response includes an `expires_in` field (or `exp` in the JWT).
-3. If the server does not send `expires_in`, manually set the refresh leeway:
+Some MCP clients have their own history of not re-invoking their auth header callback when a token expires mid-session (see Claude Code [#53267](https://github.com/anthropics/claude-code/issues/53267) and [#65036](https://github.com/anthropics/claude-code/issues/65036)) — this is exactly the class of problem mcp-stdio's proactive/reactive refresh is designed to route around, since mcp-stdio (not your MCP client) owns the token lifecycle end to end.
 
+### `AADSTS9010010` on Microsoft Entra ID
+
+**Problem:** Authorization fails with `AADSTS9010010` ("audience validation failed") when connecting through Microsoft Entra ID with `api://` scopes.
+
+**Cause:** Some Entra ID configurations reject the RFC 8707 `resource` parameter outright.
+
+**Solution:**
 ```bash
-mcp-stdio --oauth --oauth-refresh-leeway 300 https://your-server.example.com/mcp
+mcp-stdio --oauth --no-resource-indicator https://your-server.example.com/mcp
 ```
 
-This refreshes 5 minutes before expiry instead of the default 60 seconds.
-
-See Claude Code [#242](https://github.com/anthropics/claude-code/issues/242).
+This omits the `resource` parameter from every OAuth request (authorization, token exchange, refresh, and device flow).
 
 ## Tool and resource issues
-
-### Tools silently vanish after connecting
-
-**Problem:** You connect successfully, tools are listed, but then they disappear.
-
-**Cause:** Most likely one of two things:
-1. The MCP session was lost (e.g., the server restarted); mcp-stdio recovers it on the next request but tools are not re-listed until you restart your client.
-2. Claude Code did not send the `Mcp-Session-Id` header on a subsequent request (see issue below).
-
-**Solution:**
-1. Restart your MCP client (Claude Desktop / Claude Code).
-2. If it happens repeatedly, check the server logs for session drops.
-
-See Claude Code [#34498](https://github.com/anthropics/claude-code/issues/34498).
-
-### `404` on tool calls after a tool was listed
-
-**Problem:** A tool appeared in the list but calling it returns `404`.
-
-**Cause:** Claude Code is not echoing the `Mcp-Session-Id` header on tool calls, so the server cannot find the session.
-
-**Solution:**
-This is a Claude Code bug. mcp-stdio cannot work around it. Restart Claude Code to re-sync the session.
-
-See Claude Code [#34008](https://github.com/anthropics/claude-code/issues/34008).
 
 ### Tools beyond the first page are invisible
 
 **Problem:** You have dozens of tools defined, but your client only sees the first ~20.
 
-**Cause:** Claude Code ignores pagination on `tools/list` and `resources/list`, only fetching the first page. If your MCP server uses `nextCursor`, tools on page 2+ are lost.
+**Cause:** Claude Code sends only the first `tools/list` request and silently discards `nextCursor`, so tools on page 2+ never reach the client.
 
 **Solution:**
-This is a limitation of Claude Code's HTTP transport. mcp-stdio cannot work around it on the client side. The workaround is to keep the total number of tools under one page.
+Nothing to configure — mcp-stdio already follows `nextCursor` transparently across `tools/list`, `resources/list`, `resources/templates/list`, and `prompts/list` on the Streamable HTTP transport, merging every page into a single response before it reaches your client. This does **not** apply to `--transport sse` (legacy transport, not auto-paginated); keep your tool count under one page there.
 
-See Claude Code [#42470](https://github.com/anthropics/claude-code/issues/42470).
+See Claude Code [#39586](https://github.com/anthropics/claude-code/issues/39586).
+
+### `tools/list` fails with "Invalid session ID" right after a successful connect
+
+**Problem:** The connection shows as established and `initialize` succeeds, but a subsequent `tools/list` or tool call is rejected by the server as an invalid or missing session.
+
+**Cause:** Some MCP clients (including some Claude Code versions) do not echo the `Mcp-Session-Id` header returned by `initialize` on later requests, so session-aware servers (e.g. mcp-grafana, mcp-go) reject them.
+
+**Solution:**
+Nothing to configure — mcp-stdio captures `Mcp-Session-Id` from the `initialize` response itself and injects it on every subsequent request, regardless of what your MCP client does. If you still see this, the session may have genuinely expired server-side; restart your client to force a fresh `initialize`.
+
+See Claude Code [#70386](https://github.com/anthropics/claude-code/issues/70386).
+
+### Tools disappear after a brief network drop or reconnect
+
+**Problem:** Tools were listed fine, but after a short disconnect / reconnect they stop working or vanish from the list.
+
+**Cause:** The MCP session was lost (e.g., the backend server restarted, or the connection was interrupted); some Claude Code versions have also had regressions in Streamable HTTP reconnection handling.
+
+**Solution:**
+1. mcp-stdio automatically re-initializes the session on a `404` "session not found" response from the server.
+2. If tools remain unavailable, restart your MCP client (Claude Desktop / Claude Code) to force a fresh session.
+
+See Claude Code [#34498](https://github.com/anthropics/claude-code/issues/34498), [#38631](https://github.com/anthropics/claude-code/issues/38631).
 
 ## Authentication issues
 
@@ -110,12 +99,12 @@ See Claude Code [#42470](https://github.com/anthropics/claude-code/issues/42470)
 
 **Problem:** You set `--bearer-token` or `MCP_BEARER_TOKEN`, but the server reports it as missing or invalid.
 
-**Cause:** Unlikely — mcp-stdio adds the token to every request. More likely the server is looking for the token in the wrong place (e.g., a query parameter instead of the `Authorization` header).
+**Cause:** mcp-stdio attaches the token to the `Authorization` header on every outbound request; a rejection is more likely one of: an incorrect or expired token, or the server expecting the credential somewhere other than the `Authorization` header (e.g. a query parameter or custom header).
 
 **Solution:**
-1. Enable verbose logging by running mcp-stdio in the foreground and checking stderr for the requests being sent.
-2. Verify your token is correct and not expired.
-3. Check the server's authentication docs to confirm it expects an `Authorization: Bearer` header.
+1. Verify your token is correct and not expired.
+2. Check the server's authentication docs to confirm it expects an `Authorization: Bearer` header — if it expects a different header, pass it explicitly with `-H 'Header-Name: value'`.
+3. Run mcp-stdio in the foreground and check stderr; connection and retry diagnostics are printed there.
 
 ### OAuth scope not being honored
 
@@ -124,9 +113,9 @@ See Claude Code [#42470](https://github.com/anthropics/claude-code/issues/42470)
 **Cause:** The authorization server may have rejected your requested scope and granted a smaller one.
 
 **Solution:**
-1. Check what scope was actually granted. Look for the `scope` field in the server's token response (printed in mcp-stdio's logs if verbose).
+1. Check the authorization server's own logs or admin console for the scope it actually granted; mcp-stdio does not currently print the granted scope itself.
 2. If the server downgraded your scope, check the authorization server's policy or contact the server operator.
-3. Some servers support **step-up authorization** — if a tool requires a broader scope, it returns `403 insufficient_scope` with the required scopes listed. mcp-stdio re-authorizes automatically for the union of granted and required scopes.
+3. Some servers support **step-up authorization**: if a tool call needs a broader scope, the server returns `403 insufficient_scope` with the required scopes listed, and mcp-stdio automatically re-authorizes for the union of the granted and required scopes (RFC 9470), then retries the call. Note that some MCP clients do not automatically retry a tool call after mcp-stdio completes a step-up in the background (Claude Code [#44652](https://github.com/anthropics/claude-code/issues/44652)) — if the call still reports an error, try it again once.
 
 ## Transport issues
 
@@ -141,10 +130,11 @@ See Claude Code [#42470](https://github.com/anthropics/claude-code/issues/42470)
    ```bash
    mcp-stdio --timeout-read 300 https://your-server.example.com/mcp
    ```
-2. Check if you are behind a corporate proxy and set proxy env vars:
+2. mcp-stdio honors standard proxy env vars:
    ```bash
    HTTPS_PROXY=http://proxy.example.com:8080 mcp-stdio --oauth https://your-server.example.com/mcp
    ```
+   (`NO_PROXY` is respected too — this is a case where using mcp-stdio's own HTTP client sidesteps a bug in some other MCP clients' built-in transports; see Claude Code [#34804](https://github.com/anthropics/claude-code/issues/34804).)
 3. Test connectivity manually:
    ```bash
    curl -v https://your-server.example.com/mcp
@@ -161,7 +151,7 @@ See Claude Code [#42470](https://github.com/anthropics/claude-code/issues/42470)
    ```bash
    curl -v https://your-server.example.com/mcp
    ```
-2. If curl works but mcp-stdio fails, enable debug logging in mcp-stdio (check stderr).
+2. If curl works but mcp-stdio fails, run mcp-stdio in the foreground and check stderr for the underlying error.
 3. If the certificate is self-signed and you trust the server:
    - On macOS: Add the cert to your system keychain.
    - On Linux: Set `SSL_CERT_FILE` env var pointing to your CA bundle.
@@ -169,12 +159,12 @@ See Claude Code [#42470](https://github.com/anthropics/claude-code/issues/42470)
 
 ### SSE stream drops mid-request
 
-**Problem:** You are using a legacy SSE server (`--transport sse`), and long tool calls hang forever.
+**Problem:** You are using a legacy SSE server (`--transport sse`), and a tool call was in flight when the connection dropped.
 
-**Cause:** The SSE GET stream dropped mid-reply, and the client never received the response.
+**Cause:** The SSE GET stream disconnected while one or more requests were still awaiting their reply.
 
 **Solution:**
-mcp-stdio automatically reconnects on disconnect, but in-flight requests are lost. This is a limitation of the SSE transport. If possible, upgrade the server to use Streamable HTTP (the current MCP spec).
+Nothing to configure — mcp-stdio reconnects automatically and synthesizes a JSON-RPC error ("SSE stream disconnected before response arrived; please retry") for every request that was in flight when the stream dropped, instead of leaving your client hanging forever. Just retry the call once you see the error. This mirrors the failure mode reported in Claude Code [#60061](https://github.com/anthropics/claude-code/issues/60061); if possible, prefer upgrading the server to Streamable HTTP (the current MCP spec), which does not have this failure mode at all.
 
 ## Headless / SSH environment
 
@@ -191,14 +181,12 @@ mcp-stdio --oauth-device https://your-server.example.com/mcp
 
 This prints a user code (e.g., `ABCD-1234`). Open it in your browser on any device and confirm. After that, mcp-stdio completes the OAuth flow on the SSH box without needing a local display.
 
-See Claude Code [#34804](https://github.com/anthropics/claude-code/issues/34804).
-
 ## Still stuck?
 
 1. Run mcp-stdio with `--check` to validate connectivity before adding it to your client config:
    ```bash
    mcp-stdio --check --oauth https://your-server.example.com/mcp
    ```
-2. Check stderr for detailed error messages and issue references.
+2. Check stderr for detailed error messages.
 3. Search [GitHub Issues](https://github.com/shigechika/mcp-stdio/issues) for your error.
 4. If all else fails, [file an issue](https://github.com/shigechika/mcp-stdio/issues/new) with the full command and error output.


### PR DESCRIPTION
## Summary

The Troubleshooting and Reference pages added in a prior direct-to-main change (bypassing the branch/PR/`/review` workflow — an outside tool pushed straight to `main`) contained several factual errors, found while auditing the content against the actual code and GitHub issue history:

**Troubleshooting.md/.ja.md**
- 5 of 6 GitHub issue citations pointed at real-but-unrelated issues (verified with `gh issue view` against the actual titles and against WORKAROUNDS.md's existing citations). One (`#242`) linked `anthropics/claude-code` when the code's own `#242` reference is this repo's own issue.
- The SSE-stream-drop section described the old hang behavior; it now reflects the synthesized-error fix shipped in v0.25.1 (#272/#282).
- Re-attributed sections to citations that actually match: `#39586` (pagination), `#70386` (`Mcp-Session-Id` not echoed), `#34498`/`#38631` (session lost), `#44652` (step-up retry), `#34804` (`NO_PROXY`), `#53267`/`#65036` (proactive refresh), `#60061` (SSE drop).
- Dropped a couple of citations that didn't map to any real tracked issue (e.g. "browser doesn't open") rather than inventing one.

**Reference.md/.ja.md**
- Removed a fabricated exit code (`2` = "OAuth timeout or user cancelled" — the code never calls `sys.exit(2)`; that code is argparse's own usage-error exit). Documented the real codes: `0`/`1`/`2`/`130`.
- Fixed `--oauth-scope` — described as "(repeatable)" but it's a single string flag (space-separated multiple scopes in one value).
- Removed unfounded logging claims ("query strings redacted", "verbose output") and replaced with what the code actually does (a single `[mcp-stdio]`-prefixed relay log plus bare `error:`/`warning:` startup messages; no verbose mode exists).
- Fixed the `Retry-After` RFC citation from RFC 7230 to RFC 9110 §10.2.3, matching the code and WORKAROUNDS.md.
- Adjusted the top-level MCP spec citation — 2025-11-25 only applies to the optional Client ID Metadata Documents extension; the transport in general use negotiates 2025-06-18.

The scaffold work itself (new Troubleshooting/Reference pages, nav wiring, CI caching) is a good addition — this PR only corrects the content.

## Test plan

- [x] `mkdocs build --strict` passes (en + ja)
- [x] Every GitHub issue citation verified against its real title via `gh issue view`
- [x] Exit codes and logging behavior verified by grepping `sys.exit(` / `print(...stderr` across `cli.py`, `relay.py`, `server.py`, `oauth.py`
- [ ] `/review` this PR before merge