### PR TITLE
ci: fix Copilot review request (use `gh pr edit --add-reviewer @copilot`)

### DIFF
--- a/.github/workflows/copilot-review.yml
+++ b/.github/workflows/copilot-review.yml
@@ -48,7 +48,13 @@ jobs:
       - name: Request review from Copilot
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          gh api --method POST \
-            "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/requested_reviewers" \
-            -f "reviewers[]=copilot-pull-request-reviewer[bot]"
+          # The PR number is an integer, but pass it via env rather than
+          # interpolating into the run script, per the workflow-injection guard.
+          PR: ${{ github.event.pull_request.number }}
+        # Use `gh pr edit --add-reviewer @copilot`, NOT the REST
+        # requested_reviewers endpoint: that endpoint returns 200 but silently
+        # ignores the Copilot bot login, leaving the PR with no reviewer. The
+        # documented handle is @copilot, and gh resolves it via the GraphQL
+        # requestReviews mutation, which exits non-zero if it cannot — so a
+        # broken request fails the step loudly instead of no-op'ing green.
+        run: gh pr edit "$PR" --repo "${{ github.repository }}" --add-reviewer "@copilot"


### PR DESCRIPTION
## Bug

The workflow added in #313 **silently did nothing**. It requested the reviewer via the REST `requested_reviewers` endpoint with the login `copilot-pull-request-reviewer[bot]`. That endpoint returns **200 OK** but silently ignores the Copilot bot login — so no review was ever requested.

**Verified on #314** (first real PR after #313 merged):
- Workflow ran `pull_request_target` → `completed/success` (green)
- API response: `"requested_reviewers": []`
- Timeline: **no** `review_requested` event
- Contrast: #313 (via the old ruleset) shows `review_requested: Copilot`

So the workflow passed green while doing nothing — the worst failure mode.

## Fix

Use `gh pr edit <n> --add-reviewer @copilot`:
- `@copilot` is the documented handle ([GitHub CLI changelog, 2026-03-11](https://github.blog/changelog/2026-03-11-request-copilot-code-review-from-github-cli/)); the bot login does not resolve.
- `gh pr edit --add-reviewer` resolves it via the GraphQL `requestReviews` mutation and **exits non-zero** when it cannot (verified: exit 1 on an unresolvable login) — so a future breakage fails the step **loudly** instead of no-op'ing green.

**Verified working**: running `gh pr edit 314 --add-reviewer @copilot` produced `review_requested: Copilot` on #314 within seconds.

## Notes

- PR number passed via `env: PR` rather than interpolated into the `run:` script (workflow-injection guard); it is only an integer, but this keeps the pattern clean.
- `github.repository` is trusted context.