### PR TITLE
test: synchronize POST thread in flaky SSE handshake test

### DIFF
--- a/tests/test_relay.py
+++ b/tests/test_relay.py
@@ -4243,26 +4243,38 @@ class TestCheckConnectionSse:
     )
 
     def test_sse_handshake_success(self, httpx_mock):
-        """endpoint event → POST initialize → response on the stream → True."""
-        # The GET stream carries the endpoint bootstrap and then the
-        # initialize response (legacy SSE delivers POST responses on the
-        # stream, not in the POST body).
+        """endpoint event → POST initialize → response on the stream → True.
+
+        The GET stream holds the INIT_RESULT event until the endpoint POST has
+        been observed, so the mocked POST is deterministically requested before
+        check_connection returns and closes the client. Without this, the reader
+        thread could reach INIT_RESULT and return before the background POST
+        thread's request landed — leaving the POST 'mocked but not requested'
+        and `len(posts) == 1` failing (a thread-scheduling race that surfaced
+        reliably on the Python 3.14 runner; same class as #300/#301). Legacy SSE
+        delivers POST responses on the stream, not in the POST body."""
+        post_attempted = threading.Event()
+
+        def sse_gen():
+            yield b"event: endpoint\ndata: /messages?sid=xyz\n\n"
+            post_attempted.wait(timeout=3)
+            yield f"event: message\ndata: {self._INIT_RESULT}\n\n".encode()
+
         httpx_mock.add_response(
             url=self.SSE_URL,
             method="GET",
-            stream=IteratorStream(
-                [
-                    b"event: endpoint\ndata: /messages?sid=xyz\n\n",
-                    f"event: message\ndata: {self._INIT_RESULT}\n\n".encode(),
-                ]
-            ),
+            stream=IteratorStream(sse_gen()),
             headers={"content-type": "text/event-stream"},
         )
-        httpx_mock.add_response(
-            url="https://example.com/messages?sid=xyz",
-            method="POST",
-            status_code=202,
+
+        def on_post(request: httpx.Request) -> httpx.Response:
+            post_attempted.set()
+            return httpx.Response(status_code=202)
+
+        httpx_mock.add_callback(
+            on_post, url="https://example.com/messages?sid=xyz", method="POST"
         )
+
         assert (
             check_connection(self.SSE_URL, dict(self.HEADERS), transport="sse")
             is True

--- a/tests/test_relay.py
+++ b/tests/test_relay.py
@@ -4257,8 +4257,13 @@ class TestCheckConnectionSse:
 
         def sse_gen():
             yield b"event: endpoint\ndata: /messages?sid=xyz\n\n"
-            post_attempted.wait(timeout=3)
-            yield f"event: message\ndata: {self._INIT_RESULT}\n\n".encode()
+            # Release the result ONLY once the POST has actually been observed.
+            # If it is somehow not seen within the timeout, do not yield the
+            # result — let the stream end so check_connection returns False and
+            # the test fails deterministically, rather than yielding INIT_RESULT
+            # early and reintroducing the race this guard exists to remove.
+            if post_attempted.wait(timeout=3):
+                yield f"event: message\ndata: {self._INIT_RESULT}\n\n".encode()
 
         httpx_mock.add_response(
             url=self.SSE_URL,


### PR DESCRIPTION
## Summary
`TestCheckConnectionSse::test_sse_handshake_success` fails **reliably on the Python 3.14 runner** (passes 3.10–3.13), blocking merges. It is a **test thread-scheduling race, not a relay bug**.

`_check_connection_sse` reads the `endpoint` event, spawns a daemon thread to POST `initialize`, then keeps reading the same stream and returns `True` on the `INIT_RESULT` message. The test's mock delivered `endpoint` + `INIT_RESULT` **unconditionally** (not gated on the POST), so the reader thread could reach `INIT_RESULT` and return — closing the client — before the daemon POST thread's request landed against `httpx_mock`, leaving the POST "mocked but not requested" and `assert len(posts) == 1` failing.

**Why it's not a production bug:** a real SSE server sends the initialize result on the stream **only in response to the POST**, so a result implies the POST happened. The mock broke that invariant. Verified against `_check_connection_sse` (relay.py).

## Fix
Hold the `INIT_RESULT` event until the endpoint POST is observed — a `threading.Event` set from an `add_callback` POST handler — the exact pattern #301 applied to the sibling `test_sse_server_notification_before_response_is_skipped`. No production code changes.

## Test plan
- [x] Fixed test passes 5/5 locally; whole `TestCheckConnectionSse` class green
- [x] `ruff check tests/test_relay.py` clean

Unblocks #310 (once merged, #310 rebases onto this).