### PR TITLE
docs: document the serve reverse-gateway and fix stale refs

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -12,11 +12,22 @@ that remote servers expose:
 
 **This repo implements zero MCP tools of its own.** There is no FastMCP, no
 `@mcp.tool()` decorator, nothing that "wraps a tool return value" — do not
-review this code as if it were an MCP tool server. Its entire job is to
-faithfully relay a stdio stream to/from an HTTP endpoint, plus a full OAuth
-2.1 client (`oauth.py`) and on-disk token cache (`token_store.py`) to
-authenticate against that endpoint. Other modules: `cli.py` (argparse
-entry point, `mcp-stdio` → `mcp_stdio.cli:main`).
+review this code as if it were an MCP tool server. It works in **two
+directions**:
+
+- **relay** (the original job, `relay.py`) — faithfully relays a stdio stream
+  to/from a remote HTTP endpoint (client side: stdin/stdout in, HTTP out),
+  plus a full OAuth 2.1 client (`oauth.py`) and on-disk token cache
+  (`token_store.py`) to authenticate against that endpoint.
+- **serve** (`server.py`, `mcp-stdio serve`) — the mirror image (server side:
+  HTTP in, stdio out): spawns a local stdio MCP server as a child process per
+  session and publishes it as a Streamable HTTP endpoint so clients that
+  can't spawn the server locally can reach it over the network. Stdlib-only
+  (`http.server` + `subprocess`); optional layered auth (open / static bearer
+  / embedded OAuth 2.1 authorization server). See Review focus §5.
+
+Other modules: `cli.py` (argparse entry point, `mcp-stdio` →
+`mcp_stdio.cli:main`; also dispatches `serve` to `server.py`).
 
 Only runtime dependency: `httpx`. Build backend: `hatchling`.
 
@@ -31,16 +42,20 @@ pytest tests/ -v
 CI (`.github/workflows/test.yml`) runs `pytest tests/ -v` on Python 3.10–3.14
 on `ubuntu-latest`, plus a dedicated `windows-latest` / Python 3.12 job. The
 Windows job exists specifically to smoke-test the stdio newline handling
-(see "Windows CRLF" below) — it is not there for general cross-platform
-coverage, so don't suggest dropping it as redundant.
+(see the "## Windows" section in `WORKAROUNDS.md`) — it is not there for
+general cross-platform coverage, so don't suggest dropping it as redundant.
 
 ## Review focus
 
-### 1. Stdout hygiene — the single highest-value thing to get right here
+### 1. Stdout hygiene (relay mode) — the single highest-value thing to get right here
 
-Because this process's stdout *is* the JSON-RPC wire to the MCP host, any
-stray byte on stdout corrupts the protocol. The codebase already has the
-correct, verified pattern — preserve it, don't reinvent it:
+Because the relay process's stdout *is* the JSON-RPC wire to the MCP host,
+any stray byte on stdout corrupts the protocol. (This applies to the
+**relay** path — `relay.py`, `oauth.py`, `cli.py`. In `serve` mode the
+process's stdout is *not* the wire — the wires there are each backend
+child's stdin/stdout and the HTTP socket — so §5 governs that code, not this
+rule.) The codebase already has the correct, verified pattern — preserve it,
+don't reinvent it:
 
 - `log(msg)` (module-level in `relay.py`) writes exclusively to
   `sys.stderr` via `print(f"[mcp-stdio] {msg}", file=sys.stderr, flush=True)`.
@@ -126,6 +141,35 @@ Three that are easy to accidentally regress in a routine-looking diff:
   every subsequent request. A refactor of the request-building code in `run()`
   that drops this header on any request type would break session-aware
   servers even though `initialize` itself still succeeds.
+
+### 5. Serve mode (`server.py`) — auth, sessions, and Host-header hygiene
+
+`mcp-stdio serve` (dispatched from `cli.py` when `argv[1] == "serve"`) is the
+repo's largest module and its only network-listening / credential-issuing
+surface. The stdout-hygiene rule of §1 does **not** apply here — in serve
+mode the process's stdout is not the protocol wire; the wires are each
+backend child's stdin/stdout and the HTTP socket. The highest-stakes review
+targets:
+
+- **Layered auth.** Open by default; `--auth-token` adds a static-bearer
+  Resource Server gate; `--enable-oauth` adds an *embedded OAuth 2.1
+  authorization server* (issues tokens, optionally persisted to a 0o600 file
+  via `--token-store`). The static bearer should be passed via the
+  `MCP_STDIO_SERVE_TOKEN` env var rather than `--auth-token`, because the
+  flag is visible in `ps` (`_SERVE_TOKEN_ENV`). Flag a diff that logs a
+  bearer/OAuth token, prints one, widens the `--token-store` file mode, or
+  weakens a token/PKCE check — same standard as §2.
+- **Session lifecycle.** One backend child process per MCP session
+  (`SessionRegistry`, keyed on `Mcp-Session-Id`): the transport mints a
+  session id on `initialize`, returns 404 on an unknown id, terminates on
+  DELETE, and serves server-initiated messages over a GET SSE stream. Flag a
+  diff that lets one session's child answer another session's request, leaks
+  a child on teardown, or drops the 404-on-unknown-id guard.
+- **Host-header sanitization.** Incoming `Host` / `X-Forwarded-Host` values
+  are filtered through `_HOST_ALLOWED` before being echoed into the
+  `WWW-Authenticate` challenge or the Protected Resource Metadata JSON, to
+  block header injection. Flag a diff that uses a raw/unsanitized Host value
+  in those responses.
 
 ## Out of scope
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,7 @@ pytest tests/ -v
 
 # Run a single test file or class
 pytest tests/test_relay.py -v
-pytest tests/test_relay.py::TestSendRequest -v
+pytest tests/test_relay.py::TestWriteLine -v
 
 # Build package
 pip install build && python -m build
@@ -29,9 +29,14 @@ Uses **hatchling** as the build backend (`build-backend = "hatchling.build"` in 
 
 ## Architecture
 
-A minimal stdio-to-HTTP gateway for MCP (Model Context Protocol) servers — translates between stdio JSON-RPC framing and the two MCP HTTP transports (Streamable HTTP and legacy SSE). Only runtime dependency is **httpx**.
+A gateway between stdio JSON-RPC framing and MCP's HTTP transports, in **both directions**:
 
-Four modules under `src/mcp_stdio/`:
+- **relay** (the original job, `relay.py`) — the client side (stdin/stdout in, HTTP out): translates a local stdio MCP host to a remote Streamable HTTP or legacy SSE server.
+- **serve** (`server.py`, `mcp-stdio serve`) — the mirror image, the server side (HTTP in, stdio out): publishes a locally-spawned stdio MCP server as a Streamable HTTP endpoint.
+
+Only runtime dependency is **httpx** (the `serve` path is stdlib-only).
+
+The substantive modules under `src/mcp_stdio/`:
 
 - **`relay.py`** — Two transport implementations sharing stdin/stdout plumbing (file name kept for import compatibility):
   - `run()` — Streamable HTTP transport (MCP current spec, default). Reads JSON-RPC from stdin line-by-line, streams POST to the remote URL via httpx, parses JSON or SSE responses, writes to stdout. Handles retry with backoff (3 attempts), session ID tracking (`Mcp-Session-Id` header), 404-based session recovery, and 401-based token refresh.
@@ -41,9 +46,10 @@ Four modules under `src/mcp_stdio/`:
 - **`cli.py`** — argparse-based CLI. Builds headers, resolves `MCP_BEARER_TOKEN` / `MCP_OAUTH_CLIENT_ID` env vars, runs the OAuth flow before relay if `--oauth` or `--oauth-device` is set, and dispatches to `run()` or `run_sse()` based on `--transport`.
 - **`oauth.py`** — OAuth 2.1 client: RFC 9728/8414 discovery, RFC 7591 dynamic client registration, RFC 7636 PKCE, RFC 8707 resource indicators, authorization code flow with localhost callback server, RFC 8628 device authorization grant, RFC 9470 step-up authorization, token exchange and refresh.
 - **`token_store.py`** — Token persistence in `~/.config/mcp-stdio/tokens.json` (0o600). Stores per-server-URL tokens with client credentials and endpoint URLs for refresh. Migrates legacy `~/.mcp-stdio/` tokens on first read.
+- **`server.py`** — the `mcp-stdio serve` reverse gateway (dispatched from `cli.py` when `argv[1] == "serve"`). Spawns one backend stdio child process per MCP session (`SessionRegistry`, keyed on `Mcp-Session-Id`) and exposes them over a stdlib `http.server` Streamable HTTP endpoint (session minted on `initialize`, 404 on an unknown id, DELETE to terminate, GET SSE for server-initiated messages). Auth is optional and layered: open by default, `--auth-token` (or the `MCP_STDIO_SERVE_TOKEN` env var, preferred so the token isn't exposed in `ps`) for a static bearer, or `--enable-oauth` for an embedded OAuth 2.1 authorization server with optional `--token-store` persistence. Incoming `Host`/`X-Forwarded-Host` values are sanitized against `_HOST_ALLOWED` before they reach the `WWW-Authenticate` challenge / metadata responses. Stdlib only — adds no runtime dependency.
 
-Entry point: `mcp-stdio` command → `mcp_stdio.cli:main`.
+Entry point: `mcp-stdio` command → `mcp_stdio.cli:main` (which also dispatches `serve` to `server.py`).
 
 ## Release
 
-Releases are driven by **release-please** (Conventional Commits) — do not tag `v*` by hand. Pushing commits to `main` updates a standing "release PR" that bumps `__version__` (`src/mcp_stdio/__init__.py`) and `CHANGELOG.md`. Merging that PR creates the `v*` tag and a GitHub Release (via a PAT so downstream workflows fire). The `release: published` event then runs the publish pipeline: test → build → TestPyPI → PyPI → MCP Registry → GitHub Release assets → Homebrew tap update. The `server.json` version is patched from the git tag at publish time.
+Releases are driven by **release-please** (Conventional Commits) — do not tag `v*` by hand. Pushing commits to `main` updates a standing "release PR" that bumps `__version__` (`src/mcp_stdio/__init__.py`) and `CHANGELOG.md`. Merging that PR creates the `v*` tag and a GitHub Release (via a PAT so downstream workflows fire). The `release: published` event then runs the publish pipeline: test → build → TestPyPI → PyPI → MCP Registry → Homebrew tap update (jobs `test`/`build`/`testpypi`/`publish`/`mcp-registry`/`notify-homebrew` in `release.yml`); the GitHub Release itself is created by release-please, not this pipeline. The `server.json` version is patched from the git tag at publish time.


### PR DESCRIPTION
## What

A Fable5 audit flagged this repo's guidance docs as **significant-gaps**: both `CLAUDE.md` and `.github/copilot-instructions.md` still described mcp-stdio as only the **relay** direction, omitting the **`serve`** reverse gateway entirely — the repo's largest module (`src/mcp_stdio/server.py`, ~110 KB) and its only network-listening / credential-issuing surface. Docs only; every claim verified against the current tree (`68fad19`).

### `CLAUDE.md`
- Reframed Architecture as a **two-direction** gateway (relay + serve) and added a `server.py` module entry: per-session backend children (`SessionRegistry`), Streamable HTTP semantics (mint on `initialize`, 404 on unknown id, DELETE, GET SSE), layered auth (open / `--auth-token` / `MCP_STDIO_SERVE_TOKEN` / `--enable-oauth` / `--token-store`), `_HOST_ALLOWED` sanitization.
- **Stale ref:** `pytest …::TestSendRequest` — that class was removed; changed to `TestWriteLine`.
- **Inaccuracy:** the release pipeline listed a non-existent **"GitHub Release assets"** job. The actual `release.yml` jobs are `test`/`build`/`testpypi`/`publish`/`mcp-registry`/`notify-homebrew`, and release-please (not this pipeline) creates the GitHub Release.

### `.github/copilot-instructions.md`
- Added the serve direction to the overview and a new **Review focus §5** (auth layering, session lifecycle, `Host`/`X-Forwarded-Host` sanitization).
- Scoped **§1 "stdout is the wire" to relay mode** — in serve mode the process's stdout is *not* the protocol wire (the child's stdio + the HTTP socket are), so the old rule would misjudge `server.py` diffs.
- **Stale ref:** fixed the dangling `(see "Windows CRLF" below)` cross-reference (no such section) to point at `WORKAROUNDS.md`'s `## Windows` section.

## Scope

**Do not merge yet** — part of a batch of doc-audit PRs held for review.