### PR TITLE
docs: note the granted-scope log in the --oauth-scope reference

### DIFF
--- a/docs/reference.ja.md
+++ b/docs/reference.ja.md
@@ -20,7 +20,7 @@ Arguments:
 | `--oauth-device` | — | OAuth 2.1 デバイス認可グラント（RFC 8628、ヘッドレス） |
 | `--client-id ID` | `MCP_OAUTH_CLIENT_ID` | 事前登録済み OAuth クライアント ID（Dynamic Client Registration をスキップ） |
 | `--client-metadata-url URL` | — | Dynamic Client Registration の代わりに使用するクライアント ID メタデータドキュメントの HTTPS URL |
-| `--oauth-scope SCOPE` | — | リクエストする OAuth スコープ。複数指定する場合は1つの値の中でスペース区切り（例：`"openid offline_access"`）。サーバーがこのリクエストと異なるスコープを付与した場合、mcp-stdio は `authorization server granted scope: …` を stderr にログ出力します |
+| `--oauth-scope SCOPE` | — | リクエストする OAuth スコープ。複数指定する場合は1つの値の中でスペース区切り（例：`"openid offline_access"`）。付与されたスコープが以前に付与されたものと異なる場合（例：ダウングレード）、mcp-stdio は `authorization server granted scope: …` を stderr にログ出力します（変化しないリフレッシュでは出力しません） |
 | `--oauth-use-id-token` | — | アクセストークンの代わりに OIDC id_token をベアラー認証情報として提示（AWS Bedrock / Cognito） |
 | `--oauth-eager` | — | コールドスタート：initialize をローカルで応答し、バックグラウンドでインタラクティブ OAuth を実行。長いログインがクライアントの約 60 秒のタイムアウトを超えない |
 | `--oauth-refresh-leeway SECONDS` | `MCP_OAUTH_REFRESH_LEEWAY` | トークン有効期限の何秒前にプロアクティブにリフレッシュするか（デフォルト: 60） |

--- a/docs/reference.ja.md
+++ b/docs/reference.ja.md
@@ -20,7 +20,7 @@ Arguments:
 | `--oauth-device` | — | OAuth 2.1 デバイス認可グラント（RFC 8628、ヘッドレス） |
 | `--client-id ID` | `MCP_OAUTH_CLIENT_ID` | 事前登録済み OAuth クライアント ID（Dynamic Client Registration をスキップ） |
 | `--client-metadata-url URL` | — | Dynamic Client Registration の代わりに使用するクライアント ID メタデータドキュメントの HTTPS URL |
-| `--oauth-scope SCOPE` | — | リクエストする OAuth スコープ。複数指定する場合は1つの値の中でスペース区切り（例：`"openid offline_access"`） |
+| `--oauth-scope SCOPE` | — | リクエストする OAuth スコープ。複数指定する場合は1つの値の中でスペース区切り（例：`"openid offline_access"`）。サーバーがこのリクエストと異なるスコープを付与した場合、mcp-stdio は `authorization server granted scope: …` を stderr にログ出力します |
 | `--oauth-use-id-token` | — | アクセストークンの代わりに OIDC id_token をベアラー認証情報として提示（AWS Bedrock / Cognito） |
 | `--oauth-eager` | — | コールドスタート：initialize をローカルで応答し、バックグラウンドでインタラクティブ OAuth を実行。長いログインがクライアントの約 60 秒のタイムアウトを超えない |
 | `--oauth-refresh-leeway SECONDS` | `MCP_OAUTH_REFRESH_LEEWAY` | トークン有効期限の何秒前にプロアクティブにリフレッシュするか（デフォルト: 60） |

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -20,7 +20,7 @@ Arguments:
 | `--oauth-device` | — | Enable OAuth 2.1 Device Authorization Grant (RFC 8628, headless) |
 | `--client-id ID` | `MCP_OAUTH_CLIENT_ID` | Pre-registered OAuth client ID (skips Dynamic Client Registration) |
 | `--client-metadata-url URL` | — | HTTPS URL of a Client ID Metadata Document to use as client_id instead of DCR |
-| `--oauth-scope SCOPE` | — | OAuth scope(s) to request, space-separated in one value (e.g. `"openid offline_access"`) |
+| `--oauth-scope SCOPE` | — | OAuth scope(s) to request, space-separated in one value (e.g. `"openid offline_access"`). When the server grants a scope that differs from this request, mcp-stdio logs `authorization server granted scope: …` to stderr |
 | `--oauth-use-id-token` | — | Present the OIDC id_token as the Bearer credential instead of access_token (AWS Bedrock / Cognito) |
 | `--oauth-eager` | — | Cold-start: answer initialize locally and run interactive OAuth in the background, so a long login does not exceed the client's ~60 s timeout |
 | `--oauth-refresh-leeway SECONDS` | `MCP_OAUTH_REFRESH_LEEWAY` | Proactively refresh tokens this many seconds before expiry (default: 60) |

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -20,7 +20,7 @@ Arguments:
 | `--oauth-device` | — | Enable OAuth 2.1 Device Authorization Grant (RFC 8628, headless) |
 | `--client-id ID` | `MCP_OAUTH_CLIENT_ID` | Pre-registered OAuth client ID (skips Dynamic Client Registration) |
 | `--client-metadata-url URL` | — | HTTPS URL of a Client ID Metadata Document to use as client_id instead of DCR |
-| `--oauth-scope SCOPE` | — | OAuth scope(s) to request, space-separated in one value (e.g. `"openid offline_access"`). When the server grants a scope that differs from this request, mcp-stdio logs `authorization server granted scope: …` to stderr |
+| `--oauth-scope SCOPE` | — | OAuth scope(s) to request, space-separated in one value (e.g. `"openid offline_access"`). When the server grants a scope that differs from the one previously granted (e.g. a downgrade), mcp-stdio logs `authorization server granted scope: …` to stderr; unchanged refreshes stay quiet |
 | `--oauth-use-id-token` | — | Present the OIDC id_token as the Bearer credential instead of access_token (AWS Bedrock / Cognito) |
 | `--oauth-eager` | — | Cold-start: answer initialize locally and run interactive OAuth in the background, so a long login does not exceed the client's ~60 s timeout |
 | `--oauth-refresh-leeway SECONDS` | `MCP_OAUTH_REFRESH_LEEWAY` | Proactively refresh tokens this many seconds before expiry (default: 60) |


### PR DESCRIPTION
Adds a note to the `--oauth-scope` reference row (EN + JA) that mcp-stdio logs `authorization server granted scope: …` when the AS grants a scope differing from the request (shipped in v0.28.0, #316).

Small discoverability fix. Docs-only; `mkdocs build --strict` passes.

---

Also serves as the **smoke test for the PAT-based Copilot-review workflow** (#317): this is the first non-release PR since the PAT workflow went live, so it should get `@copilot` requested automatically via `COPILOT_REVIEW_TOKEN`.