### PR TITLE
docs: document --oauth-resource as an AADSTS9010010 remedy for Entra ID

### DIFF
--- a/docs/guides/connect-remote.ja.md
+++ b/docs/guides/connect-remote.ja.md
@@ -78,9 +78,10 @@ OAuth ログイン、トークン交換、MCP `initialize` の往復——そし
 
 - **ブラウザが開かない** — authorize URL は stderr に出力されています。
   手動で開いてください（クライアントの MCP ログに出ます）。
-- **Microsoft Entra ID で `AADSTS9010010`** — 一部の Entra ID 構成は
-  `resource` パラメータそのものを拒否します。`--no-resource-indicator` を
-  追加してください。詳細は[トラブルシューティング](../troubleshooting.ja.md#microsoft-entra-id-aadsts9010010)を参照。
+- **Microsoft Entra ID で `AADSTS9010010`** — 導出した `resource` が Entra の
+  期待するトークン audience と一致していません。App ID URI を
+  `--oauth-resource api://<app-id>` で送るか、`--no-resource-indicator` で
+  パラメータを落としてください。詳細は[トラブルシューティング](../troubleshooting.ja.md#microsoft-entra-id-aadsts9010010)を参照。
 - **昨日まで動いていたのに今日は `401`** — サーバー側で鍵のローテートや
   グラントの失効があったかもしれません。`~/.config/mcp-stdio/tokens.json`
   から該当サーバーのエントリを消して、再認可させてください。

--- a/docs/guides/connect-remote.md
+++ b/docs/guides/connect-remote.md
@@ -78,8 +78,10 @@ Every flag: `mcp-stdio --help`, or the
 
 - **Browser never opens** — the authorize URL is printed to stderr; open it
   manually (the client's MCP log shows it).
-- **`AADSTS9010010` on Microsoft Entra ID** — some Entra ID configurations
-  reject the `resource` parameter outright; add `--no-resource-indicator`.
+- **`AADSTS9010010` on Microsoft Entra ID** — the derived `resource` does not
+  match the token audience Entra expects. Send the App ID URI with
+  `--oauth-resource api://<app-id>`, or drop the parameter with
+  `--no-resource-indicator`.
   See [Troubleshooting](../troubleshooting.md#aadsts9010010-on-microsoft-entra-id).
 - **Worked yesterday, `401` today** — the server may have rotated its keys or
   revoked the grant. Delete the server's entry from

--- a/docs/troubleshooting.ja.md
+++ b/docs/troubleshooting.ja.md
@@ -48,14 +48,22 @@ rm ~/.config/mcp-stdio/tokens.json
 
 **問題：** `api://` スコープを使う Microsoft Entra ID 経由の接続で、認可が `AADSTS9010010`（audience 検証失敗）で失敗します。
 
-**原因：** 一部の Entra ID 構成は RFC 8707 の `resource` パラメータそのものを拒否します。
+**原因：** mcp-stdio は既定で RFC 8707 の `resource` パラメータをサーバー URL から導出します。Entra ID はその値をトークンの audience として検証するため、アプリ登録が期待する値と一致しないと拒否します。
 
-**解決方法：**
-```bash
-mcp-stdio --oauth --no-resource-indicator https://your-server.example.com/mcp
-```
+**解決方法：** Entra ID のアプリ登録に合わせて対処を選びます。
 
-これにより、認可・トークン交換・リフレッシュ・デバイスフローのすべての OAuth リクエストから `resource` パラメータが省略されます。
+- **Entra が特定の App ID URI を期待する場合**（最も一般的）— audience が一致するよう、その値をそのまま送ります：
+  ```bash
+  mcp-stdio --oauth --oauth-resource api://<app-id> https://your-server.example.com/mcp
+  ```
+  この値は認可・トークン交換・リフレッシュ・デバイスフローのすべての OAuth リクエストで使われ、トークンストアに永続化されます。
+
+- **Entra が `resource` パラメータそのものを拒否する場合** — 完全に省略します：
+  ```bash
+  mcp-stdio --oauth --no-resource-indicator https://your-server.example.com/mcp
+  ```
+
+2 つのフラグは排他です：`--oauth-resource` は特定の値を送り、`--no-resource-indicator` は何も送りません。
 
 ## ツールとリソースの問題
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -48,14 +48,22 @@ Some MCP clients have their own history of not re-invoking their auth header cal
 
 **Problem:** Authorization fails with `AADSTS9010010` ("audience validation failed") when connecting through Microsoft Entra ID with `api://` scopes.
 
-**Cause:** Some Entra ID configurations reject the RFC 8707 `resource` parameter outright.
+**Cause:** By default mcp-stdio derives the RFC 8707 `resource` parameter from the server URL. Entra ID validates that value as the token audience and rejects it when it does not match what the app registration expects.
 
-**Solution:**
-```bash
-mcp-stdio --oauth --no-resource-indicator https://your-server.example.com/mcp
-```
+**Solution:** pick the remedy that matches your Entra ID app registration.
 
-This omits the `resource` parameter from every OAuth request (authorization, token exchange, refresh, and device flow).
+- **Entra expects a specific App ID URI** (most common) — send it verbatim so the audience matches:
+  ```bash
+  mcp-stdio --oauth --oauth-resource api://<app-id> https://your-server.example.com/mcp
+  ```
+  The value is used on every OAuth request (authorization, token exchange, refresh, and device flow) and persisted in the token store.
+
+- **Entra rejects the `resource` parameter outright** — omit it entirely:
+  ```bash
+  mcp-stdio --oauth --no-resource-indicator https://your-server.example.com/mcp
+  ```
+
+The two flags are mutually exclusive: `--oauth-resource` sends a specific value, `--no-resource-indicator` sends none.
 
 ## Tool and resource issues
 


### PR DESCRIPTION
## What

Expands the `AADSTS9010010` troubleshooting entry (and the connect-remote guide's quick-reference bullet) to cover **`--oauth-resource`** as a remedy, in both EN and JA.

## Why

The troubleshooting section was written before `--oauth-resource` shipped (v0.27.0) and only offered `--no-resource-indicator` — which drops the RFC 8707 `resource` entirely. But the more common Entra ID failure is that Entra expects the `resource` to equal the app registration's **App ID URI** (`api://<app-id>`), not the server-URL-derived value mcp-stdio sends by default. That case is fixed by sending the right value with `--oauth-resource api://<app-id>`, not by omitting it.

Now both remedies are documented with guidance on which to use:

| Entra config | Flag |
|---|---|
| Expects a specific App ID URI (most common) | `--oauth-resource api://<app-id>` |
| Rejects the `resource` parameter outright | `--no-resource-indicator` |

Grounded in the scenario verified when `--oauth-resource` was implemented (#309, from anthropics/claude-code#76096).

## Files

- `docs/troubleshooting.md` / `.ja.md`
- `docs/guides/connect-remote.md` / `.ja.md`

Docs-only. `mkdocs build --strict` passes locally.