### PR TITLE
ci: bump actions/upload-pages-artifact to v5

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -48,7 +48,7 @@ jobs:
 
       - name: Upload Pages artifact
         if: github.event_name == 'push'
-        uses: actions/upload-pages-artifact@v4
+        uses: actions/upload-pages-artifact@v5
         with:
           path: site
 


### PR DESCRIPTION
## Summary
- Follow-up to #292: after bumping `deploy-pages` to v5, the docs deploy run still showed the same Node.js 20 deprecation warning, this time from `actions/upload-pages-artifact@v4`'s bundled `actions/upload-artifact` dependency.
- `v5.0.0` release notes: "Update upload-artifact action to version 7" — that dependency bump is what clears the warning. No breaking input/output changes (only additive `include-hidden-files` input, unused here).

## Test plan
- [ ] Docs workflow build passes on this PR
- [ ] After merge, the push-triggered deploy run shows no Node.js deprecation annotations at all