### PR TITLE
docs: add headless login (device flow) guide

### DIFF
--- a/docs/guides/connect-remote.ja.md
+++ b/docs/guides/connect-remote.ja.md
@@ -66,7 +66,7 @@ OAuth ログイン、トークン交換、MCP `initialize` の往復——そし
 |---|---|
 | OAuth なし、静的 Bearer トークン | `MCP_BEARER_TOKEN=… mcp-stdio https://…/mcp` |
 | スコープを追加したい | `--oauth-scope "openid offline_access mcp:tools"` |
-| このマシンにブラウザがない（SSH 先、コンテナ） | `--oauth-device` — 手元のスマホ / PC でユーザーコードを入力してログイン |
+| このマシンにブラウザがない（SSH 先、コンテナ） | `--oauth-device` — [ヘッドレスログイン](device-flow.ja.md)を参照 |
 | サーバーが OIDC の `id_token` を要求する（Google IAP、AWS） | `--oauth-use-id-token` |
 | legacy SSE サーバー（2024-11-05 トランスポート） | `--transport sse` |
 | 社内プロキシ | 標準の `HTTPS_PROXY` / `NO_PROXY` 環境変数がそのまま効きます |

--- a/docs/guides/connect-remote.md
+++ b/docs/guides/connect-remote.md
@@ -66,7 +66,7 @@ itself expires or is revoked.
 |---|---|
 | Static bearer token, no OAuth | `MCP_BEARER_TOKEN=… mcp-stdio https://…/mcp` |
 | Extra scopes | `--oauth-scope "openid offline_access mcp:tools"` |
-| No browser on this machine (SSH box, container) | `--oauth-device` — login happens on your phone/laptop via a user code |
+| No browser on this machine (SSH box, container) | `--oauth-device` — see [Headless login](device-flow.md) |
 | The server insists on the OIDC `id_token` (Google IAP, AWS) | `--oauth-use-id-token` |
 | Legacy SSE server (2024-11-05 transport) | `--transport sse` |
 | Corporate proxy | honored via standard `HTTPS_PROXY` / `NO_PROXY` env vars |

--- a/docs/guides/device-flow.ja.md
+++ b/docs/guides/device-flow.ja.md
@@ -1,0 +1,96 @@
+# ヘッドレスログイン（デバイスフロー）
+
+ゴール：ブラウザのないマシン——SSH先、コンテナ、CIランナー——で
+mcp-stdio を認証する。ブラウザを持つ別のデバイス上で短いコードを
+確認するだけで完了します。
+
+## 1. `--oauth-device` で実行
+
+```bash
+mcp-stdio --oauth-device https://mcp.example.com/mcp
+```
+
+mcp-stdio は stderr に以下を表示します：
+
+```
+Device authorization required:
+  Open: https://mcp.example.com/device?user_code=ABCD-1234
+  Code (verify it matches): ABCD-1234
+
+Waiting for authorization (giving up in 120s)...
+```
+
+## 2. 別のデバイスで承認
+
+表示された URL を開きます——スマホでもラップトップでも、ブラウザが
+あれば何でも構いません。ログインし、コードが一致することを確認して
+承認してください。mcp-stdio はバックグラウンドでトークンエンドポイント
+をポーリングしており、承認され次第すぐに処理が完了します。ヘッドレス側
+のマシンで他に何かする必要はありません。
+
+## 3. クライアントに追加
+
+[ブラウザフロー](connect-remote.ja.md)と同じ要領で、`--oauth` を
+`--oauth-device` に置き換えるだけです：
+
+=== "Claude Desktop"
+
+    `claude_desktop_config.json`：
+
+    ```json
+    {
+      "mcpServers": {
+        "my-remote-server": {
+          "command": "mcp-stdio",
+          "args": ["--oauth-device", "https://mcp.example.com/mcp"]
+        }
+      }
+    }
+    ```
+
+=== "Claude Code"
+
+    ```bash
+    claude mcp add my-remote-server -- mcp-stdio --oauth-device https://mcp.example.com/mcp
+    ```
+
+トークンはブラウザフローと同じ `~/.config/mcp-stdio/tokens.json` に
+保存されます——サーバーURLごとに一度ログインすれば、都合の良い場所から
+実行して構わず、以後はすべてのターミナル・セッションで共有されます。
+
+## 承認できるのは `--oauth-timeout` 秒だけ
+
+認可サーバーはもっと長いデバイスコードの有効期限を提示してくることが
+ありますが、mcp-stdio は実際の待ち時間を `--oauth-timeout`
+（デフォルト **120秒**）で常に上限クランプします。これでは短すぎる
+場合——デバイスの切り替えに時間がかかる、コードを手入力するなど——
+延長してください：
+
+```bash
+mcp-stdio --oauth-device --oauth-timeout 600 https://mcp.example.com/mcp
+```
+
+## 時間内に承認しなかった場合
+
+stderr に `Device authorization timed out. Please restart and try
+again.` と表示され、終了コードは `1` です。単純にコマンドを再実行
+してください——毎回新しいデバイスコードが要求されます。承認画面で
+明示的に拒否した場合はタイムアウトを待たずに即座に失敗します：
+`Device flow failed: access_denied`。
+
+## トラブルシュートの早見
+
+- **サーバーがデバイスフローに対応していない** ——
+  `Server does not support Device Authorization Grant (no
+  device_authorization_endpoint in metadata). Use --oauth for
+  browser-based flow instead.` 認可サーバー自身が RFC 8628 に対応して
+  いる必要があります。mcp-stdio 側だけでは追加できません。
+- **Dynamic Client Registration に非対応** ——
+  `Server does not support dynamic client registration. Provide a
+  --client-id or --client-metadata-url instead.` 事前にサーバー運用者
+  にクライアント登録を依頼して `--client-id` を渡すか、
+  [Client ID Metadata Document](../reference.ja.md#oauth-21-openid-connect)
+  をホストして `--client-metadata-url` を渡してください。
+
+全フラグは `mcp-stdio --help` か
+[README](https://github.com/shigechika/mcp-stdio#readme) へ。

--- a/docs/guides/device-flow.md
+++ b/docs/guides/device-flow.md
@@ -1,0 +1,94 @@
+# Headless login (device flow)
+
+Goal: authenticate mcp-stdio on a machine with no browser — an SSH box, a
+container, a CI runner — by confirming a short code on any other device
+that does have one.
+
+## 1. Run with `--oauth-device`
+
+```bash
+mcp-stdio --oauth-device https://mcp.example.com/mcp
+```
+
+mcp-stdio prints to stderr:
+
+```
+Device authorization required:
+  Open: https://mcp.example.com/device?user_code=ABCD-1234
+  Code (verify it matches): ABCD-1234
+
+Waiting for authorization (giving up in 120s)...
+```
+
+## 2. Confirm on any other device
+
+Open the printed URL — phone, laptop, whatever has a browser — log in,
+check the code matches, and approve. mcp-stdio polls the token endpoint
+in the background and returns as soon as you approve; there is nothing
+else to do on the headless box.
+
+## 3. Add it to your client
+
+Same as [the browser flow](connect-remote.md), just swap `--oauth` for
+`--oauth-device`:
+
+=== "Claude Desktop"
+
+    `claude_desktop_config.json`:
+
+    ```json
+    {
+      "mcpServers": {
+        "my-remote-server": {
+          "command": "mcp-stdio",
+          "args": ["--oauth-device", "https://mcp.example.com/mcp"]
+        }
+      }
+    }
+    ```
+
+=== "Claude Code"
+
+    ```bash
+    claude mcp add my-remote-server -- mcp-stdio --oauth-device https://mcp.example.com/mcp
+    ```
+
+Tokens land in the same `~/.config/mcp-stdio/tokens.json` used by the
+browser flow — log in once per server URL, from wherever is convenient,
+and every terminal and session shares the result.
+
+## You only have `--oauth-timeout` seconds to confirm
+
+The authorization server may advertise a much longer device-code
+lifetime, but mcp-stdio caps the actual wait at `--oauth-timeout`
+(default **120 s**) regardless. If that is too tight — switching devices
+takes a while, the code has to be copied by hand — raise it:
+
+```bash
+mcp-stdio --oauth-device --oauth-timeout 600 https://mcp.example.com/mcp
+```
+
+## What happens if you don't confirm in time
+
+`Device authorization timed out. Please restart and try again.` on
+stderr, exit code `1`. Just rerun the command — a fresh device code is
+requested each time. Explicitly denying the request on the confirmation
+page fails immediately instead of waiting out the timeout:
+`Device flow failed: access_denied`.
+
+## Troubleshooting quickies
+
+- **Server doesn't support device flow** —
+  `Server does not support Device Authorization Grant (no
+  device_authorization_endpoint in metadata). Use --oauth for
+  browser-based flow instead.` The authorization server itself has to
+  advertise RFC 8628 support; mcp-stdio cannot add it on the client side.
+- **No dynamic client registration** —
+  `Server does not support dynamic client registration. Provide a
+  --client-id or --client-metadata-url instead.` Register a client with
+  the server operator ahead of time and pass `--client-id`, or host a
+  [Client ID Metadata Document](../reference.md#oauth-21-openid-connect)
+  and pass `--client-metadata-url`.
+
+Every flag: `mcp-stdio --help`, or the
+[README](https://github.com/shigechika/mcp-stdio#readme).

--- a/docs/troubleshooting.ja.md
+++ b/docs/troubleshooting.ja.md
@@ -179,7 +179,7 @@ Claude Code の [#34498](https://github.com/anthropics/claude-code/issues/34498)
 mcp-stdio --oauth-device https://your-server.example.com/mcp
 ```
 
-ユーザーコード（例：`ABCD-1234`）が出力されます。任意のデバイスのブラウザでそれを開いて確認します。その後、mcp-stdio は SSH ボックスで OAuth フローを完了します（ローカルディスプレイは不要）。
+ユーザーコード（例：`ABCD-1234`）が出力されます。任意のデバイスのブラウザでそれを開いて確認します。その後、mcp-stdio は SSH ボックスで OAuth フローを完了します（ローカルディスプレイは不要）。承認までの制限時間やタイムアウト時の挙動を含む完全な手順は[ヘッドレスログイン](guides/device-flow.ja.md)を参照してください。
 
 ## それでも解決しない場合
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -179,7 +179,7 @@ Use the Device Authorization Grant (RFC 8628) instead:
 mcp-stdio --oauth-device https://your-server.example.com/mcp
 ```
 
-This prints a user code (e.g., `ABCD-1234`). Open it in your browser on any device and confirm. After that, mcp-stdio completes the OAuth flow on the SSH box without needing a local display.
+This prints a user code (e.g., `ABCD-1234`). Open it in your browser on any device and confirm. After that, mcp-stdio completes the OAuth flow on the SSH box without needing a local display. See [Headless login](guides/device-flow.md) for the full walkthrough, including how long you have to confirm and what happens if you don't.
 
 ## Still stuck?
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -61,6 +61,7 @@ nav:
   - Two ways to use it: modes.md
   - Guides:
       - Connect to a remote MCP server: guides/connect-remote.md
+      - Headless login (device flow): guides/device-flow.md
       - Publish your stdio server: guides/serve.md
   - Troubleshooting: troubleshooting.md
   - Reference: reference.md


### PR DESCRIPTION
## Summary
- Adds the one remaining guide item from #284's proposal: a dedicated walkthrough for `--oauth-device` (RFC 8628 Device Authorization Grant), covering the stderr prompt, the `--oauth-timeout` confirmation window (default 120s, independent of the server-advertised device-code lifetime), and the exact timeout/denial error messages.
- Adds `docs/guides/device-flow.md` + `.ja.md`, wires into `mkdocs.yml` nav under Guides.
- Cross-links from `connect-remote.md`'s Variations table (previously a one-line mention) and `troubleshooting.md`'s SSH section.

All wording verified against the actual `_run_device_authorization_flow` implementation and CLI help text in `src/mcp_stdio/oauth.py` / `cli.py` (error strings, `--oauth-timeout` clamping behavior, default 120s).

Closes #284

## Test plan
- [x] `mkdocs build --strict` passes (no broken links/anchors)
- [x] Cross-reference anchors (`reference.md#oauth-21-openid-connect`) verified against built HTML output