### PR TITLE
ci: request Copilot review via workflow, skip release-please PRs

### DIFF
--- a/.github/workflows/copilot-review.yml
+++ b/.github/workflows/copilot-review.yml
@@ -1,0 +1,46 @@
+name: Request Copilot review
+
+# Automatically request a GitHub Copilot code review on new pull requests,
+# EXCEPT the release PRs that release-please keeps open. Copilot review is a
+# metered premium request, and a release PR is only a version bump plus a
+# generated CHANGELOG — reviewing it every release wastes credits with nothing
+# to catch.
+#
+# This replaces the repository ruleset "Copilot review for default branch".
+# A ruleset (or the equivalent repo setting) can only match on the PR's *base*
+# branch, so it cannot skip PRs by head branch — every PR into main, including
+# release-please's, gets reviewed. release-please PRs are also authored by a
+# real user (a PAT), not a bot, so they cannot be excluded by author either.
+# Moving the request into a workflow lets us gate on the head branch name.
+#
+# pull_request_target (not pull_request) is deliberate: on a fork PR the
+# pull_request token is read-only, so it could not request a reviewer, and
+# external contributions would silently lose Copilot review. pull_request_target
+# runs with the base repository's write token, so fork PRs are covered too. It
+# is safe here because this workflow never checks out or executes the PR's code
+# — it only passes the PR number to the API — so none of the usual
+# pull_request_target code-injection risks apply.
+
+on:
+  pull_request_target:
+    types: [opened, ready_for_review]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  request:
+    # Skip release-please PRs (credit saving) and drafts (reviewed once marked
+    # ready via the ready_for_review trigger above).
+    if: >-
+      github.event.pull_request.draft == false &&
+      !startsWith(github.event.pull_request.head.ref, 'release-please--')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Request review from Copilot
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh api --method POST \
+            "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/requested_reviewers" \
+            -f "reviewers[]=copilot-pull-request-reviewer[bot]"

--- a/.github/workflows/copilot-review.yml
+++ b/.github/workflows/copilot-review.yml
@@ -20,10 +20,15 @@ name: Request Copilot review
 # is safe here because this workflow never checks out or executes the PR's code
 # — it only passes the PR number to the API — so none of the usual
 # pull_request_target code-injection risks apply.
+#
+# The release-please skip is scoped to same-repo PRs: release-please only ever
+# creates branches in this repository, and on a fork the author controls
+# head.ref, so a fork PR named "release-please--…" must NOT be allowed to skip
+# review. Requiring head.repo == this repo closes that bypass.
 
 on:
   pull_request_target:
-    types: [opened, ready_for_review]
+    types: [opened, reopened, ready_for_review]
 
 permissions:
   pull-requests: write
@@ -31,10 +36,13 @@ permissions:
 jobs:
   request:
     # Skip release-please PRs (credit saving) and drafts (reviewed once marked
-    # ready via the ready_for_review trigger above).
+    # ready via the ready_for_review trigger above). The release-please match is
+    # scoped to same-repo branches so a fork PR cannot skip review by naming its
+    # branch "release-please--…".
     if: >-
       github.event.pull_request.draft == false &&
-      !startsWith(github.event.pull_request.head.ref, 'release-please--')
+      !(github.event.pull_request.head.repo.full_name == github.repository &&
+        startsWith(github.event.pull_request.head.ref, 'release-please--'))
     runs-on: ubuntu-latest
     steps:
       - name: Request review from Copilot


### PR DESCRIPTION
## What

Replaces the `Copilot review for default branch` **repository ruleset** with a workflow (`.github/workflows/copilot-review.yml`) that requests a Copilot code review on new PRs but **skips the release PRs release-please keeps open**.

## Why

Copilot code review is a metered premium request. A release-please PR is only a version bump + a generated `CHANGELOG.md`, so requesting Copilot on it every release wastes credits with nothing to catch.

A ruleset (or the equivalent repo setting) can only match on a PR's **base** branch, so it cannot skip PRs by head branch — every PR into `main`, including release-please's, gets reviewed. release-please PRs are also authored by a **PAT (a real user)**, not a bot, so they can't be excluded by author either. Moving the request into a workflow lets us gate on the head branch name (`release-please--…`).

## Design notes

- **`pull_request_target`, not `pull_request`**: on a fork PR the `pull_request` token is read-only and could not request a reviewer, so external contributions would silently lose Copilot review. `pull_request_target` runs with the base repo's write token. It is safe here because the workflow **never checks out or executes the PR's code** — it only passes the PR number to the API — so the usual `pull_request_target` code-injection risks do not apply.
- **release-please skip is scoped to same-repo PRs** (`head.repo.full_name == github.repository`): on `pull_request_target` a fork author controls `head.ref`, so a fork PR named `release-please--…` could otherwise bypass the review request. release-please only ever creates branches in this repo, so requiring same-repo closes that bypass. (Raised by Copilot's review.)
- `github.event.pull_request.head.ref` is used only in the `if:` expression, never in a `run:` shell command, so there is no command-injection path.
- Reviewer login `copilot-pull-request-reviewer[bot]` is the documented identifier for Copilot code review.

## Rollout

The `deletion` / `non_fast_forward` rules the ruleset also carried are already enforced by classic branch protection on `main` (`allow_deletions: false`, `allow_force_pushes: false`), so **deleting the ruleset loses no protection**. The ruleset is deleted **after this PR merges** — sequencing it that way avoids a window where neither the ruleset nor the (not-yet-merged) workflow requests a review.

The default `GITHUB_TOKEN` (with `pull-requests: write`) is used to request the reviewer; the first real PR after merge is the smoke test that the token is accepted for a Copilot review request. If it is not, fall back to a PAT.