### PR TITLE
ci: bump actions/deploy-pages to v5

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -65,4 +65,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5


### PR DESCRIPTION
## Summary
- The PR #291 docs deploy run showed a deprecation annotation: `actions/deploy-pages@v4` still targets Node.js 20, which GitHub Actions runners now force onto Node 24 via a temporary compatibility shim (and warn about).
- `v5.0.0` release notes confirm: "Update Node.js version to 24.x" — bumping the pin removes the warning.

## Test plan
- [ ] Docs workflow run on this PR (build-only, deploy is push-only) passes
- [ ] After merge, the push-triggered deploy run shows no Node.js deprecation annotation