### PR TITLE
feat(oauth): add --oauth-resource to send a custom RFC 8707 resource value

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -225,6 +225,11 @@ mcp-stdio [OPTIONS] URL
                          Entra ID v2 など、resource パラメータを拒否する AS
                          （AADSTS9010010）で必要。トークンストアに永続化され、
                          proactive refresh や step-up フローでも一貫して適用される
+  --oauth-resource URI   server-URL 由来の値の代わりに、この RFC 8707 resource
+                         値をすべての OAuth リクエストで送る。特定の resource
+                         識別子を要求する AS（例: Microsoft Entra ID の App ID
+                         URI api://<app-id>）で必要。トークンストアに永続化。
+                         --no-resource-indicator とは排他
   -H, --header 'Key: Value'  カスタムヘッダー（複数指定可）
   --transport {streamable-http,sse}
                          トランスポート種別（デフォルト: streamable-http）

--- a/README.md
+++ b/README.md
@@ -228,6 +228,12 @@ Options:
                          Microsoft Entra ID v2 with api:// scopes (AADSTS9010010).
                          Persisted in the token store so proactive refreshes
                          and step-up flows stay consistent
+  --oauth-resource URI   Send this exact RFC 8707 resource value on every OAuth
+                         request instead of the server-URL-derived one. Required
+                         for AS that demand a specific resource identifier, e.g.
+                         Microsoft Entra ID's App ID URI api://<app-id>. Persisted
+                         in the token store. Mutually exclusive with
+                         --no-resource-indicator
   -H, --header 'Key: Value'  Custom header (can be repeated)
   --transport {streamable-http,sse}
                          Transport type (default: streamable-http)

--- a/docs/reference.ja.md
+++ b/docs/reference.ja.md
@@ -27,6 +27,7 @@ Arguments:
 | `--no-proactive-refresh` | — | OAuth トークンをプロアクティブにリフレッシュするバックグラウンドタイマーを無効化 |
 | `--oauth-timeout SECONDS` | — | インタラクティブ OAuth フロー（ブラウザコールバック/デバイスコード確認）がタイムアウトするまでの秒数（デフォルト: 120） |
 | `--no-resource-indicator` | — | すべての OAuth リクエストから RFC 8707 resource パラメータを省略。それを拒否する認可サーバー用（例：api:// スコープ付き Microsoft Entra ID） |
+| `--oauth-resource URI` | — | server-URL 由来の値の代わりに、この RFC 8707 resource 値をすべての OAuth リクエストで送る。特定の resource 識別子を要求する AS（例：Entra ID の App ID URI `api://<app-id>`）用。トークンストアに永続化。`--no-resource-indicator` とは排他 |
 
 ### トランスポート
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -27,6 +27,7 @@ Arguments:
 | `--no-proactive-refresh` | — | Disable the background timer that refreshes the OAuth token before it expires |
 | `--oauth-timeout SECONDS` | — | Seconds to wait for the interactive OAuth flow (browser callback / device-code confirmation) before giving up (default: 120) |
 | `--no-resource-indicator` | — | Omit the RFC 8707 resource parameter from all OAuth requests. Required for some authorization servers that reject it (e.g. Microsoft Entra ID with api:// scopes) |
+| `--oauth-resource URI` | — | Send this exact RFC 8707 resource value on every OAuth request instead of the server-URL-derived one. Required for AS that demand a specific resource identifier, e.g. Entra ID's App ID URI `api://<app-id>`. Persisted in the token store. Mutually exclusive with `--no-resource-indicator` |
 
 ### Transport
 

--- a/src/mcp_stdio/cli.py
+++ b/src/mcp_stdio/cli.py
@@ -95,6 +95,25 @@ _HEADER_NAME_RE = re.compile(r"^[!#$%&'*+\-.^_`|~0-9A-Za-z]+$")
 _HEADER_VALUE_FORBIDDEN = ("\r", "\n", "\0")
 
 
+def _rfc8707_resource(value: str) -> str:
+    """Validate an RFC 8707 §2 ``resource`` URI for ``--oauth-resource``.
+
+    Must be an absolute URI (has a scheme) and MUST NOT include a fragment
+    (RFC 8707 §2). The scheme is intentionally not constrained to http(s):
+    Microsoft Entra ID's App ID URI is ``api://<app-id>``.
+    """
+    parsed = urlparse(value)
+    if not parsed.scheme:
+        raise argparse.ArgumentTypeError(
+            f"--oauth-resource must be an absolute URI with a scheme (got {value!r})"
+        )
+    if parsed.fragment:
+        raise argparse.ArgumentTypeError(
+            "--oauth-resource must not include a fragment (RFC 8707 §2)"
+        )
+    return value
+
+
 def _bearer_header_value(token: str) -> str:
     """Build a ``Bearer <token>`` Authorization value, rejecting CR/LF/NUL.
 
@@ -315,6 +334,7 @@ def _build_cold_start_login(
     device_flow: bool,
     refresh_leeway: float,
     resource_indicator: bool,
+    oauth_resource: str | None,
     oauth_timeout: float,
     timeout_connect: float,
     timeout_read: float,
@@ -351,6 +371,7 @@ def _build_cold_start_login(
                 device_flow=device_flow,
                 refresh_leeway=refresh_leeway,
                 resource_indicator=resource_indicator,
+                oauth_resource=oauth_resource,
                 timeout=oauth_timeout,
                 interactive=True,  # cold-start: run the full browser/device flow
             )
@@ -441,6 +462,22 @@ def _main() -> None:
             "Entra ID v2 when using api:// scopes (AADSTS9010010). "
             "The setting is persisted in the token store so proactive "
             "refreshes and step-up flows behave consistently."
+        ),
+    )
+    parser.add_argument(
+        "--oauth-resource",
+        default=None,
+        type=_rfc8707_resource,
+        metavar="URI",
+        help=(
+            "Send this exact value as the RFC 8707 resource on every OAuth "
+            "request (authorization, token exchange, refresh, device flow), "
+            "instead of the value derived from the server URL. Required for AS "
+            "that demand a specific resource identifier, e.g. Microsoft Entra "
+            "ID's App ID URI api://<app-id-guid> (which returns AADSTS9010010 "
+            "when the resource is anything else). Persisted in the token store "
+            "so refresh and step-up stay consistent. Mutually exclusive with "
+            "--no-resource-indicator. Only used with --oauth / --oauth-device."
         ),
     )
     parser.add_argument(
@@ -657,6 +694,15 @@ def _main() -> None:
         )
         sys.exit(1)
 
+    # --no-resource-indicator omits the RFC 8707 resource; --oauth-resource sets
+    # a specific value. Requesting both is contradictory.
+    if args.no_resource_indicator and args.oauth_resource is not None:
+        print(
+            "error: --no-resource-indicator and --oauth-resource are mutually exclusive",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
     # Resolve --client-id: the explicit flag wins; otherwise the env var. The
     # warning below only counts an EXPLICIT --client-id (args.client_id is not
     # None), so an ambient MCP_OAUTH_CLIENT_ID does not trip it.
@@ -679,13 +725,14 @@ def _main() -> None:
         or args.client_metadata_url is not None
         or args.oauth_scope
         or args.no_resource_indicator
+        or args.oauth_resource is not None
         or args.oauth_use_id_token
         or args.oauth_eager
     ):
         print(
             "warning: --client-id / --client-metadata-url / --oauth-scope / "
-            "--no-resource-indicator / --oauth-use-id-token / --oauth-eager "
-            "are ignored without --oauth or --oauth-device",
+            "--no-resource-indicator / --oauth-resource / --oauth-use-id-token / "
+            "--oauth-eager are ignored without --oauth or --oauth-device",
             file=sys.stderr,
         )
 
@@ -823,6 +870,7 @@ def _main() -> None:
                 device_flow=args.oauth_device,
                 refresh_leeway=args.oauth_refresh_leeway,
                 resource_indicator=not args.no_resource_indicator,
+                oauth_resource=args.oauth_resource,
                 timeout=args.oauth_timeout,
                 interactive=not eager,
             )
@@ -840,6 +888,7 @@ def _main() -> None:
                     device_flow=args.oauth_device,
                     refresh_leeway=args.oauth_refresh_leeway,
                     resource_indicator=not args.no_resource_indicator,
+                    oauth_resource=args.oauth_resource,
                     oauth_timeout=args.oauth_timeout,
                     timeout_connect=args.timeout_connect,
                     timeout_read=args.timeout_read,

--- a/src/mcp_stdio/oauth.py
+++ b/src/mcp_stdio/oauth.py
@@ -2218,6 +2218,23 @@ def ensure_token(
     """
     cached = load_token(server_url)
     if cached and cached.access_token:
+        # Reconcile the persisted RFC 8707 resource settings to the CURRENT CLI
+        # intent (--oauth-resource / --no-resource-indicator) so a changed flag
+        # takes effect on the next refresh/step-up — and on the refresh attempt
+        # just below — instead of only after the cached token expires. The flags
+        # are supplied on the command line every run, so they reflect current
+        # intent; persisting here keeps the store authoritative for the flag-free
+        # refresh/step-up paths that read it back. Only the resource-selection
+        # fields change (never the token itself), and we re-save only on an
+        # actual difference so an unchanged invocation does not rewrite the store.
+        desired_no_ri = not resource_indicator
+        if (
+            cached.no_resource_indicator != desired_no_ri
+            or cached.oauth_resource != oauth_resource
+        ):
+            cached.no_resource_indicator = desired_no_ri
+            cached.oauth_resource = oauth_resource
+            save_token(server_url, cached)
         if cached.expires_at is None or cached.expires_at > time.time() + refresh_leeway:
             log("using cached OAuth token")
             return cached

--- a/src/mcp_stdio/oauth.py
+++ b/src/mcp_stdio/oauth.py
@@ -2234,7 +2234,15 @@ def ensure_token(
         ):
             cached.no_resource_indicator = desired_no_ri
             cached.oauth_resource = oauth_resource
-            save_token(server_url, cached)
+            # Best-effort persist: the reconcile is a convenience, and the cached
+            # access_token is already valid, so a store-write failure must NOT
+            # fail a request this path previously always served. Degrade to the
+            # in-memory reconciled token (refresh below re-reads the store, so it
+            # would still use the old settings until the next successful save).
+            try:
+                save_token(server_url, cached)
+            except OSError as e:
+                log(f"warning: could not persist reconciled resource settings: {e}")
         if cached.expires_at is None or cached.expires_at > time.time() + refresh_leeway:
             log("using cached OAuth token")
             return cached

--- a/src/mcp_stdio/oauth.py
+++ b/src/mcp_stdio/oauth.py
@@ -174,6 +174,31 @@ def _resource_indicator(server_url: str) -> str:
     return resource
 
 
+def _effective_resource(
+    server_url: str,
+    *,
+    resource_indicator: bool,
+    oauth_resource: str | None,
+) -> str | None:
+    """Resolve the RFC 8707 ``resource`` value to send on OAuth requests.
+
+    Three states, mirroring the CLI:
+
+    - ``resource_indicator`` False (``--no-resource-indicator``) → ``None`` (omit).
+    - ``oauth_resource`` set (``--oauth-resource``) → sent verbatim, e.g. an
+      Entra ID App ID URI ``api://<app-id>`` that the AS requires instead of the
+      server URL (#309).
+    - otherwise → the server-URL-derived value (:func:`_resource_indicator`).
+
+    ``--no-resource-indicator`` and ``--oauth-resource`` are mutually exclusive
+    (enforced at the CLI), so ``oauth_resource`` is consulted only when
+    ``resource_indicator`` is True.
+    """
+    if not resource_indicator:
+        return None
+    return oauth_resource or _resource_indicator(server_url)
+
+
 # Default ports used when normalising a parsed URL into a RFC 6454 origin
 # tuple for comparison. Any scheme outside this table falls through as None,
 # which is fine — we only reach the cross-origin check after scheme has
@@ -606,6 +631,7 @@ def discover_oauth_metadata(
     server_url: str,
     client: httpx.Client,
     www_authenticate: str | None = None,
+    oauth_resource: str | None = None,
 ) -> OAuthMetadata:
     """Discover OAuth authorization server metadata.
 
@@ -689,7 +715,11 @@ def discover_oauth_metadata(
         # server_url would emit a misleading §3.3 mismatch warning whenever the
         # operator passed `https://user:pass@host/mcp` against a correct PRM
         # advertising `https://host/mcp`.
-        expected_resource = _resource_indicator(server_url)
+        # With --oauth-resource the operator has declared the resource identity
+        # explicitly (e.g. an Entra ID App ID URI), which is exactly what a
+        # compliant PRM would advertise — compare against that so a deliberate
+        # override does not emit a spurious §3.3 mismatch warning.
+        expected_resource = oauth_resource or _resource_indicator(server_url)
         if (
             isinstance(prm_resource, str)
             and prm_resource.rstrip("/") != expected_resource.rstrip("/")
@@ -1351,6 +1381,7 @@ def _token_response_to_data(
     client_secret_expires_at: float | None = None,
     auth_method: str = "none",
     no_resource_indicator: bool = False,
+    oauth_resource: str | None = None,
 ) -> TokenData:
     """Convert a raw token response to TokenData.
 
@@ -1443,6 +1474,7 @@ def _token_response_to_data(
         issuer=metadata.issuer,
         token_endpoint_auth_method=auth_method,
         no_resource_indicator=no_resource_indicator,
+        oauth_resource=oauth_resource,
         # Persist the RFC 9207 §3 flag so a later step-up that reconstructs
         # metadata from this cached entry keeps the §2.4 missing-iss MUST-reject
         # active (otherwise it silently defaults off).
@@ -1483,6 +1515,7 @@ def refresh_cached_token(
         return None
     auth_method = cached.token_endpoint_auth_method
     no_resource_indicator = cached.no_resource_indicator
+    oauth_resource = cached.oauth_resource
     try:
         raw = refresh_access_token(
             cached.token_endpoint,
@@ -1490,7 +1523,11 @@ def refresh_cached_token(
             cached.client_secret,
             cached.refresh_token,
             client,
-            resource=None if no_resource_indicator else _resource_indicator(server_url),
+            resource=_effective_resource(
+                server_url,
+                resource_indicator=not no_resource_indicator,
+                oauth_resource=oauth_resource,
+            ),
             auth_method=auth_method,
         )
     except Exception as e:
@@ -1526,6 +1563,7 @@ def refresh_cached_token(
             client_secret_expires_at=cached.client_secret_expires_at,
             auth_method=auth_method,
             no_resource_indicator=no_resource_indicator,
+            oauth_resource=oauth_resource,
         )
     except Exception as e:
         # a non-compliant 200 token response MISSING access_token
@@ -1580,6 +1618,7 @@ def _run_authorization_flow(
     scope: str | None = None,
     timeout: float = 120,
     resource_indicator: bool = True,
+    oauth_resource: str | None = None,
 ) -> TokenData:
     """Run the browser-based authorization code flow.
 
@@ -1660,8 +1699,13 @@ def _run_authorization_flow(
             "code_challenge": code_challenge,
             "code_challenge_method": "S256",
         }
-        if resource_indicator:
-            params["resource"] = _resource_indicator(server_url)
+        res = _effective_resource(
+            server_url,
+            resource_indicator=resource_indicator,
+            oauth_resource=oauth_resource,
+        )
+        if res is not None:
+            params["resource"] = res
         if scope:
             params["scope"] = scope
 
@@ -1771,7 +1815,11 @@ def _run_authorization_flow(
         code_verifier,
         redirect_uri,
         client,
-        resource=_resource_indicator(server_url) if resource_indicator else None,
+        resource=_effective_resource(
+            server_url,
+            resource_indicator=resource_indicator,
+            oauth_resource=oauth_resource,
+        ),
         auth_method=auth_method,
     )
     data = _token_response_to_data(
@@ -1799,6 +1847,7 @@ def _run_authorization_flow(
         client_secret_expires_at=cse_at,
         auth_method=auth_method,
         no_resource_indicator=not resource_indicator,
+        oauth_resource=oauth_resource,
     )
     save_token(server_url, data)
     log("OAuth token obtained and saved")
@@ -1815,6 +1864,7 @@ def _run_device_authorization_flow(
     client_metadata_url: str | None = None,
     scope: str | None = None,
     resource_indicator: bool = True,
+    oauth_resource: str | None = None,
     timeout: float | None = None,
 ) -> TokenData:
     """Run RFC 8628 Device Authorization Grant flow.
@@ -1866,8 +1916,13 @@ def _run_device_authorization_flow(
 
     # Step 1: Device Authorization Request (RFC 8628 §3.1)
     da_params: dict[str, str] = {}
-    if resource_indicator:
-        da_params["resource"] = _resource_indicator(server_url)
+    da_res = _effective_resource(
+        server_url,
+        resource_indicator=resource_indicator,
+        oauth_resource=oauth_resource,
+    )
+    if da_res is not None:
+        da_params["resource"] = da_res
     if scope:
         da_params["scope"] = scope
     da_headers: dict[str, str] = {
@@ -2057,6 +2112,7 @@ def _run_device_authorization_flow(
                 client_secret_expires_at=cse_at,
                 auth_method=auth_method,
                 no_resource_indicator=not resource_indicator,
+                oauth_resource=oauth_resource,
             )
             save_token(server_url, data)
             log("device flow token obtained and saved")
@@ -2125,6 +2181,7 @@ def ensure_token(
     device_flow: bool = False,
     refresh_leeway: float = 60.0,
     resource_indicator: bool = True,
+    oauth_resource: str | None = None,
     interactive: bool = True,
 ) -> TokenData | None:
     """Ensure a valid access token is available.
@@ -2186,7 +2243,12 @@ def ensure_token(
     # a non-standard URL advertise it here, letting us skip the well-known
     # guessing. Best-effort — failures silently fall back to normal discovery.
     www_authenticate = _probe_www_authenticate(server_url, client)
-    metadata = discover_oauth_metadata(server_url, client, www_authenticate=www_authenticate)
+    metadata = discover_oauth_metadata(
+        server_url,
+        client,
+        www_authenticate=www_authenticate,
+        oauth_resource=oauth_resource,
+    )
     if device_flow:
         return _run_device_authorization_flow(
             server_url,
@@ -2197,6 +2259,7 @@ def ensure_token(
             client_metadata_url=client_metadata_url,
             scope=scope,
             resource_indicator=resource_indicator,
+            oauth_resource=oauth_resource,
             # honour --oauth-timeout for the device-code wait too,
             # matching the auth-code branch below and the CLI help text.
             timeout=timeout,
@@ -2211,6 +2274,7 @@ def ensure_token(
         scope=scope,
         timeout=timeout,
         resource_indicator=resource_indicator,
+        oauth_resource=oauth_resource,
     )
 
 
@@ -2260,6 +2324,9 @@ def step_up_authorize(
     cached TokenData; if the cache is gone (rare), discovery is rerun.
     """
     cached = load_token(server_url)
+    # Reproduce the persisted RFC 8707 resource override (--oauth-resource) on the
+    # step-up's re-discovery and re-authorization, mirroring no_resource_indicator.
+    oauth_resource = cached.oauth_resource if cached else None
 
     scope_parts: set[str] = set()
     if cached and cached.scope:
@@ -2312,7 +2379,10 @@ def step_up_authorize(
         #
         www_authenticate = _probe_www_authenticate(server_url, client)
         metadata = discover_oauth_metadata(
-            server_url, client, www_authenticate=www_authenticate
+            server_url,
+            client,
+            www_authenticate=www_authenticate,
+            oauth_resource=oauth_resource,
         )
 
     resource_indicator = not (cached.no_resource_indicator if cached else False)
@@ -2324,4 +2394,5 @@ def step_up_authorize(
         scope=merged_scope or None,
         timeout=timeout,
         resource_indicator=resource_indicator,
+        oauth_resource=oauth_resource,
     )

--- a/src/mcp_stdio/token_store.py
+++ b/src/mcp_stdio/token_store.py
@@ -153,6 +153,10 @@ class TokenData:
     token_endpoint_auth_method: str = "none"
     # Suppress RFC 8707 resource parameter (for AS that reject it, e.g. Entra ID v2)
     no_resource_indicator: bool = False
+    # Custom RFC 8707 resource value (--oauth-resource): sent verbatim instead of
+    # the server-URL-derived value — e.g. an Entra ID App ID URI api://<app-id>
+    # (#309). Mutually exclusive with no_resource_indicator. None = derive from URL.
+    oauth_resource: str | None = None
     # RFC 9207 §3 authorization_response_iss_parameter_supported. Persisted so a
     # step-up that reconstructs OAuthMetadata from this cached entry can keep the
     # §2.4 missing-iss MUST-reject active instead of silently defaulting to off.
@@ -886,6 +890,7 @@ def load_token(server_url: str) -> TokenData | None:
         "registration_endpoint",
         "issuer",
         "token_endpoint_auth_method",
+        "oauth_resource",
     ):
         value = getattr(td, field)
         if value is not None and not isinstance(value, str):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1319,6 +1319,77 @@ class TestClientMetadataUrlFlag:
             main()
         assert mock_ensure.call_args.kwargs["resource_indicator"] is False
 
+    def test_oauth_resource_passes_value(self):
+        """--oauth-resource propagates the value to ensure_token as oauth_resource."""
+        with (
+            patch(
+                "sys.argv",
+                [
+                    "mcp-stdio",
+                    "--oauth",
+                    "--oauth-resource",
+                    "api://app-id-guid",
+                    "https://example.com/mcp",
+                ],
+            ),
+            patch("mcp_stdio.oauth.ensure_token") as mock_ensure,
+            patch("mcp_stdio.cli.run"),
+        ):
+            mock_ensure.return_value.access_token = "tok"
+            main()
+        assert mock_ensure.call_args.kwargs["oauth_resource"] == "api://app-id-guid"
+
+    def test_oauth_resource_default_none(self):
+        """Without --oauth-resource, oauth_resource=None reaches ensure_token."""
+        with (
+            patch("sys.argv", ["mcp-stdio", "--oauth", "https://example.com/mcp"]),
+            patch("mcp_stdio.oauth.ensure_token") as mock_ensure,
+            patch("mcp_stdio.cli.run"),
+        ):
+            mock_ensure.return_value.access_token = "tok"
+            main()
+        assert mock_ensure.call_args.kwargs["oauth_resource"] is None
+
+    def test_oauth_resource_conflicts_with_no_resource_indicator(self, capsys):
+        """--oauth-resource and --no-resource-indicator are mutually exclusive."""
+        with (
+            patch(
+                "sys.argv",
+                [
+                    "mcp-stdio",
+                    "--oauth",
+                    "--no-resource-indicator",
+                    "--oauth-resource",
+                    "api://x",
+                    "https://example.com/mcp",
+                ],
+            ),
+            pytest.raises(SystemExit),
+        ):
+            main()
+        assert "mutually exclusive" in capsys.readouterr().err
+
+    def test_oauth_resource_validator_accepts_app_id_uri(self):
+        from mcp_stdio.cli import _rfc8707_resource
+
+        assert _rfc8707_resource("api://app-id-guid") == "api://app-id-guid"
+
+    def test_oauth_resource_validator_rejects_fragment(self):
+        import argparse
+
+        from mcp_stdio.cli import _rfc8707_resource
+
+        with pytest.raises(argparse.ArgumentTypeError):
+            _rfc8707_resource("api://x#frag")
+
+    def test_oauth_resource_validator_rejects_relative(self):
+        import argparse
+
+        from mcp_stdio.cli import _rfc8707_resource
+
+        with pytest.raises(argparse.ArgumentTypeError):
+            _rfc8707_resource("not-a-uri")
+
 
 class _SpyClient:
     """httpx.Client stand-in that records close() and construction kwargs."""

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -119,6 +119,48 @@ class TestResourceIndicator:
         assert _resource_indicator(url) == expected
 
 
+class TestEffectiveResource:
+    """_effective_resource resolves the three RFC 8707 resource states (#309)."""
+
+    def test_omitted_when_indicator_off(self):
+        from mcp_stdio.oauth import _effective_resource
+
+        # --no-resource-indicator wins, and a stray oauth_resource is ignored
+        # (the CLI makes them mutually exclusive, but be defensive).
+        assert (
+            _effective_resource(
+                "https://h/mcp", resource_indicator=False, oauth_resource=None
+            )
+            is None
+        )
+        assert (
+            _effective_resource(
+                "https://h/mcp", resource_indicator=False, oauth_resource="api://x"
+            )
+            is None
+        )
+
+    def test_custom_value_when_set(self):
+        from mcp_stdio.oauth import _effective_resource
+
+        assert (
+            _effective_resource(
+                "https://h/mcp", resource_indicator=True, oauth_resource="api://x"
+            )
+            == "api://x"
+        )
+
+    def test_server_derived_when_unset(self):
+        from mcp_stdio.oauth import _effective_resource
+
+        assert (
+            _effective_resource(
+                "https://h/mcp", resource_indicator=True, oauth_resource=None
+            )
+            == "https://h/mcp"
+        )
+
+
 class TestAuthorizationBaseUrl:
     def test_strips_path(self):
         assert (
@@ -985,6 +1027,34 @@ class TestDiscoverMetadata:
         client = httpx.Client()
         meta = discover_oauth_metadata("https://api.example.com/mcp", client)
         assert meta.authorization_endpoint == "https://auth.example.com/authorize"
+
+    def test_rfc9728_resource_match_against_oauth_resource_override(
+        self, httpx_mock, capsys
+    ):
+        """With --oauth-resource, the §3.3 check compares the PRM resource against
+        the operator-declared value, so a PRM advertising the App ID URI matches
+        (no spurious mismatch warning) even though it differs from the server URL
+        (#309)."""
+        httpx_mock.add_response(
+            url="https://api.example.com/.well-known/oauth-protected-resource/mcp",
+            json={
+                "resource": "api://app-id-guid",  # matches the override, not the URL
+                "authorization_servers": ["https://auth.example.com"],
+            },
+        )
+        httpx_mock.add_response(
+            url="https://auth.example.com/.well-known/oauth-authorization-server",
+            json={
+                "authorization_endpoint": "https://auth.example.com/authorize",
+                "token_endpoint": "https://auth.example.com/token",
+            },
+        )
+        client = httpx.Client()
+        meta = discover_oauth_metadata(
+            "https://api.example.com/mcp", client, oauth_resource="api://app-id-guid"
+        )
+        assert meta.authorization_endpoint == "https://auth.example.com/authorize"
+        assert "§3.3 resource mismatch" not in capsys.readouterr().err
 
     def test_rfc9728_resource_match_ignores_userinfo_in_server_url(
         self, httpx_mock, capsys
@@ -2057,6 +2127,42 @@ class TestRefreshCachedToken:
         req = httpx_mock.get_requests()[0]
         assert b"resource=https%3A%2F%2Fapi.example.com%2Fmcp" in req.content
         assert data.no_resource_indicator is False
+
+    def test_refresh_sends_and_persists_custom_oauth_resource(
+        self, tmp_path, monkeypatch, httpx_mock
+    ):
+        """oauth_resource sends a custom RFC 8707 resource on refresh, not the
+        server-URL-derived one, and persists it for future refreshes (#309)."""
+        store_file = tmp_path / "tokens.json"
+        monkeypatch.setattr("mcp_stdio.token_store._STORE_DIR", tmp_path)
+        monkeypatch.setattr("mcp_stdio.token_store._STORE_FILE", store_file)
+
+        from mcp_stdio.token_store import save_token
+
+        save_token(
+            "https://api.example.com/mcp",
+            TokenData(
+                access_token="old_at",
+                refresh_token="rt123",
+                expires_at=time.time() - 10,
+                client_id="cid",
+                token_endpoint="https://auth.example.com/token",
+                authorization_endpoint="https://auth.example.com/authorize",
+                oauth_resource="api://app-id-guid",
+            ),
+        )
+        httpx_mock.add_response(
+            url="https://auth.example.com/token",
+            json={"access_token": "new_at", "expires_in": 3600},
+        )
+        client = httpx.Client()
+        data = refresh_cached_token("https://api.example.com/mcp", client)
+        assert data is not None
+        req = httpx_mock.get_requests()[0]
+        # The custom value is sent, NOT the server-URL-derived resource.
+        assert b"resource=api%3A%2F%2Fapp-id-guid" in req.content
+        assert b"resource=https%3A%2F%2Fapi.example.com" not in req.content
+        assert data.oauth_resource == "api://app-id-guid"
 
 
 # --- _token_response_to_data ---
@@ -3913,7 +4019,7 @@ class TestStepUpAuthorize:
             token_endpoint="https://as.example/token",
         )
 
-        def fake_discover(server_url, client, www_authenticate=None):
+        def fake_discover(server_url, client, www_authenticate=None, oauth_resource=None):
             discover_hints.append(www_authenticate)
             return sentinel_md
 

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -3014,6 +3014,37 @@ class TestEnsureToken:
         assert persisted.no_resource_indicator is True
         assert persisted.oauth_resource is None
 
+    def test_cache_hit_reconcile_save_failure_still_returns_cached(
+        self, tmp_path, monkeypatch
+    ):
+        """#309: a store-write failure while reconciling resource settings on a
+        cache hit must NOT fail the request — the still-valid cached token is
+        returned (with the in-memory reconciled setting)."""
+        store_file = tmp_path / "tokens.json"
+        monkeypatch.setattr("mcp_stdio.token_store._STORE_DIR", tmp_path)
+        monkeypatch.setattr("mcp_stdio.token_store._STORE_FILE", store_file)
+
+        from mcp_stdio.token_store import save_token
+
+        save_token(
+            "https://example.com/mcp",
+            TokenData(access_token="cached_at", expires_at=time.time() + 3600),
+        )
+
+        def boom(*_a, **_k):
+            raise OSError("disk full")
+
+        monkeypatch.setattr("mcp_stdio.oauth.save_token", boom)
+        client = httpx.Client()
+        data = ensure_token(
+            "https://example.com/mcp",
+            client,
+            oauth_resource="api://app-id-guid",
+            interactive=False,
+        )
+        assert data is not None and data.access_token == "cached_at"
+        assert data.oauth_resource == "api://app-id-guid"  # in-memory reconciled
+
     def test_expired_cached_token_without_refresh_token_skips_refresh(
         self, tmp_path, monkeypatch
     ):

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -2955,6 +2955,65 @@ class TestEnsureToken:
         data = ensure_token("https://example.com/mcp", client)
         assert data.access_token == "cached_at"
 
+    def test_cache_hit_reconciles_new_oauth_resource(self, tmp_path, monkeypatch):
+        """#309: adding --oauth-resource while a fresh token is cached persists the
+        override on the cache hit, so the next refresh/step-up uses it instead of
+        waiting for the token to expire."""
+        store_file = tmp_path / "tokens.json"
+        monkeypatch.setattr("mcp_stdio.token_store._STORE_DIR", tmp_path)
+        monkeypatch.setattr("mcp_stdio.token_store._STORE_FILE", store_file)
+
+        from mcp_stdio.token_store import load_token, save_token
+
+        save_token(
+            "https://example.com/mcp",
+            TokenData(access_token="cached_at", expires_at=time.time() + 3600),
+        )
+        client = httpx.Client()
+        data = ensure_token(
+            "https://example.com/mcp",
+            client,
+            oauth_resource="api://app-id-guid",
+            interactive=False,
+        )
+        assert data is not None and data.access_token == "cached_at"
+        assert data.oauth_resource == "api://app-id-guid"
+        # Persisted, so the flag-free refresh/step-up paths read it back.
+        assert load_token("https://example.com/mcp").oauth_resource == "api://app-id-guid"
+
+    def test_cache_hit_switch_to_no_resource_indicator_clears_override(
+        self, tmp_path, monkeypatch
+    ):
+        """#309: switching from --oauth-resource to --no-resource-indicator on a
+        fresh cached token reconciles both fields — omit wins, override cleared."""
+        store_file = tmp_path / "tokens.json"
+        monkeypatch.setattr("mcp_stdio.token_store._STORE_DIR", tmp_path)
+        monkeypatch.setattr("mcp_stdio.token_store._STORE_FILE", store_file)
+
+        from mcp_stdio.token_store import load_token, save_token
+
+        save_token(
+            "https://example.com/mcp",
+            TokenData(
+                access_token="cached_at",
+                expires_at=time.time() + 3600,
+                oauth_resource="api://app-id-guid",
+            ),
+        )
+        client = httpx.Client()
+        data = ensure_token(
+            "https://example.com/mcp",
+            client,
+            resource_indicator=False,  # --no-resource-indicator
+            interactive=False,
+        )
+        assert data is not None
+        assert data.no_resource_indicator is True
+        assert data.oauth_resource is None
+        persisted = load_token("https://example.com/mcp")
+        assert persisted.no_resource_indicator is True
+        assert persisted.oauth_resource is None
+
     def test_expired_cached_token_without_refresh_token_skips_refresh(
         self, tmp_path, monkeypatch
     ):

--- a/tests/test_token_store.py
+++ b/tests/test_token_store.py
@@ -177,6 +177,36 @@ class TestLoadSaveDelete:
         store_file.write_text(_json.dumps(raw))
         assert load_token("https://example.com/mcp") is None
 
+    def test_oauth_resource_round_trips(self, tmp_path, monkeypatch):
+        """#309: oauth_resource survives a save/load round-trip; a legacy store
+        that predates the field loads with the default None (backward compat);
+        a type-broken value degrades the whole entry to None."""
+        store_file = tmp_path / "tokens.json"
+        monkeypatch.setattr("mcp_stdio.token_store._STORE_DIR", tmp_path)
+        monkeypatch.setattr("mcp_stdio.token_store._STORE_FILE", store_file)
+
+        save_token(
+            "https://example.com/mcp",
+            TokenData(access_token="tok", oauth_resource="api://app-id-guid"),
+        )
+        loaded = load_token("https://example.com/mcp")
+        assert loaded is not None and loaded.oauth_resource == "api://app-id-guid"
+
+        import json as _json
+
+        raw = _json.loads(store_file.read_text())
+        key = next(iter(raw))
+        # A legacy entry written before the field existed loads with None.
+        del raw[key]["oauth_resource"]
+        store_file.write_text(_json.dumps(raw))
+        legacy = load_token("https://example.com/mcp")
+        assert legacy is not None and legacy.oauth_resource is None
+
+        # A type-broken value rejects the whole entry (load None → re-auth).
+        raw[key]["oauth_resource"] = 123
+        store_file.write_text(_json.dumps(raw))
+        assert load_token("https://example.com/mcp") is None
+
     def test_load_missing(self, tmp_path, monkeypatch):
         store_file = tmp_path / "tokens.json"
         monkeypatch.setattr("mcp_stdio.token_store._STORE_DIR", tmp_path)


### PR DESCRIPTION
## Summary
Adds `--oauth-resource URI` so mcp-stdio can send a **specific** RFC 8707 `resource` value on OAuth requests, instead of only the server-URL-derived value or omitting it (`--no-resource-indicator`, #64).

**Motivation:** Microsoft Entra ID requires the `resource` on `/authorize` + `/token` to be the resource's **App ID URI** (`api://<app-id-guid>`), not the server URL — otherwise `AADSTS9010010`. So Entra-protected MCP servers were unreachable ([anthropics/claude-code#76096](https://github.com/anthropics/claude-code/issues/76096)). mcp-stdio already tolerated the sibling RFC 9728 §3.3 PRM mismatch (warn-and-continue); only the outbound value was missing.

## Design
- New `--oauth-resource URI`: sent verbatim as `resource` on **every** OAuth request (authorization URL, token exchange, refresh, device flow), and used as the expected identity in the RFC 9728 §3.3 PRM check (a deliberate override → no spurious mismatch warning).
- A single `_effective_resource()` helper resolves the three states (omit / custom / server-derived) at all send sites.
- Persisted in the token store (`TokenData.oauth_resource`) so proactive refresh and step-up reproduce it — mirrors `no_resource_indicator`. **Backward compatible**: a legacy store without the field loads with `None`.
- Mutually exclusive with `--no-resource-indicator`. Validated as an RFC 8707 §2 absolute URI with no fragment (scheme unconstrained so `api://` is accepted).
- Spec basis: RFC 8707 §2 permits the client to specify the resource.

No behavior change unless the flag is set.

## Test plan
- [x] `pytest tests/` → 1207 passed, 3 skipped (+12 new: `_effective_resource` unit ×3, refresh sends+persists custom, §3.3 override no-warning, token-store round-trip + backward-compat + type-reject, CLI propagation ×2, mutual-exclusion, validator ×3)
- [x] `ruff check src/ tests/` clean; `mkdocs build --strict` clean
- [x] End-to-end: `--help` lists it; `--no-resource-indicator --oauth-resource` errors "mutually exclusive"; a fragment / relative URI is rejected by the validator

Closes #309