### PR TITLE
ci: request Copilot review with a PAT + verify it attaches

### DIFF
--- a/.github/workflows/copilot-review.yml
+++ b/.github/workflows/copilot-review.yml
@@ -74,9 +74,17 @@ jobs:
           set -euo pipefail
           gh pr edit "$PR" --repo "$REPO" --add-reviewer "@copilot"
           for attempt in 1 2 3; do
-            if gh api "repos/$REPO/issues/$PR/timeline" \
-                 --jq '.[] | select(.event=="review_requested") | .requested_reviewer.login' \
-               | grep -qi copilot; then
+            # --paginate: the review_requested we just added is the NEWEST event,
+            # and the timeline is returned oldest-first, so on a PR with many
+            # events it lands on the last page — page 1 alone would miss it.
+            # Capture the output and match with a bash test rather than piping
+            # into `grep -q`, whose early exit could SIGPIPE gh api and, under
+            # pipefail, flip the result to a false negative. `|| true` keeps a
+            # transient gh error from aborting the retry loop via set -e.
+            logins=$(gh api --paginate "repos/$REPO/issues/$PR/timeline?per_page=100" \
+                       --jq '.[] | select(.event=="review_requested") | .requested_reviewer.login' \
+                     || true)
+            if [[ "${logins,,}" == *copilot* ]]; then
               echo "Copilot review requested."
               exit 0
             fi

--- a/.github/workflows/copilot-review.yml
+++ b/.github/workflows/copilot-review.yml
@@ -13,13 +13,20 @@ name: Request Copilot review
 # real user (a PAT), not a bot, so they cannot be excluded by author either.
 # Moving the request into a workflow lets us gate on the head branch name.
 #
-# pull_request_target (not pull_request) is deliberate: on a fork PR the
-# pull_request token is read-only, so it could not request a reviewer, and
-# external contributions would silently lose Copilot review. pull_request_target
-# runs with the base repository's write token, so fork PRs are covered too. It
-# is safe here because this workflow never checks out or executes the PR's code
-# — it only passes the PR number to the API — so none of the usual
-# pull_request_target code-injection risks apply.
+# The request is made with a Copilot-enabled user PAT (secret
+# COPILOT_REVIEW_TOKEN), NOT the Actions GITHUB_TOKEN: github-actions[bot] has
+# no Copilot seat, so `gh pr edit --add-reviewer @copilot` returns success but
+# silently attaches nothing under GITHUB_TOKEN (verified on #316). The PAT must
+# be a fine-grained token owned by a user with Copilot access, scoped to this
+# repo, with Pull requests: read and write.
+#
+# pull_request_target (not pull_request) is deliberate on two counts: on a fork
+# PR the pull_request token is read-only AND its secrets are withheld, so the
+# PAT would be unavailable and external contributions would silently lose
+# Copilot review. pull_request_target exposes secrets and runs with write
+# access, so fork PRs are covered too. It is safe here because this workflow
+# never checks out or executes the PR's code — it only passes the PR number to
+# the API — so none of the usual pull_request_target code-injection risks apply.
 #
 # The release-please skip is scoped to same-repo PRs: release-please only ever
 # creates branches in this repository, and on a fork the author controls
@@ -30,8 +37,9 @@ on:
   pull_request_target:
     types: [opened, reopened, ready_for_review]
 
-permissions:
-  pull-requests: write
+# The default GITHUB_TOKEN is unused (the step authenticates with the PAT), so
+# it needs no permissions.
+permissions: {}
 
 jobs:
   request:
@@ -47,14 +55,32 @@ jobs:
     steps:
       - name: Request review from Copilot
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # The PR number is an integer, but pass it via env rather than
-          # interpolating into the run script, per the workflow-injection guard.
+          GH_TOKEN: ${{ secrets.COPILOT_REVIEW_TOKEN }}
+          # Pass PR number and repo via env rather than interpolating into the
+          # run script, per the workflow-injection guard. (Both are trusted —
+          # an integer and owner/repo — but this keeps the pattern uniform.)
           PR: ${{ github.event.pull_request.number }}
-        # Use `gh pr edit --add-reviewer @copilot`, NOT the REST
-        # requested_reviewers endpoint: that endpoint returns 200 but silently
-        # ignores the Copilot bot login, leaving the PR with no reviewer. The
-        # documented handle is @copilot, and gh resolves it via the GraphQL
-        # requestReviews mutation, which exits non-zero if it cannot — so a
-        # broken request fails the step loudly instead of no-op'ing green.
-        run: gh pr edit "$PR" --repo "${{ github.repository }}" --add-reviewer "@copilot"
+          REPO: ${{ github.repository }}
+        # Use `gh pr edit --add-reviewer @copilot` (the documented handle), NOT
+        # the REST requested_reviewers endpoint, which returns 200 but silently
+        # ignores the Copilot bot login. Even gh's request can attach nothing if
+        # the token lacks a Copilot seat, so afterwards confirm a Copilot
+        # review_requested event actually landed and fail loudly otherwise — a
+        # Copilot review that is already present (idempotent re-request) or one
+        # that has already been submitted still leaves this event, so the check
+        # is stable across re-fires. This turns a silent green no-op into a
+        # visible red.
+        run: |
+          set -euo pipefail
+          gh pr edit "$PR" --repo "$REPO" --add-reviewer "@copilot"
+          for attempt in 1 2 3; do
+            if gh api "repos/$REPO/issues/$PR/timeline" \
+                 --jq '.[] | select(.event=="review_requested") | .requested_reviewer.login' \
+               | grep -qi copilot; then
+              echo "Copilot review requested."
+              exit 0
+            fi
+            sleep 5
+          done
+          echo "::error::Copilot was not requested — COPILOT_REVIEW_TOKEN may lack Copilot access or be expired."
+          exit 1


### PR DESCRIPTION
## Why

The workflow shipped in #313/#315 **cannot work with the Actions GITHUB_TOKEN**. `github-actions[bot]` has no Copilot seat, so `gh pr edit --add-reviewer @copilot` returns **success (exit 0) but attaches nothing**.

**Verified on #316** (first fresh PR after #315 merged): the workflow ran `pull_request_target` → `completed/success`, output the PR URL, but produced **no `review_requested` event** and no reviewer. The identical command with my Copilot-enabled user token attaches Copilot within seconds (`review_requested: Copilot`). The differentiator is the token identity.

## Fix

1. **Authenticate with a Copilot-enabled user PAT** (`secrets.COPILOT_REVIEW_TOKEN`) instead of `GITHUB_TOKEN`.
2. **Verify the attach and fail loudly.** Since a token without a Copilot seat produces a silent green no-op, after the request the step confirms a Copilot `review_requested` event actually landed (timeline API, 3× 5 s retry for propagation) and `exit 1` with a `::error::` otherwise. No more green-while-doing-nothing.
3. `permissions: {}` — the default `GITHUB_TOKEN` is no longer used.

The verification is stable across re-fires: an idempotent re-request, or a review Copilot has already submitted, still leaves the `review_requested` event.

## ⚠️ Requires a secret before merge

This needs the repo secret **`COPILOT_REVIEW_TOKEN`** to exist:
- Fine-grained PAT, owner = a user with Copilot access, scoped to this repo, **Pull requests: Read and write**.

**Do not merge until the secret is set**, otherwise the next PR's run fails red (loudly, but pointlessly). Sequencing: create secret → merge → next PR validates.